### PR TITLE
Adds 'main' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A TDS driver, for connecting to MS SQLServer databases.",
   "homepage": "https://github.com/pekim/tedious",
   "version": "0.0.1",
+  "main" : "./lib/tedious.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/pekim/tedious.git"


### PR DESCRIPTION
So module consumers just need to require('tedious') rather than
require('tedious/lib/tedious').
