### PR TITLE
Fix VarBinary handling with strings.

### DIFF
--- a/src/tracking-buffer/writable-tracking-buffer.coffee
+++ b/src/tracking-buffer/writable-tracking-buffer.coffee
@@ -175,7 +175,7 @@ class WritableTrackingBuffer
     @writeUInt16LE(value.length)
     @writeString(value, encoding)
   
-  writeUsVarbyte: (value, encoding = @encoding) ->
+  writeUsVarbyte: (value, encoding = "utf8") ->
     if Buffer.isBuffer value
       length = value.length
     else

--- a/test/integration/parameterised-statements-test.coffee
+++ b/test/integration/parameterised-statements-test.coffee
@@ -100,6 +100,12 @@ exports.intZero = (test) ->
 exports.intNull = (test) ->
   execSql(test, TYPES.Int, null)
 
+exports.varBinaryWithString = (test) ->
+  execSql(test, TYPES.VarBinary, "test")
+
+exports.varBinaryWithBuffer = (test) ->
+  execSql(test, TYPES.VarBinary, new Buffer([0x01, 0x02, 0x03, 0x04]))
+
 exports.varChar = (test) ->
   execSql(test, TYPES.VarChar, 'qaz')
 
@@ -318,7 +324,12 @@ execSql = (test, type, value, tdsVersion, options) ->
   request.on('row', (columns) ->
       test.strictEqual(columns.length, 1)
 
-      if (value instanceof Date)
+      if (type == TYPES.VarBinary)
+        if typeof value == "string"
+          test.strictEqual(columns[0].value.toString(), value)
+        else
+          test.deepEqual(columns[0].value, value)
+      else if (value instanceof Date)
         test.strictEqual(columns[0].value.getTime(), value.getTime())
       else if (type == TYPES.BigInt)
         test.strictEqual(columns[0].value, value.toString())


### PR DESCRIPTION
When storing a String into a VarBinary column, tedious currently incorrectly encodes that string as UCS-2. This is a bit weird, because that means that

```
request.addParameter('test', TYPES.VarBinary, "Some String")
```

and

```
request.addParameter('test', TYPES.VarBinary, new Buffer("Some String"))
```

will cause different binary data to be stored in the database.

---

I'm not really sure whether that is a bug or I'm just doing something wrong.

To clarify: I'd expect a VarBinary column to store exactly what I throw at it, and in case of a String I'd expect it to store the same binary representation I'd get when calling `new Buffer("Some String")`. But that's not what is happening. By default, Tedious currently encodes this into `UCS-2`, which I find super weird and super awkward to work with.

Another Note: This is probably a breaking change.
