### PR TITLE
Use a larger buffer for variable data.

### DIFF
--- a/src/login7-payload.js
+++ b/src/login7-payload.js
@@ -161,8 +161,8 @@ module.exports = class Login7Payload {
       this.variableLengthsLength = (9 * 4) + 6 + (2 * 4);
     }
     const variableData = {
-      offsetsAndLengths: new WritableTrackingBuffer(200),
-      data: new WritableTrackingBuffer(200, 'ucs2'),
+      offsetsAndLengths: new WritableTrackingBuffer(400),
+      data: new WritableTrackingBuffer(400, 'ucs2'),
       offset: offset + this.variableLengthsLength
     };
     this.hostname = os.hostname();


### PR DESCRIPTION
Hi,

Recently I started to get `RangeError: Offset is out of bounds` errors while starting my server, and it started just after I moved the server to a new address.
I debugged the issue, and found that the length of the content in variableData (see code change) is 263, which is too large for the allocated 200.
I hope this fix is fine for you and you can produce a new tagged version very soon.
Thank you very much.

Regards,

Nicolas