### PR TITLE
Ability to use single-byte legacy-encoded (non-ASCII) text fields

### DIFF
--- a/lib/token/row-token-parser.coffee
+++ b/lib/token/row-token-parser.coffee
@@ -115,7 +115,7 @@ parser = (buffer, columnsMetaData) ->
       when 'VarChar', 'Char', 'NVarChar', 'NChar'
         switch type.name
           when 'VarChar', 'Char'
-            encoding = 'ascii'
+            encoding = 'binary'
           when 'NVarChar', 'NChar'
             encoding = 'ucs2'
 
@@ -132,7 +132,7 @@ parser = (buffer, columnsMetaData) ->
         if dataLength == 0
           value = null
         else
-          value = readChars(buffer, dataLength, 'ascii')
+          value = readChars(buffer, dataLength, 'binary')
       when 'NText'
         if dataLength == 0
           value = null


### PR DESCRIPTION
Hi,

To import a legacy Microsoft SQL Server database using Latin1 characters into node.js, I had to make this small change in tedious. This change should not break anything (it breaks none of the unit tests, at least, and works in my app).

---

Use "binary" instead of "ascii" encoding for single-byte text columns, so that legacy-encoded non-ascii characters are preserved and not replaced by the invalid character.

If the code page for the database is not iso-8859-1 / latin1, this means that those characters will be wrong, but they will not be destroyed and it will at least be possible to iconv them.

A better solution might be to specify the character encoding as an option, and add iconv as a dependency. I may make such a patch if you are interested.

Regards, Philippe
