### PR TITLE
Currently inTransaction state on Connection is maintained based on the

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -854,7 +854,7 @@ class Connection extends EventEmitter {
       this.debug.log(message);
       return request.callback(RequestError(message, 'EINVALIDSTATE'));
     } else {
-      if (packetType == TYPE.SQL_BATCH) {
+      if (packetType === TYPE.SQL_BATCH) {
         this.isSqlBatch = true;
       } else {
         this.isSqlBatch = false;

--- a/src/connection.js
+++ b/src/connection.js
@@ -53,9 +53,15 @@ class Connection extends EventEmitter {
     this.transactionDescriptors = [new Buffer([0, 0, 0, 0, 0, 0, 0, 0])];
     this.transitionTo(this.STATE.CONNECTING);
 
-    // These fields are used for managing transactions in TDS versions below 7.1.
-    this.transactionDepth = 0;
-    this.isSqlBatch = false;
+    if (this.config.options.tdsVersion < '7_2') {
+      // 'beginTransaction', 'commitTransaction' and 'rollbackTransaction'
+      // events are utilized to maintain inTransaction property state which in
+      // turn is used in managing transactions. These events are only fired for
+      // TDS version 7.2 and beyond. The properties below are used to emulate
+      // equivalent behavior for TDS versions before 7.2.
+      this.transactionDepth = 0;
+      this.isSqlBatch = false;
+    }
   }
 
   close() {

--- a/src/connection.js
+++ b/src/connection.js
@@ -728,7 +728,7 @@ class Connection extends EventEmitter {
         if (self.transactionDepth === 1) {
           self.inTransaction = true;
         }
-        return callback.apply(this, arguments);
+        return callback.apply(null, arguments);
       }));
     }
 
@@ -747,7 +747,7 @@ class Connection extends EventEmitter {
         if (self.transactionDepth === 0) {
           self.inTransaction = false;
         }
-        return callback.apply(this, arguments);
+        return callback.apply(null, arguments);
       }));
     }
     const request = new Request(void 0, callback);
@@ -763,7 +763,7 @@ class Connection extends EventEmitter {
         if (self.transactionDepth === 0) {
           self.inTransaction = false;
         }
-        return callback.apply(this, arguments);
+        return callback.apply(null, arguments);
       }));
     }
     const request = new Request(void 0, callback);
@@ -776,7 +776,7 @@ class Connection extends EventEmitter {
       const self = this;
       return this.execSqlBatch(new Request('SAVE TRAN ' + transaction.name, function() {
         self.transactionDepth++;
-        return callback.apply(this, arguments);
+        return callback.apply(null, arguments);
       }));
     }
     const request = new Request(void 0, callback);

