### PR TITLE
Russian chars does not work in queries with ucs2.

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -468,13 +468,13 @@ TYPE =
       if parameter.value?
         if length <= @maximumLength
           buffer.writeUInt16LE(length)
-          buffer.writeString(parameter.value.toString(), 'ucs2')
+          buffer.writeString(parameter.value.toString())
         else
           # Length of all chunks.
           buffer.writeUInt64LE(length)
           # One chunk.
           buffer.writeUInt32LE(length)
-          buffer.writeString(parameter.value.toString(), 'ucs2')
+          buffer.writeString(parameter.value.toString())
           # PLP_TERMINATOR (no more chunks).
           buffer.writeUInt32LE(0)
       else


### PR DESCRIPTION
When i remove 'ucs2', queries goes properly. I am connecting to TDS7.2 MSSQL(windows machine)
