### PR TITLE
Do not attempt to connect after instance lookup in final state.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -447,6 +447,8 @@ class Connection extends EventEmitter
         @config.server
         @config.options.instanceName
         (message, port) =>
+          if @state == @STATE.FINAL
+            return
           if message
             @emit('connect', ConnectionError(message, 'EINSTLOOKUP'))
           else


### PR DESCRIPTION
Fix for #185 

I chose to check the state of the connection rather than disable the instance lookup retries, since that uses UDP.
