### PR TITLE
Add option to set the default isolation level for the connection

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -662,6 +662,7 @@ set transaction isolation level #{@getIsolationLevelText @config.options.connect
       when ISOLATION_LEVEL.READ_UNCOMMITTED then 'read uncommitted'
       when ISOLATION_LEVEL.REPEATABLE_READ then 'repeatable read'
       when ISOLATION_LEVEL.SERIALIZABLE then 'serializable'
+      when ISOLATION_LEVEL.SNAPSHOT then 'snapshot'
       else 'read committed'
 
 


### PR DESCRIPTION
We have a requirement that all queries use `READ UNCOMMITTED` by default. This PR adds an option, `connectionIsolationLevel`, that allows setting the isolation level in the initial sql batch that gets sent when a connection is opened (defaulting to READ COMMITTED so as not to change existing behavior).

Also, I noticed that using the single quoted block string was causing the newline to be trimmed, resulting in the wrong sql being sent

``` text
set textsize 2147483647set quoted_identifier on
```

instead of

``` sql
set textsize 2147483647
set quoted_identifier on
```

Changing the batch to use a single double quoted block string and using coffee-script's interpolation fixes the issue.

Usage would be:

``` javascript
var tds = require('tedious');

var conn = new tds.Connection({
  ...
  options: {
    connectionIsolationLevel: tds.ISOLATION_LEVEL.READ_UNCOMMITTED
  }
});
```
