### PR TITLE
Update iconv-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": "0.6 || 0.7 || 0.8 || 0.9 || 0.10 || 0.11"
   },
   "dependencies": {
-    "iconv-lite": "0.2.7",
+    "iconv-lite": "0.4.2",
     "sprintf": "0.1.1"
   },
   "devDependencies": {

--- a/src/value-parser.coffee
+++ b/src/value-parser.coffee
@@ -11,6 +11,8 @@ MONEY_DIVISOR = 10000
 PLP_NULL = new Buffer([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 UNKNOWN_PLP_LEN = new Buffer([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 
+DEFAULT_ENCODING = 'utf8'
+
 parse = (buffer, metaData, options) ->
   value = undefined
   dataLength = undefined
@@ -220,7 +222,7 @@ readBinary = (buffer, dataLength) ->
   else
     buffer.readBuffer(dataLength)
 
-readChars = (buffer, dataLength, codepage) ->
+readChars = (buffer, dataLength, codepage=DEFAULT_ENCODING) ->
   if dataLength == NULL
     null
   else
@@ -237,7 +239,7 @@ readMaxBinary = (buffer) ->
     valueBuffer
   )
 
-readMaxChars = (buffer, codepage) ->
+readMaxChars = (buffer, codepage=DEFAULT_ENCODING) ->
   readMax(buffer, (valueBuffer) ->
     iconv.decode(valueBuffer, codepage)
   )


### PR DESCRIPTION
0.2.7 doesn't support cp932. 0.4.2 does. A problem: iconv-lite doesn't have a default encoding anymore (I asked for the previous behavior to be restored in this PR, but the author decided against it: https://github.com/ashtuchkin/iconv-lite/pull/67) so I wrote a possible solution for dealing with this change (at the very least, it gets tests passing and works in my application).
