### PR TITLE
Add ConnectionError and RequestError to module.exports

### DIFF
--- a/src/tedious.js
+++ b/src/tedious.js
@@ -5,6 +5,9 @@ module.exports.Connection = require('./connection');
 module.exports.Request = require('./request');
 module.exports.library = require('./library');
 
+module.exports.ConnectionError = require('./errors').ConnectionError;
+module.exports.RequestError = require('./errors').RequestError;
+
 module.exports.TYPES = require('./data-type').typeByName;
 module.exports.ISOLATION_LEVEL = require('./transaction').ISOLATION_LEVEL;
 module.exports.TDS_VERSION = require('./tds-versions').versions;


### PR DESCRIPTION
Unless I'm missing something, it seems that you can't easily instantiate a ConnectionError or RequestError with the current exports from tedious.js. I find that this makes it difficult to interrogate errors returned from the library, i.e. by using instanceof, such as in the following code:

```
tds.process(function(err, data) {
  if (err) {
    if (err instanceof ConnectionError) {
      manageConnectionError(err);
    } else if (err instanceof RequestError) {
      manageRequestError(err);
    }
  }
  else {
    doStuff(data);
  } 
});
```

It seems like exporting the error types would make it easier to write code like the above.

I'm relatively new to working with JavaScript, so it may be that there's a reason this isn't being done, or that this isn't actually necessary.  My apologies if that's the case.