### PR TITLE
Issue #426 Making verifyError emit a non-ESOCKET error again

### DIFF
--- a/src/message-io.js
+++ b/src/message-io.js
@@ -99,7 +99,8 @@ module.exports = class MessageIO extends EventEmitter {
 
         if (verifyError) {
           this.securePair.destroy();
-          this.socket.destroy(verifyError);
+          this.socket.destroy();
+          this.emit('error', verifyError);
           return;
         }
       }


### PR DESCRIPTION
This is to allow node-mssql to properly report the error again as at present a verifyError silently
closes the socket without reporting any errors making debugging and verification impossible.
