### PR TITLE
Set keepAlive on connected socket.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -449,7 +449,6 @@ class Connection extends EventEmitter
 
   connectOnPort: (port) ->
     @socket = new Socket({})
-    @socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY)
 
     connectOpts =
       host: @config.server
@@ -536,6 +535,7 @@ class Connection extends EventEmitter
     @dispatchEvent('socketError', error)
 
   socketConnect: =>
+    @socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY)
     @closed = false
     @debug.log("connected to #{@config.server}:#{@config.options.port}")
     @dispatchEvent('socketConnect')


### PR DESCRIPTION
#198

This prevents tedious from having troubles with idle connection while working with Azure DB behind load balancer.

We have found, that calling setKeepAlive on newly created socket has no effect. It only works if called on connected socket.
