### PR TITLE
Make SET ARITHABORT configurable

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -135,7 +135,7 @@ class Connection extends EventEmitter {
         if (typeof config.options.enableArithAbort !== 'boolean') {
           throw new TypeError('options.enableArithAbort must be a boolean (true or false).');
         }
-        
+
         this.config.options.enableArithAbort = config.options.enableArithAbort;
       }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -61,6 +61,7 @@ class Connection extends EventEmitter {
         connectionIsolationLevel: ISOLATION_LEVEL.READ_COMMITTED,
         cryptoCredentialsDetails: {},
         database: undefined,
+        enableArithAbort: false,
         enableAnsiNullDefault: true,
         encrypt: false,
         fallbackToDefaultDb: false,
@@ -128,6 +129,10 @@ class Connection extends EventEmitter {
 
       if (config.options.enableAnsiNullDefault != undefined) {
         this.config.options.enableAnsiNullDefault = config.options.enableAnsiNullDefault;
+      }
+
+      if (config.options.enableArithAbort != undefined) {
+        this.config.options.enableArithAbort = config.options.enableArithAbort;
       }
 
       if (config.options.encrypt != undefined) {
@@ -696,7 +701,8 @@ class Connection extends EventEmitter {
   getInitialSql() {
     const xact_abort = this.config.options.abortTransactionOnError ? 'on' : 'off';
     const enableAnsiNullDefault = this.config.options.enableAnsiNullDefault ? 'on' : 'off';
-    return 'set textsize ' + this.config.options.textsize + '\nset quoted_identifier on\nset arithabort off\nset numeric_roundabort off\nset ansi_warnings on\nset ansi_padding on\nset ansi_nulls on\nset ansi_null_dflt_on ' + enableAnsiNullDefault + '\nset concat_null_yields_null on\nset cursor_close_on_commit off\nset implicit_transactions off\nset language us_english\nset dateformat mdy\nset datefirst 7\nset transaction isolation level ' + (this.getIsolationLevelText(this.config.options.connectionIsolationLevel)) + '\nset xact_abort ' + xact_abort;
+    const enableArithAbort = this.config.options.enableArithAbort ? 'on' : 'off';
+    return 'set textsize ' + this.config.options.textsize + '\nset quoted_identifier on\nset arithabort ' + enableArithAbort + '\nset numeric_roundabort off\nset ansi_warnings on\nset ansi_padding on\nset ansi_nulls on\nset ansi_null_dflt_on ' + enableAnsiNullDefault + '\nset concat_null_yields_null on\nset cursor_close_on_commit off\nset implicit_transactions off\nset language us_english\nset dateformat mdy\nset datefirst 7\nset transaction isolation level ' + (this.getIsolationLevelText(this.config.options.connectionIsolationLevel)) + '\nset xact_abort ' + xact_abort;
   }
 
   processedInitialSql() {

--- a/src/connection.js
+++ b/src/connection.js
@@ -131,7 +131,11 @@ class Connection extends EventEmitter {
         this.config.options.enableAnsiNullDefault = config.options.enableAnsiNullDefault;
       }
 
-      if (config.options.enableArithAbort != undefined) {
+      if (config.options.enableArithAbort !== undefined) {
+        if (typeof config.options.enableArithAbort !== 'boolean') {
+          throw new TypeError('options.enableArithAbort must be a boolean (true or false).');
+        }
+        
         this.config.options.enableArithAbort = config.options.enableArithAbort;
       }
 

--- a/test/integration/connection-test.coffee
+++ b/test/integration/connection-test.coffee
@@ -1041,7 +1041,7 @@ testArithAbort = (test, setting) ->
 	request.on('row', (columns) ->
 		test.strictEqual(Object.keys(columns).length, 1)
 		# The current ARITHABORT default setting in Tedious is OFF
-		test.strictEqual(columns[0].value, if setting === true then 1 else 0)
+		test.strictEqual(columns[0].value, if setting is true then 1 else 0)
 	)
 
 	connection = new Connection(config)
@@ -1060,5 +1060,5 @@ exports.testArithAbortDefault = (test) ->
 exports.testArithAbortOn = (test) ->
 	testArithAbort(test, true)
 
-exports.testArithAbortOf = (test) ->
+exports.testArithAbortOff = (test) ->
 	testArithAbort(test, false)

--- a/test/integration/connection-test.coffee
+++ b/test/integration/connection-test.coffee
@@ -1022,43 +1022,54 @@ exports.disableAnsiNullDefault = (test) ->
         test.strictEqual err?.number, 515 # Cannot insert the value NULL
 
 testArithAbort = (test, setting) ->
-	test.expect(5)
+  test.expect(5)
 	
-	config = getConfig()
-	config.options.enableArithAbort = setting if typeof setting is 'boolean'
+  config = getConfig()
+  config.options.enableArithAbort = setting if typeof setting is 'boolean'
 
-	request = new Request('SELECT SESSIONPROPERTY(\'ARITHABORT\') AS ArithAbortSetting', (err, rowCount) ->
-		test.ifError(err)
-		test.strictEqual(rowCount, 1)
+  request = new Request('SELECT SESSIONPROPERTY(\'ARITHABORT\') AS ArithAbortSetting', (err, rowCount) ->
+    test.ifError(err)
+    test.strictEqual(rowCount, 1)
 
-		connection.close()
-	)
+    connection.close()
+  )
 
-	request.on('columnMetadata', (columnsMetadata) ->
-		test.strictEqual(Object.keys(columnsMetadata).length, 1)
-	)
+  request.on('columnMetadata', (columnsMetadata) ->
+    test.strictEqual(Object.keys(columnsMetadata).length, 1)
+  )
 
-	request.on('row', (columns) ->
-		test.strictEqual(Object.keys(columns).length, 1)
-		# The current ARITHABORT default setting in Tedious is OFF
-		test.strictEqual(columns[0].value, if setting is true then 1 else 0)
-	)
+  request.on('row', (columns) ->
+    test.strictEqual(Object.keys(columns).length, 1)
+    # The current ARITHABORT default setting in Tedious is OFF
+    test.strictEqual(columns[0].value, if setting is true then 1 else 0)
+  )
 
-	connection = new Connection(config)
+  connection = new Connection(config)
 
-	connection.on('connect', (err) ->
-		connection.execSql(request)
-	)
+  connection.on('connect', (err) ->
+    connection.execSql(request)
+  )
 
-	connection.on('end', (info) ->
-		test.done()
-	)
+  connection.on('end', (info) ->
+    test.done()
+  )
 
 exports.testArithAbortDefault = (test) ->
-	testArithAbort(test, undefined)
+  testArithAbort(test, undefined)
 
 exports.testArithAbortOn = (test) ->
-	testArithAbort(test, true)
+  testArithAbort(test, true)
 
 exports.testArithAbortOff = (test) ->
-	testArithAbort(test, false)
+  testArithAbort(test, false)
+
+exports.badArithAbort = (test) ->
+  config = getConfig()
+  config.options.enableArithAbort = 'on'
+
+  connection = null
+
+  test.throws ->
+    connection = new Connection(config)
+
+  test.done()

--- a/test/integration/connection-test.coffee
+++ b/test/integration/connection-test.coffee
@@ -1020,3 +1020,68 @@ exports.disableAnsiNullDefault = (test) ->
     runSqlBatch test, config, sql, (err) ->
         test.ok(err instanceof Error)
         test.strictEqual err?.number, 515 # Cannot insert the value NULL
+
+
+# Test that the default behaviour has ARITHABORT set to off
+exports.testArithAbortDefault = (test) ->
+	test.expect(5)
+
+	config = getConfig()
+	request = new Request('SELECT SESSIONPROPERTY(\'ARITHABORT\') AS ArithAbortSetting', (err, rowCount) ->
+		test.ifError(err)
+		test.strictEqual(rowCount, 1)
+
+		connection.close()
+	)
+
+	request.on('columnMetadata', (columnsMetadata) ->
+		test.strictEqual(Object.keys(columnsMetadata).length, 1)
+	)
+
+	request.on('row', (columns) ->
+		test.strictEqual(Object.keys(columns).length, 1)
+		test.strictEqual(columns[0].value, 0)
+	)
+
+	connection = new Connection(config)
+
+	connection.on('connect', (err) ->
+		connection.execSql(request)
+	)
+
+	connection.on('end', (info) ->
+		test.done()
+	)
+
+# Test that ARITHABORT can be set to on
+exports.testArithAbortCanBeSetToOn = (test) ->
+	test.expect(5)
+
+	config = getConfig()
+	config.options.enableArithAbort = true
+
+	request = new Request('SELECT SESSIONPROPERTY(\'ARITHABORT\') AS ArithAbortSetting', (err, rowCount) ->
+		test.ifError(err) 
+		test.strictEqual(rowCount, 1)
+
+		connection.close()
+	)
+
+	request.on('columnMetadata', (columnsMetadata) ->
+		test.strictEqual(Object.keys(columnsMetadata).length, 1)
+	)
+
+	request.on('row', (columns) ->
+		test.strictEqual(Object.keys(columns).length, 1)
+		test.strictEqual(columns[0].value, 1)
+	)
+
+	connection = new Connection(config)
+
+	connection.on('connect', (err) ->
+		connection.execSql(request)
+	)
+
+	connection.on('end', (info) ->
+		test.done()
+	)


### PR DESCRIPTION
I need the behavior afforded by the SET ARITHABORT ON setting, in order to use this driver, as part of patriksimek's node-mssql driver. I have been modifying this setting manually in the lib/connection.js file for a few versions now, every time I upgrade the node_modules for my product.

My changes leave the ARITHABORT default "off", as you currently have it, but I should also point out the recommendation from the RDBMS developer's [SET ARITHABORT (Transact-SQL) manual page](https://msdn.microsoft.com/en-us/library/ms190306.aspx), on the "Remarks" paragraph, states: "You should always set ARITHABORT to ON in your logon sessions. Setting ARITHABORT to OFF can negatively impact query optimization leading to performance issues."