### PR TITLE
when sending decimals as UInt's, Math.round the value to prevent IEEE 754 floating point errors

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -224,7 +224,8 @@ TYPE =
         if parameter.precision <= 9
           buffer.writeUInt8 5
           buffer.writeUInt8 sign
-          buffer.writeUInt32LE value
+        # Round to preven IEEE 754 floating point errors
+          buffer.writeUInt32LE Math.round(value)
         else if parameter.precision <= 19
           buffer.writeUInt8 9
           buffer.writeUInt8 sign


### PR DESCRIPTION
I ran into an issue when using small precision decimals as parameters. Specifically, the the value that was causing me problems was `32.343948`. The parameter type is a `decimal(9, 6)`. Tedious writes decimals with precision of <= 9 directly to the TDS stream as a single 32-bit integer, and it does so by multiplying the value by 10^scale (the scale is 6 in this case). The [line](https://github.com/pekim/tedious/blob/master/src/data-type.coffee#L222) that performs the conversion looks like this:

``` coffee-script
value = Math.abs parameter.value * Math.pow(10, parameter.scale)
```

The resulting value _should_ be `32343948`. However, due to floating point rounding errors, you end up with `32343947.999999996`, which causes Buffer.writeUInt32LE to throw an exception.

My quick fix is to just `Math.round` the value when tedious determines that it needs to write the decimal value to the TDS stream as a 32-bit UInt value.
