### PR TITLE
allow for lower-casing column names

### DIFF
--- a/src/token/colmetadata-token-parser.coffee
+++ b/src/token/colmetadata-token-parser.coffee
@@ -21,7 +21,7 @@ parser = (buffer, colMetadata, options) ->
 
     colName = buffer.readBVarchar()
 
-    if options.lowerCaseColumns
+    if options.camelCaseColumns
       colName = colName.replace /^[A-Z]/, (s) -> s.toLowerCase()
 
 


### PR DESCRIPTION
A simple addition of a `lowerCaseColumns` option that will return an object with lower cased column names (moar javascript-y)
