### PR TITLE
Add `options.trustServerCertificate`.

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -121,6 +121,10 @@ class Connection extends EventEmitter {
       this.config.options.cryptoCredentialsDetails = {};
     }
 
+    if (this.config.options.trustServerCertificate === undefined) {
+      this.config.options.trustServerCertificate = true;
+    }
+
     if (this.config.options.useUTC == undefined) {
       this.config.options.useUTC = true;
     }
@@ -924,7 +928,7 @@ Connection.prototype.STATE = {
         }
       },
       tls: function() {
-        this.messageIo.startTls(this.config.options.cryptoCredentialsDetails);
+        this.messageIo.startTls(this.config.options.cryptoCredentialsDetails, this.config.options.trustServerCertificate);
         return this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
       }
     }


### PR DESCRIPTION
This allows accepting or rejecting a connection to a server that presents an untrusted certificate.

This fixes #397 and #399.

---

@SimonHooker Sorry this has taken me so long. 😞 I took your commits, squashed them together, and fixed a few issues (both style wise as well as a "this won't actually do the right thing in case of an certification verification error"). Please take a final look, and if everything looks good, I'll merge this ASAP.