### PR TITLE
bulk: getTableCreationSql 

### DIFF
--- a/src/bulk-load.coffee
+++ b/src/bulk-load.coffee
@@ -75,6 +75,17 @@ class BulkLoad extends EventEmitter
     sql += ')'
     return sql
   
+  getTableCreationSql: () ->
+    sql = 'CREATE TABLE ' + @table + '(' + "\n"
+    for c, i in @columns
+      if i != 0
+        sql += ', \n'
+      sql += "[#{c.name}] [#{c.type.declaration(c)}]"
+      if (c.nullable != undefined)
+        sql += " " + (if c.nullable then "NULL" else "NOT NULL")
+    sql += '\n)'
+    return sql
+
   getPayload: () ->
     # Create COLMETADATA token
     metaData = @getColMetaData()


### PR DESCRIPTION
This adds a `getTableCreationSql()` function to `BulkLoad`

It returns a string containing the `CREATE TABLE ...` statement for the target table of the Bulk Insert.

This can be useful when the target table doesn't exist prior to the bulk insert.
