### PR TITLE
SET defaults

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -408,7 +408,22 @@ class Connection extends EventEmitter
     @tokenStreamParser.addBuffer(data)
 
   sendInitialSql: ->
-    payload = new SqlBatchPayload('set textsize ' + @config.options.textsize, @currentTransactionDescriptor())
+    initialSql = 'set textsize ' + @config.options.textsize + ''' 
+set quoted_identifier on
+set arithabort off
+set numeric_roundabort off
+set ansi_warnings on
+set ansi_padding on
+set ansi_nulls on
+set concat_null_yields_null on
+set cursor_close_on_commit off
+set implicit_transactions off
+set language us_english
+set dateformat mdy
+set datefirst 7
+set transaction isolation level read committed'''
+
+    payload = new SqlBatchPayload(initialSql, @currentTransactionDescriptor())
     @messageIo.sendMessage(TYPE.SQL_BATCH, payload.data)
 
   processedInitialSql: ->


### PR DESCRIPTION
Updated the initial sql call to set default settings flags to match those generated by ADO.NET/SQL Server Management Studio, as validated by SQL Server Profiler.

These are considered "sane" & "least suprise" defaults (for example, linked server queries fail without a couple settings here, etc).

The same effect may be forced by the `ODBC_ON` flag in `login7-payload.coffee`, however I'm unaware if this can cause other unintended side effects (again, settings can be verified in SQL Server Profiler).

This also addresses issue #59
