### PR TITLE
Duplicate column names support

### DIFF
--- a/src/token/row-token-parser.coffee
+++ b/src/token/row-token-parser.coffee
@@ -19,11 +19,20 @@ parser = (buffer, columnsMetaData) ->
     columns.push(column)
 
     if !(DIGITS_REGEX.test(columnMetaData.colName))
-      columns[columnMetaData.colName] = column
+      saveColumn(columnMetaData.colName, columns, column)
 
   # Return token
   name: 'ROW'
   event: 'row'
   columns: columns
+
+saveColumn = (columnName, columns, value) ->
+  entry = columns[columnName]
+  if !entry
+    columns[columnName] = value;
+  else if Array.isArray(entry)
+    entry.push(value)
+  else
+    columns[columnName] = [entry, value]
 
 module.exports = parser


### PR DESCRIPTION
This makes it easier to re-use stored procedures that have duplicate
column names for multi-mapping between Dapper and tedious. When the same
column is used multiple times, you can reference it with:
row['columnName'][index].value

Single occurence columns would still work with row['columnName'].value.
There might be a more intuitive way of references the duplicated column,
so I'm open to ideas there.
