### PR TITLE
Emit connect event with error (if connecting) or emit errorMessage event...

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -357,6 +357,10 @@ class Connection extends EventEmitter
     message = "connection to #{@config.server}:#{@config.options.port} - failed #{error}"
 
     @debug.log(message)
+    if @state == @STATE.CONNECTING
+      @emit('connect', message)
+    else
+      @emit('errorMessage', message)
     @dispatchEvent('socketError', error)
 
   socketConnect: =>


### PR DESCRIPTION
... on socket error

When a network issue prevents connection to the database, there is no
callback made to the connection callback nor to the errorMessage
callback. Only the connection.end event is fired. This leads to silent
failures.
