### PR TITLE
Verify the server's hostname against the certificate.

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1058,7 +1058,7 @@ Connection.prototype.STATE = {
         }
       },
       tls: function() {
-        this.messageIo.startTls(this.config.options.cryptoCredentialsDetails, this.config.options.trustServerCertificate);
+        this.messageIo.startTls(this.config.options.cryptoCredentialsDetails, this.config.server, this.config.options.trustServerCertificate);
         return this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
       }
     }


### PR DESCRIPTION
Setting `trustServerCertificate`to `false` makes `tedious` check the server's certificate for validity, but it does not actually check that the hostname we tried connecting to is also listed in the certificate. This means the server side could present **any** valid certificate and `tedious` would happily connect to it. That's bad. 😞 

/cc @SimonHooker If you got some time, please take a look!
/cc @tvrprasad I want this to go into 1.15.0 as well.