### PR TITLE
include all engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "git://github.com/pekim/tedious.git"
   },
   "engines": {
-    "node": "0.6 || 0.7 || 0.8 || 0.9"
+    "node": "0.6 || 0.7 || 0.8 || 0.9 || 0.10 || 0.11"
   },
   "dependencies": {
     "async": "0.2.6",


### PR DESCRIPTION
0.10 and 0.11 are being tested in travis, but I am still getting a warning with npm install.