--- a/src/connection.js
+++ b/src/connection.js
@@ -728,13 +728,12 @@ class Connection extends EventEmitter {
     isolationLevel || (isolationLevel = this.config.options.isolationLevel);
     const transaction = new Transaction(name || '', isolationLevel);
     if (this.config.options.tdsVersion < '7_2') {
-      const self = this;
-      return this.execSqlBatch(new Request('SET TRANSACTION ISOLATION LEVEL ' + (transaction.isolationLevelToTSQL()) + ';BEGIN TRAN ' + transaction.name, function() {
-        self.transactionDepth++;
-        if (self.transactionDepth === 1) {
-          self.inTransaction = true;
+      return this.execSqlBatch(new Request('SET TRANSACTION ISOLATION LEVEL ' + (transaction.isolationLevelToTSQL()) + ';BEGIN TRAN ' + transaction.name, (...args) => {
+        this.transactionDepth++;
+        if (this.transactionDepth === 1) {
+          this.inTransaction = true;
         }
-        return callback.apply(null, arguments);
+        return callback.apply(null, args);
       }));
     }
 
@@ -747,13 +746,12 @@ class Connection extends EventEmitter {
   commitTransaction(callback, name) {
     const transaction = new Transaction(name || '');
     if (this.config.options.tdsVersion < '7_2') {
-      const self = this;
-      return this.execSqlBatch(new Request('COMMIT TRAN ' + transaction.name, function() {
-        self.transactionDepth--;
-        if (self.transactionDepth === 0) {
-          self.inTransaction = false;
+      return this.execSqlBatch(new Request('COMMIT TRAN ' + transaction.name, (...args) => {
+        this.transactionDepth--;
+        if (this.transactionDepth === 0) {
+          this.inTransaction = false;
         }
-        return callback.apply(null, arguments);
+        return callback.apply(null, args);
       }));
     }
     const request = new Request(void 0, callback);
@@ -763,13 +761,12 @@ class Connection extends EventEmitter {
   rollbackTransaction(callback, name) {
     const transaction = new Transaction(name || '');
     if (this.config.options.tdsVersion < '7_2') {
-      const self = this;
-      return this.execSqlBatch(new Request('ROLLBACK TRAN ' + transaction.name, function() {
-        self.transactionDepth--;
-        if (self.transactionDepth === 0) {
-          self.inTransaction = false;
+      return this.execSqlBatch(new Request('ROLLBACK TRAN ' + transaction.name, (...args) => {
+        this.transactionDepth--;
+        if (this.transactionDepth === 0) {
+          this.inTransaction = false;
         }
-        return callback.apply(null, arguments);
+        return callback.apply(null, args);
       }));
     }
     const request = new Request(void 0, callback);
@@ -779,10 +776,9 @@ class Connection extends EventEmitter {
   saveTransaction(callback, name) {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
-      const self = this;
-      return this.execSqlBatch(new Request('SAVE TRAN ' + transaction.name, function() {
-        self.transactionDepth++;
-        return callback.apply(null, arguments);
+      return this.execSqlBatch(new Request('SAVE TRAN ' + transaction.name, (...args) => {
+        this.transactionDepth++;
+        return callback.apply(null, args);
       }));
     }
     const request = new Request(void 0, callback);

--- a/src/connection.js
+++ b/src/connection.js
@@ -811,6 +811,9 @@ class Connection extends EventEmitter {
       } else {
         if (useSavepoint) {
           return process.nextTick(function() {
+            if (this.config.options.tdsVersion < '7_2') {
+              self.transactionDepth--;
+            }
             args.unshift(null);
             return done.apply(null, args);
           });

--- a/src/connection.js
+++ b/src/connection.js
@@ -811,7 +811,7 @@ class Connection extends EventEmitter {
       } else {
         if (useSavepoint) {
           return process.nextTick(function() {
-            if (this.config.options.tdsVersion < '7_2') {
+            if (self.config.options.tdsVersion < '7_2') {
               self.transactionDepth--;
             }
             args.unshift(null);

--- a/test/integration/transactions-test.coffee
+++ b/test/integration/transactions-test.coffee
@@ -219,7 +219,13 @@ exports.nestedTransactionInProcRollbackOuter = (test) ->
   ])
 
 exports.firesRollbackTransactionEventWithXactAbort = (test) ->
-  test.expect(5)
+  # From 2.2.7.8, ENVCHANGE_TOKEN type Begin Transaction (8) is only supported
+  # in TDS version 7.2 and above. 'rollbackTransaction' event fires in response
+  # to that token type and hence won't be firing for lower versions.
+  if config.options.tdsVersion < '7_2'
+    test.expect(4)
+  else
+    test.expect(5)
 
   connection = new Connection(config)
   connection.on('end', (info) => test.done())


### PR DESCRIPTION
events 'beginTransaction', 'commitTransaction' and 'rollbackTransaction'.
These are all available only for TDS versions 7.2 and over. This is
causing several transaction integration tests to fail.

This PR attempts to fill in the gaps by managing inTransaction state based
on equivalent events and callbacks for TDS versions below 7.2. All the
tests pass now except for
transactionHelperMixedWithLowLevelTransactionMethods.