### PR TITLE
varchar nvarchar param length calculation

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -289,6 +289,8 @@ TYPE =
         length = parameter.length
       else if parameter.value?
         length = parameter.value.toString().length
+      else if parameter.value is null
+        length = 1
       else
         length = @.maximumLength
 
@@ -347,6 +349,8 @@ TYPE =
         length = parameter.length
       else if parameter.value?
         length = parameter.value.toString().length
+      else if parameter.value is null
+        length = 1
       else
         length = @maximumLength
 


### PR DESCRIPTION
1. calculate and use value length
2. for nvarchar storage size is two times n bytes 
   http://msdn.microsoft.com/en-us/library/ms186939.aspx
3. no need for big buffer if param value is null
