### PR TITLE
NTLM authentication requires domain to be upper case 

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -41,6 +41,12 @@ class Connection extends EventEmitter {
     this.config = config;
 
     if (typeof (config.domain) === 'string') {
+      // Assigning 'config' passed in directly to 'this.config' will have
+      // 'config' and 'this.config' referring to the same object. Now modifying
+      // this.config.domain would also modify config.domain which would be an
+      // unexpected side effect on the input parameter. JSON serializing and
+      // deserializing creates a new object thus protecting the input parameter
+      // from side-effects.
       this.config = JSON.parse(JSON.stringify(config));
       this.config.domain = this.config.domain.toUpperCase();
     }

--- a/src/connection.js
+++ b/src/connection.js
@@ -41,13 +41,6 @@ class Connection extends EventEmitter {
     this.config = config;
 
     if (typeof (config.domain) === 'string') {
-      // Assigning 'config' passed in directly to 'this.config' will have
-      // 'config' and 'this.config' referring to the same object. Now modifying
-      // this.config.domain would also modify config.domain which would be an
-      // unexpected side effect on the input parameter. JSON serializing and
-      // deserializing creates a new object thus protecting the input parameter
-      // from side-effects.
-      this.config = JSON.parse(JSON.stringify(config));
       this.config.domain = this.config.domain.toUpperCase();
     }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -39,6 +39,12 @@ class Connection extends EventEmitter {
     super();
 
     this.config = config;
+
+    if (typeof (config.domain) === 'string') {
+      this.config = JSON.parse(JSON.stringify(config));
+      this.config.domain = this.config.domain.toUpperCase();
+    }
+
     this.reset = this.reset.bind(this);
     this.socketClose = this.socketClose.bind(this);
     this.socketEnd = this.socketEnd.bind(this);

--- a/test/integration/connection-test.coffee
+++ b/test/integration/connection-test.coffee
@@ -191,7 +191,13 @@ exports.connectByInvalidInstanceName = (test) ->
     #console.log(text)
   )
 
-exports.ntlm = (test) ->
+DomainCaseEnum = {
+    AsIs: 0,
+    Lower: 1,
+    Upper: 2
+}
+
+runNtlmTest = (test, domainCase) ->
   if !getNtlmConfig()
     console.log('Skipping ntlm test')
     test.done()
@@ -204,7 +210,12 @@ exports.ntlm = (test) ->
 
   config.userName = ntlmConfig.userName
   config.password = ntlmConfig.password
-  config.domain = ntlmConfig.domain
+
+  switch domainCase
+    when DomainCaseEnum.AsIs then config.domain = ntlmConfig.domain
+    when DomainCaseEnum.Lower then config.domain = ntlmConfig.domain.toLowerCase()
+    when DomainCaseEnum.Upper then config.domain = ntlmConfig.domain.toUpperCase()
+    else test.ok(false, 'Unexpected value for domainCase: ' + domainCase)
 
   connection = new Connection(config)
 
@@ -225,6 +236,15 @@ exports.ntlm = (test) ->
   connection.on('debug', (text) ->
     #console.log(text)
   )
+
+exports.ntlm = (test) ->
+  runNtlmTest test, DomainCaseEnum.AsIs 
+
+exports.ntlmLower = (test) ->
+  runNtlmTest test, DomainCaseEnum.Lower
+
+exports.ntlmUpper = (test) ->
+  runNtlmTest test, DomainCaseEnum.Upper
 
 exports.encrypt = (test) ->
   test.expect(5)


### PR DESCRIPTION
This addresses the issue:
https://github.com/tediousjs/tedious/issues/414

The issues speaks to FDQN in addition to the pull request. But I couldn't repro the FDQN failure. It seems to work for me just fine.

@arthurschreiber @arobson  - This is a follow-up to our discussion on https://github.com/tediousjs/tedious/issues/246.
