### PR TITLE
add parameterised value support for text

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -201,6 +201,29 @@ TYPE =
     hasTableName: true
     hasTextPointerAndTimestamp: true
     dataLengthLength: 4
+    declaration: (parameter) ->
+      'text'
+    writeParameterData: (buffer, parameter) ->
+      if parameter.length
+        length = parameter.length
+      else if parameter.value?
+        length = parameter.value.toString().length
+      else
+        length = -1
+        
+      # ParamMetaData (TYPE_INFO)
+      buffer.writeUInt8(typeByName.Text.id)
+      buffer.writeInt32LE(length)
+      
+      # Collation
+      buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]))
+      
+      # ParamLenData
+      if parameter.value?
+        buffer.writeInt32LE(length)
+        buffer.writeString(parameter.value.toString(), 'ascii')
+      else
+        buffer.writeInt32LE(length)
   0x24:
     type: 'GUIDN'
     name: 'UniqueIdentifierN'

--- a/test/integration/parameterised-statements-test.coffee
+++ b/test/integration/parameterised-statements-test.coffee
@@ -102,6 +102,20 @@ exports.nVarCharMax = (test) ->
 
   execSql(test, TYPES.NVarChar, longString)
 
+exports.textNull = (test) ->
+  execSql(test, TYPES.Text, null)
+  
+exports.textEmpty = (test) ->
+  execSql(test, TYPES.Text, '')
+  
+exports.textSmall = (test) ->
+  execSql(test, TYPES.Text, 'small')
+
+exports.textLarge = (test) ->
+  dBuf = new Buffer(5000000)
+  dBuf.fill('x')
+  execSql(test, TYPES.Text, dBuf.toString())
+
 exports.smallDateTime = (test) ->
   execSql(test, TYPES.SmallDateTime, new Date('December 4, 2011 10:04:00'))
 
@@ -299,7 +313,6 @@ execSqlOutput = (test, type, value) ->
     else if (type == TYPES.BigInt)
       test.strictEqual(returnValue, value.toString())
     else if (type == TYPES.UniqueIdentifierN)
-
       test.deepEqual(returnValue, value)
     else
       test.strictEqual(returnValue, value)
@@ -318,5 +331,5 @@ execSqlOutput = (test, type, value) ->
   )
 
   connection.on('debug', (text) ->
-    #console.log(text)
+    # console.log(text)
   )


### PR DESCRIPTION
This allows support for text types to be parameters however TDS dose not allow text to be ouput parameters so that is not supported as well as I had some issue with empty string such as '' from my understanding it my not be supported (http://lists.ibiblio.org/pipermail/freetds/2010q2/025787.html) and if so the test case for it should either be removed or modified.

Signed-off-by: Zach Aller zachaller@hotmail.com
