### PR TITLE
Do not remove handlers in 'connect' handler.

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -30,9 +30,6 @@ class Connector {
     };
 
     const onConnect = () => {
-      socket.removeListener('error', onError);
-      socket.removeListener('connect', onConnect);
-
       cb(null, socket);
     };
 
@@ -134,9 +131,6 @@ class SequentialConnectionStrategy {
     };
 
     const onConnect = () => {
-      socket.removeListener('error', onError);
-      socket.removeListener('connect', onConnect);
-
       callback(null, socket);
     };
 


### PR DESCRIPTION
Current code does not remove handlers in 'connect' handler for
the socket over which we're going to communicate in
ParallelConnectionStrategy. But 'connect' handlers in other
places do so. The right behavior is to not remove the handlers,
especially the 'error' handler as errors can happen after a
successful connection is established. With the 'connect' handler
we could go either way.