### PR TITLE
Fix issue: sql.Time.

### DIFF
--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1305,6 +1305,10 @@ const TYPE = module.exports.TYPE = {
       if (value instanceof Date) {
         return value;
       }
+      value = Date.parse(value);
+      if (!isNaN(value)){
+        return value;
+      }
       var timespan = (function(input) {
         var regex = /^([0-9]{1}|(?:0[0-9]|1[0-9]|2[0-3])+):([0-5]?[0-9])(?::([0-5]?[0-9])(?:\.(\d{1,9}))?)?$/;
         var result = (regex.exec(input) || []).slice(1, 5);

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1306,7 +1306,7 @@ const TYPE = module.exports.TYPE = {
         return value;
       }
       value = Date.parse(value);
-      if (!isNaN(value)){
+      if (!isNaN(value)) {
         return value;
       }
       var timespan = (function(input) {

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1305,10 +1305,26 @@ const TYPE = module.exports.TYPE = {
       if (value instanceof Date) {
         return value;
       }
-      value = Date.parse(value);
-      if (isNaN(value)) {
+      var timespan = (function(input) {
+        var regex = /^([0-9]{1}|(?:0[0-9]|1[0-9]|2[0-3])+):([0-5]?[0-9])(?::([0-5]?[0-9])(?:\.(\d{1,9}))?)?$/;
+        var result = (regex.exec(input) || []).slice(1, 5);
+
+        if (result[0] == null) {
+          return null;
+        }
+
+        return {
+          hours: result[0] || 0,
+          minutes: result[1] || 0,
+          seconds: result[2] || 0,
+          milliseconds: result[3] || 0
+        };
+      })(value);
+
+      if (timespan == null) {
         return new TypeError('Invalid time.');
       }
+      value = new Date(0, 0, 0, timespan.hours, timespan.minutes, timespan.seconds, timespan.milliseconds);
       return value;
     }
   },

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1305,9 +1305,9 @@ const TYPE = module.exports.TYPE = {
       if (value instanceof Date) {
         return value;
       }
-      value = Date.parse(value);
-      if (!isNaN(value)) {
-        return value;
+      var dateValue = Date.parse(value);
+      if (!isNaN(dateValue)) {
+        return dateValue;
       }
       var timespan = (function(input) {
         var regex = /^([0-9]{1}|(?:0[0-9]|1[0-9]|2[0-3])+):([0-5]?[0-9])(?::([0-5]?[0-9])(?:\.(\d{1,9}))?)?$/;


### PR DESCRIPTION
Now when a parameter is of type "sql.Time" and the value is a string, it will try to parse it; instead of returning a TypeError('Invalid time');

https://github.com/patriksimek/node-mssql/issues/320

http://stackoverflow.com/questions/33098711/mssql-nodejs-module-throws-invalid-time-in-execution-of-a-stored-procedure
