### PR TITLE
add fallbackToDefaultDb option, and make INIT_DB_FATAL the default

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -532,6 +532,7 @@ class Connection extends EventEmitter
       appName: @config.options.appName
       packetSize: @config.options.packetSize
       tdsVersion: @config.options.tdsVersion
+      initDbFatal: not @config.options.fallbackToDefaultDb
 
     payload = new Login7Payload(loginData)
     @messageIo.sendMessage(TYPE.LOGIN7, payload.data)

--- a/src/login7-payload.coffee
+++ b/src/login7-payload.coffee
@@ -133,8 +133,12 @@ class Login7Payload
       FLAGS_1.FLOAT_IEEE_754 |
       FLAGS_1.BCD_DUMPLOAD_OFF |
       FLAGS_1.USE_DB_OFF |
-      FLAGS_1.INIT_DB_WARN |
       FLAGS_1.SET_LANG_WARN_ON
+
+    if @loginData.initDbFatal
+      @flags1 |= FLAGS_1.INIT_DB_FATAL
+    else
+      @flags1 |= FLAGS_1.INIT_DB_WARN
 
     @flags2 =
       FLAGS_2.INIT_LANG_WARN |


### PR DESCRIPTION
Most SQL Server clients will throw an error if the database requested in the connection is unavailable.

Currently, Tedious does not, and falls back to the user's default database. This can potentially have disastrous results (running an automated script such as a migration on the wrong database).

I'm proposing we change the default behavior and add an option, `fallbackToDefaultDb` to re-enable the previous behavior.

Proposed documentation patch:

``` diff
diff --git a/api-connection.html b/api-connection.html
index 699bd7d..f205bfc 100644
--- a/api-connection.html
+++ b/api-connection.html
@@ -116,6 +116,16 @@ var connection = new Connection(config);
       </dd>

       <dt>
+        <code>options.fallbackToDefaultDb</code>
+      </dt>
+      <dd>
+        By default, if the database requestion by <code>options.database</code> cannot be accessed,
+        the connection will fail with an error. However, if <code>options.fallbackToDefaultDb</code> is
+        set to <code>true</code>, then the user's default database will be used instead
+        (Default: <code>false</code>).
+      </dd>
+
+      <dt>
         <code>options.connectTimeout</code>
       </dt>
       <dd>
```
