### PR TITLE
add requireDatabase option

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -532,6 +532,7 @@ class Connection extends EventEmitter
       appName: @config.options.appName
       packetSize: @config.options.packetSize
       tdsVersion: @config.options.tdsVersion
+      initDbFatal: @config.options.requireDatabase
 
     payload = new Login7Payload(loginData)
     @messageIo.sendMessage(TYPE.LOGIN7, payload.data)

--- a/src/login7-payload.coffee
+++ b/src/login7-payload.coffee
@@ -133,8 +133,9 @@ class Login7Payload
       FLAGS_1.FLOAT_IEEE_754 |
       FLAGS_1.BCD_DUMPLOAD_OFF |
       FLAGS_1.USE_DB_OFF |
-      FLAGS_1.INIT_DB_WARN |
       FLAGS_1.SET_LANG_WARN_ON
+
+    @flags1 |= if @loginData.initDbFatal then FLAGS_1.INIT_DB_FATAL else FLAGS_1.INIT_DB_WARN
 
     @flags2 =
       FLAGS_2.INIT_LANG_WARN |


### PR DESCRIPTION
Currently, when the user requests a database that doesn't exist, or they don't have access to, tedious/TDS falls back to the user's default database. This is unexpected, as most client's will give an error when the requested database is inaccessible. This could also be potentially disastrous (in the case of running DB migrations on the wrong database, for instance).

Since I don't want to introduce any breaking changes to current behavior, this PR introduces a new option, `requireDatabase` which tells tedious to send the `INIT_DB_FATAL` flag along with the login packet, which will throw an error if the requested database is inaccessible.

If everything looks good to you guys I'll go ahead and merge this in and update the docs as well:

``` diff
diff --git a/api-connection.html b/api-connection.html
index 699bd7d..72d6b09 100644
--- a/api-connection.html
+++ b/api-connection.html
@@ -116,6 +116,15 @@ var connection = new Connection(config);
       </dd>

       <dt>
+        <code>options.requireDatabase</code>
+      </dt>
+      <dd>
+        If this is <code>true</code>, and the connection cannot be changed to the requested database,
+        then the connection will fail with an error. If this is <code>false</code>, then the connection
+        will succeed and be set to the default database for the specified user instead (default: <code>false</code>).
+      </dd>
+
+      <dt>
         <code>options.connectTimeout</code>
       </dt>
       <dd>
```
