### PR TITLE
Have a mean to disable the request timeout.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -281,7 +281,7 @@ class Connection extends EventEmitter
     else if @config.options.port
       if @config.options.port < 0 or @config.options.port > 65536
         throw new RangeError "Port should be > 0 and < 65536"
-    
+
     if @config.options.columnNameReplacer && typeof @config.options.columnNameReplacer != 'function'
       throw new TypeError('options.columnNameReplacer must be a function or null.')
 
@@ -324,13 +324,13 @@ class Connection extends EventEmitter
         @loginError = ConnectionError "Server responded with unknown TDS version.", 'ETDS'
         @loggedIn = false
         return
-      
+
       unless token.interface
         # unsupported interface
         @loginError = ConnectionError "Server responded with unsupported interface.", 'EINTERFACENOTSUPP'
         @loggedIn = false
         return
-        
+
       # use negotiated version
       @config.options.tdsVersion = token.tdsVersion
       @loggedIn = true
@@ -358,7 +358,7 @@ class Connection extends EventEmitter
             columns[col.colName] = col for col in token.columns when not columns[col.colName]?
           else
             columns = token.columns
-            
+
           @request.emit('columnMetadata', columns)
         else
           @emit 'error', new Error "Received 'columnMetadata' when no sqlRequest is in progress"
@@ -375,7 +375,7 @@ class Connection extends EventEmitter
       if @request
         if @config.options.rowCollectionOnRequestCompletion
           @request.rows.push token.columns
-        
+
         if @config.options.rowCollectionOnDone
           @request.rst.push token.columns
 
@@ -418,7 +418,7 @@ class Connection extends EventEmitter
       if @request
         if token.attention
           @dispatchEvent("attention")
-        
+
         # check if the DONE_ERROR flags was set, but an ERROR token was not sent.
         if token.sqlError && !@request.error
           @request.error = RequestError('An unknown error has occurred.', 'UNKNOWN')
@@ -484,7 +484,7 @@ class Connection extends EventEmitter
     @connectTimer = setTimeout(@connectTimeout, @config.options.connectTimeout)
 
   createRequestTimer: ->
-    if @config.options.requestTimeout
+    if @config.options.requestTimeout isnt -1
       @requestTimer = setTimeout(@requestTimeout, @config.options.requestTimeout)
 
   connectTimeout: =>
@@ -513,7 +513,7 @@ class Connection extends EventEmitter
     if @state == newState
       @debug.log("State is already #{newState.name}")
       return
-      
+
     if @state?.exit
       @state.exit.apply(@)
 
@@ -705,10 +705,10 @@ set xact_abort #{xact_abort}"""
   execSql: (request) ->
     request.transformIntoExecuteSqlRpc()
     @makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, @currentTransactionDescriptor(), @config.options))
-  
+
   newBulkLoad: (table, callback) ->
     return new BulkLoad(table, @config.options, callback)
-  
+
   execBulkLoad: (bulkLoad) ->
     request = new Request(bulkLoad.getBulkInsertSql(), (error) =>
       if error
@@ -739,7 +739,7 @@ set xact_abort #{xact_abort}"""
   beginTransaction: (callback, name, isolationLevel) ->
     name ||= ''
     isolationLevel ||= @config.options.isolationLevel
-      
+
     transaction = new Transaction(name, isolationLevel)
     @transactions.push(transaction)
 
@@ -755,9 +755,9 @@ set xact_abort #{xact_abort}"""
   commitTransaction: (callback) ->
     if @transactions.length == 0
       return callback RequestError('No transaction in progress', 'ENOTRNINPROG')
-      
+
     transaction = @transactions.pop()
-    
+
     if @config.options.tdsVersion < "7_2"
       return  @execSqlBatch new Request "COMMIT TRAN #{transaction.name}", callback
 
@@ -767,9 +767,9 @@ set xact_abort #{xact_abort}"""
   rollbackTransaction: (callback) ->
     if @transactions.length == 0
       return callback RequestError('No transaction in progress', 'ENOTRNINPROG')
-      
+
     transaction = @transactions.pop()
-    
+
     if @config.options.tdsVersion < "7_2"
       return @execSqlBatch new Request "ROLLBACK TRAN #{transaction.name}", callback
 
@@ -797,7 +797,7 @@ set xact_abort #{xact_abort}"""
       )
 
       @transitionTo(@STATE.SENT_CLIENT_REQUEST)
-  
+
   cancel: ->
     if @state != @STATE.SENT_CLIENT_REQUEST
       message = "Requests can only be canceled in the #{@STATE.SENT_CLIENT_REQUEST.name} state, not the #{@state.name} state"


### PR DESCRIPTION
The current implementation of `requestTimeout` will always set a request timeout, either with a custom value or the default value. But sometimes this is not what I want. Especially when I run long running stored procedures with a variable running time, I don't want the request timeout to be specified. This patch gives me the possibility to disable the request timeout by setting the configuration option `requestTimeout` to -1. This preserves backwards compatibility and makes disabling the request timeout a conscious decision (which is probably good). Probably the documentation should be updated too.

PS: Sorry for polluting the PR with the white space removal. My editor does this automatically and I haven't noticed. The actual patch is really simple and can be found on line 487 in `src/connection.coffee`. If this is a problem, than I can send a new PR.
