### PR TITLE
Zero length varchar params don't work unless a length greater than zero

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -295,7 +295,7 @@ TYPE =
         length = @.maximumLength
 
       if length <= @maximumLength
-        "varchar(#{length})"
+        "varchar(#{Math.max(length,1)})"
       else
         "varchar(max)"
     writeParameterData: (buffer, parameter) ->
@@ -355,7 +355,7 @@ TYPE =
         length = @maximumLength
 
       if length <= @maximumLength
-        "nvarchar(#{length})"
+        "nvarchar(#{Math.max(length,1)})"
       else
         "nvarchar(max)"
     writeParameterData: (buffer, parameter) ->


### PR DESCRIPTION
I ran into an issue where a sql statement could be generated with a parameter type of varchar(0) which sql server didn't seem to allow.

Changing the minimum value to 1 seemed to fix the issue.
