### PR TITLE
Make SET ARITHABORT configurable

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -202,6 +202,7 @@ class Connection extends EventEmitter
     @config.options.cryptoCredentialsDetails ||= {}
     @config.options.useUTC ?= true
     @config.options.useColumnNames ?= false
+    @config.options.useArithAbort ?= false
 
     if !@config.options.port && !@config.options.instanceName
       @config.options.port = DEFAULT_PORT
@@ -500,9 +501,9 @@ class Connection extends EventEmitter
     @messageIo.sendMessage(TYPE.SQL_BATCH, payload.data)
 
   getInitialSql: ->
-    'set textsize ' + @config.options.textsize + '''
+    'set textsize ' + @config.options.textsize +  '\n' +
+    'set arithabort ' + if @config.options.useArithAbort is true then 'on' else 'off' + '''
 set quoted_identifier on
-set arithabort off
 set numeric_roundabort off
 set ansi_warnings on
 set ansi_padding on


### PR DESCRIPTION
I need the behavior afforded by the SET ARITHABORT ON setting, in order to use this driver, as part of patriksimek's node-mssql driver. I have been modifying this setting manually in the lib/connection.js file for a few versions now, every time I upgrade the node_modules for my product.

I should also point out that the [SET ARITHABORT (Transact-SQL) manual page](https://msdn.microsoft.com/en-us/library/ms190306.aspx) , on the "Remarks" paragraph, states: "You should always set ARITHABORT to ON in your logon sessions. Setting ARITHABORT to OFF can negatively impact query optimization leading to performance issues."