### PR TITLE
Drop support for node versions that fell out of LTS maintenance window.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ sudo: false
 before_install:
   - npm install -g npm
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
   - "6"
   - "7"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,7 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
-    - nodejs_version: "5"
     - nodejs_version: "6"
     - nodejs_version: "7"
 


### PR DESCRIPTION
Status of various versions of node may be seen at:
https://github.com/nodejs/LTS

Per that, versions v0.10, v0.12 and v5 fell out of maintenance mode. It
might make sense drop support for these versions for future releases of
Tedious.

Specific motivation for this is the Windows Integrated Authentication
work which has test failures due to bugs in those versions, and forcing a
hacky work-around that requires installing latest version of npm before
running the tests for each version of nodejs. See:
https://github.com/tediousjs/tedious/pull/486/commits/15a52b798f14ce90f2a60c2e0000b14b99d9fd97

This part of this PR: https://github.com/tediousjs/tedious/pull/486