### PR TITLE
Getting an error with token type == 0

### DIFF
--- a/src/token/token-stream-parser.coffee
+++ b/src/token/token-stream-parser.coffee
@@ -71,7 +71,7 @@ class Parser extends EventEmitter
       else
         throw new Error("Unrecognised token #{type} at offset #{@buffer.position}")
     catch error
-      if error?.error == 'oob'
+      if error?.error == 'oob' || type == 0
         # There was an attempt to read past the end of the buffer.
         # In other words, we've run out of buffer.
         return false


### PR DESCRIPTION
On a failed login I get an error token followed by a token with a type value of zero which throws:

Error: Unrecognised token 0 at offset 76
    at Parser.nextToken (./node_modules/tedious/lib/token/token-stream-parser.js:97:15)
    at Parser.addBuffer (./node_modules/tedious/lib/token/token-stream-parser.js:65:17)
    at Connection.sendPacketToTokenStreamParser (./node_modules/tedious/lib/connection.js:439:35)
    at Connection.<anonymous> (./node_modules/tedious/lib/connection.js:103:23)
    at Connection.dispatchEvent (./node_modules/tedious/lib/connection.js:375:59)
    at MessageIO.<anonymous> (./node_modules/tedious/lib/connection.js:329:20)
    at MessageIO.emit (events.js:67:17)
    at MessageIO.<anonymous> (./node_modules/tedious/lib/message-io.js:47:12)
    at Socket.<anonymous> (./node_modules/tedious/lib/message-io.js:3:59)
    at Socket.emit (events.js:67:17)

Should that be discarded?
