### PR TITLE
Remove default SSL cipher suite

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -601,8 +601,6 @@ class Connection extends EventEmitter
       payload.toString '  '
 
   initiateTlsSslHandshake: ->
-    @config.options.cryptoCredentialsDetails.ciphers ||= 'RC4-MD5'
-
     credentials = crypto.createCredentials(@config.options.cryptoCredentialsDetails)
     @securePair = tls.createSecurePair(credentials)
 


### PR DESCRIPTION
If no "options.cryptoCredentialsDefaults.ciphers" option is set in the configuration, then Tedious defaults to the "RC4-MD5" cipher suite.

This is a very old cipher suite, and worse yet it uses MD5 which is disabled by many modern web servers and firewalls.

Rather than hard-code a default, I think that Tedious should not try to override the default cipher suite, but instead let the implementation choose one as part of normal TLS/SSL negotiation. That way, as cipher suites evolve, Tedious won't need to be updated again.

I see MD5 used elsewhere with HMAC, but I presume that's part of NTLM authentication and that it can't be replaced.
