### PR TITLE
Fixed typo in api-connection.html

### DIFF
--- a/api-connection.html
+++ b/api-connection.html
@@ -476,7 +476,7 @@ var connection = new Connection(config);
 </p>
 <p>
   As <code>sp_executesql</code> is used to execute the SQL,
-  is the same SQL is executed multiples times using this function,
+  if the same SQL is executed multiples times using this function,
   the SQL Server query optimizer is likely to reuse the execution plan it generates for the first execution.
 </p>
 <p>


### PR DESCRIPTION
Fixed small typo in the 'execSql' section ('is'->'if').
