### PR TITLE
update iconv-lite dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "async": "0.1.22",
-    "iconv-lite": "0.2.1",
+    "iconv-lite": "0.2.4",
     "sprintf": "0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
iconv-lite 0.2.1 can't parse encoding windows936
