### PR TITLE
Extensive refactoring of instance-lookup code to support UDP v6 and

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -5,7 +5,7 @@ require('./buffertools');
 const BulkLoad = require('./bulk-load');
 const Debug = require('./debug');
 const EventEmitter = require('events').EventEmitter;
-const instanceLookup = require('./instance-lookup').instanceLookup;
+const InstanceLookup = require('./instance-lookup').InstanceLookup;
 const TYPE = require('./packet').TYPE;
 const PreloginPayload = require('./prelogin-payload');
 const Login7Payload = require('./login7-payload');
@@ -475,7 +475,7 @@ class Connection extends EventEmitter {
     if (this.config.options.port) {
       return this.connectOnPort(this.config.options.port, this.config.options.multiSubnetFailover);
     } else {
-      return instanceLookup({
+      return new InstanceLookup().instanceLookup({
         server: this.config.server,
         instanceName: this.config.options.instanceName,
         timeout: this.config.options.connectTimeout,

--- a/src/connection.js
+++ b/src/connection.js
@@ -478,8 +478,7 @@ class Connection extends EventEmitter {
       return new InstanceLookup().instanceLookup({
         server: this.config.server,
         instanceName: this.config.options.instanceName,
-        timeout: this.config.options.connectTimeout,
-        multiSubnetFailover: this.config.options.multiSubnetFailover
+        timeout: this.config.options.connectTimeout
       }, (message, port) => {
         if (this.state === this.STATE.FINAL) {
           return;

--- a/src/instance-lookup.js
+++ b/src/instance-lookup.js
@@ -13,8 +13,8 @@ class InstanceLookup {
   constructor() { }
 
   // Wrapper allows for stubbing Sender when unit testing instance-lookup.
-  createSender(host, port, request, multiSubnetFailover) {
-    return new Sender(host, port, request, multiSubnetFailover);
+  createSender(host, port, request) {
+    return new Sender(host, port, request);
   }
 
   instanceLookup(options, callback) {
@@ -42,7 +42,6 @@ class InstanceLookup {
       throw new TypeError('Invalid arguments: "callback" must be a function');
     }
 
-    const multiSubnetFailover = options.multiSubnetFailover !== undefined && options.multiSubnetFailover;
     let sender, timer, retriesLeft = retries;
 
     const onTimeout = () => {
@@ -55,7 +54,7 @@ class InstanceLookup {
         retriesLeft--;
 
         const request = new Buffer([0x02]);
-        sender = this.createSender(options.server, SQL_SERVER_BROWSER_PORT, request, multiSubnetFailover);
+        sender = this.createSender(options.server, SQL_SERVER_BROWSER_PORT, request);
         sender.execute((err, message) => {
           clearTimeout(timer);
           if (err) {

--- a/src/instance-lookup.js
+++ b/src/instance-lookup.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const dgram = require('dgram');
-const lookupAll = require('dns-lookup-all');
+const Sender = require('./sender').Sender;
 
 const SQL_SERVER_BROWSER_PORT = 1434;
 const TIMEOUT = 2 * 1000;
@@ -10,120 +9,105 @@ const RETRIES = 3;
 const MYSTERY_HEADER_LENGTH = 3;
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
-module.exports.instanceLookup = instanceLookup;
-function instanceLookup(options, callback) {
-  const server = options.server;
-  if (typeof server !== 'string') {
-    throw new TypeError('Invalid arguments: "server" must be a string');
+class InstanceLookup {
+  constructor() { }
+
+  // Wrapper allows for stubbing Sender when unit testing instance-lookup.
+  createSender(host, port, request, multiSubnetFailover) {
+    return new Sender(host, port, request, multiSubnetFailover);
   }
 
-  const instanceName = options.instanceName;
-  if (typeof instanceName !== 'string') {
-    throw new TypeError('Invalid arguments: "instanceName" must be a string');
-  }
-
-  const timeout = options.timeout === undefined ? TIMEOUT : options.timeout;
-  if (typeof timeout !== 'number') {
-    throw new TypeError('Invalid arguments: "timeout" must be a number');
-  }
-
-  const retries = options.retries === undefined ? RETRIES : options.retries;
-  if (typeof retries !== 'number') {
-    throw new TypeError('Invalid arguments: "retries" must be a number');
-  }
-
-  if (typeof callback !== 'function') {
-    throw new TypeError('Invalid arguments: "callback" must be a function');
-  }
-
-  const multiSubnetFailover = options.multiSubnetFailover !== undefined && options.multiSubnetFailover;
-  let socket, timer, retriesLeft = retries;
-
-  function onMessage(message) {
-    clearTimeout(timer);
-    socket.close();
-
-    message = message.toString('ascii', MYSTERY_HEADER_LENGTH);
-    const port = parseBrowserResponse(message, instanceName);
-
-    if (port) {
-      return callback(undefined, port);
-    } else {
-      return callback('Port for ' + instanceName + ' not found in ' + message);
+  instanceLookup(options, callback) {
+    const server = options.server;
+    if (typeof server !== 'string') {
+      throw new TypeError('Invalid arguments: "server" must be a string');
     }
-  }
 
-  function onError(err) {
-    clearTimeout(timer);
-    socket.close();
+    const instanceName = options.instanceName;
+    if (typeof instanceName !== 'string') {
+      throw new TypeError('Invalid arguments: "instanceName" must be a string');
+    }
 
-    return callback('Failed to lookup instance on ' + server + ' - ' + err.message);
-  }
+    const timeout = options.timeout === undefined ? TIMEOUT : options.timeout;
+    if (typeof timeout !== 'number') {
+      throw new TypeError('Invalid arguments: "timeout" must be a number');
+    }
 
-  function onTimeout() {
-    socket.close();
+    const retries = options.retries === undefined ? RETRIES : options.retries;
+    if (typeof retries !== 'number') {
+      throw new TypeError('Invalid arguments: "retries" must be a number');
+    }
+
+    if (typeof callback !== 'function') {
+      throw new TypeError('Invalid arguments: "callback" must be a function');
+    }
+
+    const multiSubnetFailover = options.multiSubnetFailover !== undefined && options.multiSubnetFailover;
+    let sender, timer, retriesLeft = retries;
+
+    const onTimeout = () => {
+      sender.cancel();
+      return makeAttempt();
+    };
+
+    const makeAttempt = () => {
+      if (retriesLeft > 0) {
+        retriesLeft--;
+
+        const request = new Buffer([0x02]);
+        sender = this.createSender(options.server, SQL_SERVER_BROWSER_PORT, request, multiSubnetFailover);
+        sender.execute((err, message) => {
+          clearTimeout(timer);
+          if (err) {
+            return callback('Failed to lookup instance on ' + server + ' - ' + err.message);
+          } else {
+            message = message.toString('ascii', MYSTERY_HEADER_LENGTH);
+            const port = this.parseBrowserResponse(message, instanceName);
+
+            if (port) {
+              return callback(undefined, port);
+            } else {
+              return callback('Port for ' + instanceName + ' not found in ' + message);
+            }
+          }
+        });
+
+        return timer = setTimeout(onTimeout, timeout);
+      } else {
+        return callback('Failed to get response from SQL Server Browser on ' + server);
+      }
+    };
 
     return makeAttempt();
   }
 
-  function makeAttempt() {
-    if (retriesLeft > 0) {
-      retriesLeft--;
-      const request = new Buffer([0x02]);
-      socket = dgram.createSocket('udp4');
-      socket.on('error', onError);
-      socket.on('message', onMessage);
+  parseBrowserResponse(response, instanceName) {
+    let getPort;
 
-      if (multiSubnetFailover) {
-        // TODO: Support both IPv4 and IPv6 here.
-        lookupAll(server, 4, (err, addresses) => {
-          if (err) {
-            return callback(err.message);
+    const instances = response.split(';;');
+    for (let i = 0, len = instances.length; i < len; i++) {
+      const instance = instances[i];
+      const parts = instance.split(';');
+
+      for (let p = 0, partsLen = parts.length; p < partsLen; p += 2) {
+        const name = parts[p];
+        const value = parts[p + 1];
+
+        if (name === 'tcp' && getPort) {
+          const port = parseInt(value, 10);
+          return port;
+        }
+
+        if (name === 'InstanceName') {
+          if (value.toUpperCase() === instanceName.toUpperCase()) {
+            getPort = true;
+          } else {
+            getPort = false;
           }
-
-          const len = addresses.length;
-          for (let i = 0; i < len; i++) {
-            socket.send(request, 0, request.length, SQL_SERVER_BROWSER_PORT, addresses[i].address);
-          }
-        });
-      } else {
-        socket.send(request, 0, request.length, SQL_SERVER_BROWSER_PORT, server);
-      }
-
-      return timer = setTimeout(onTimeout, timeout);
-    } else {
-      return callback('Failed to get response from SQL Server Browser on ' + server);
-    }
-  }
-
-  return makeAttempt();
-}
-
-module.exports.parseBrowserResponse = parseBrowserResponse;
-function parseBrowserResponse(response, instanceName) {
-  let getPort;
-
-  const instances = response.split(';;');
-  for (let i = 0, len = instances.length; i < len; i++) {
-    const instance = instances[i];
-    const parts = instance.split(';');
-
-    for (let p = 0, partsLen = parts.length; p < partsLen; p += 2) {
-      const name = parts[p];
-      const value = parts[p + 1];
-
-      if (name === 'tcp' && getPort) {
-        const port = parseInt(value, 10);
-        return port;
-      }
-
-      if (name === 'InstanceName') {
-        if (value.toUpperCase() === instanceName.toUpperCase()) {
-          getPort = true;
-        } else {
-          getPort = false;
         }
       }
     }
   }
 }
+
+module.exports.InstanceLookup = InstanceLookup;

--- a/src/sender.js
+++ b/src/sender.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const dgram = require('dgram');
+const lookupAll = require('dns-lookup-all');
+const net = require('net');
+
+function sendDgramSocketRequest(ipAddress, port, request, onError, onMessage) {
+  let ipType;
+
+  if (net.isIPv4(ipAddress)) {
+    ipType = 'udp4';
+  } else {
+    ipType = 'udp6';
+  }
+
+  const socket = dgram.createSocket(ipType);
+
+  socket.on('error', onError);
+  socket.on('message', onMessage);
+  socket.send(request, 0, request.length, port, ipAddress);
+
+  return socket;
+}
+
+function clearSocket(socket, onError, onMessage) {
+  socket.removeListener('error', onError);
+  socket.removeListener('message', onMessage);
+  socket.close();
+}
+
+class Sender {
+  constructor(host, port, request, multiSubnetFailover) {
+    this.host = host;
+    this.port = port;
+    this.request = request;
+    this.multiSubnetFailover = multiSubnetFailover;
+
+    this.socket = null;
+    this.onError = null;
+    this.onMessage = null;
+    this.parallelSendStrategy = null;
+    this.sequentialSendStrategy = null;
+  }
+
+  execute(cb) {
+    if (net.isIP(this.host)) {
+      this.executeForIP(cb);
+    } else {
+      this.executeForHostname(cb);
+    }
+  }
+
+  executeForIP(cb) {
+    const onError = function(err) {
+      clearSocket(this, onError, onMessage);
+      cb(err);
+    };
+
+    const onMessage = function(message) {
+      clearSocket(this, onError, onMessage);
+      cb(null, message);
+    };
+
+    this.socket = sendDgramSocketRequest(this.host, this.port, this.request, onError, onMessage);
+
+    this.onError = onError;
+    this.onMessage = onMessage;
+  }
+
+  // Wrapper for stubbing. Sinon does not have support for stubbing module functions.
+  invokeLookupAll(host, cb) {
+    lookupAll(host, cb);
+  }
+
+  // Wrappers for stubbing creation of Strategy objects. Sinon support for constructors
+  // seems limited.
+  createParallelSendStrategy(addresses, port, request) {
+    return new ParallelSendStrategy(addresses, port, request);
+  }
+
+  createSequentialSendStrategy(addresses, port, request) {
+    return new SequentialSendStrategy(addresses, port, request);
+  }
+
+  executeForHostname(cb) {
+    this.invokeLookupAll(this.host, (err, addresses) => {
+      if (err) {
+        return cb(err);
+      }
+
+      if (this.multiSubnetFailover) {
+        this.parallelSendStrategy =
+          this.createParallelSendStrategy(addresses, this.port, this.request);
+        this.parallelSendStrategy.send(cb);
+      } else {
+        this.sequentialSendStrategy =
+          this.createSequentialSendStrategy(addresses, this.port, this.request);
+        this.sequentialSendStrategy.send(cb);
+      }
+    });
+  }
+
+  cancel() {
+    if (this.socket) {
+      clearSocket(this.socket, this.onError, this.onMessage);
+      this.socket = null;
+    } else if (this.parallelSendStrategy) {
+      this.parallelSendStrategy.cancel();
+    } else if (this.sequentialSendStrategy) {
+      this.sequentialSendStrategy.cancel();
+    }
+  }
+}
+
+class ParallelSendStrategy {
+  constructor(addresses, port, request) {
+    this.addresses = addresses;
+    this.port = port;
+    this.request = request;
+
+    this.sockets = new Array(addresses.length);
+    this.onError = null;
+    this.onMessage = null;
+  }
+
+  send(cb) {
+    const that = this;
+
+    let errorCount = 0;
+    const onError = function(err) {
+      clearSocket(this, onError, onMessage);
+
+      for (let j = 0; j < that.sockets.length; j++) {
+        if (that.sockets[j] === this) {
+          that.sockets[j] = null;
+          break;
+        }
+      }
+
+      errorCount += 1;
+      if (errorCount === that.addresses.length) {
+        cb(err);
+      }
+    };
+
+    const onMessage = function(message) {
+      for (let j = 0; j < that.sockets.length; j++) {
+        if (that.sockets[j]) {
+          clearSocket(that.sockets[j], onError, onMessage);
+          that.sockets[j] = null;
+        }
+      }
+
+      cb(null, message);
+    };
+
+    for (let j = 0; j < this.addresses.length; j++) {
+      this.sockets[j] = sendDgramSocketRequest(this.addresses[j].address, this.port, this.request, onError, onMessage);
+    }
+
+    this.onError = onError;
+    this.onMessage = onMessage;
+  }
+
+  cancel() {
+    for (let j = 0; j < this.sockets.length; j++) {
+      if (this.sockets[j]) {
+        clearSocket(this.sockets[j], this.onError, this.onMessage);
+        this.sockets[j] = null;
+      }
+    }
+  }
+}
+
+class SequentialSendStrategy {
+  constructor(addresses, port, request) {
+    this.addresses = addresses;
+    this.port = port;
+    this.request = request;
+
+    this.socket = null;
+    this.onError = null;
+    this.onMessage = null;
+    this.next = 0;
+  }
+
+  send(cb) {
+    const that = this;
+
+    const onError = function(err) {
+      clearSocket(this, onError, onMessage);
+      that.socket = null;
+
+      if (that.addresses.length > that.next) {
+        that.send(cb);
+      } else {
+        cb(err);
+      }
+    };
+
+    const onMessage = function(message) {
+      clearSocket(this, onError, onMessage);
+      that.socket = null;
+      cb(null, message);
+    };
+
+    this.socket = sendDgramSocketRequest(
+      this.addresses[this.next].address, this.port, this.request, onError, onMessage);
+    this.next++;
+
+    this.onError = onError;
+    this.onMessage = onMessage;
+  }
+
+  cancel() {
+    if (this.socket) {
+      clearSocket(this.socket, this.onError, this.onMessage);
+      this.socket = null;
+    }
+  }
+}
+
+module.exports.Sender = Sender;
+module.exports.ParallelSendStrategy = ParallelSendStrategy;
+module.exports.SequentialSendStrategy = SequentialSendStrategy;

--- a/test/integration/instance-lookup-test.coffee
+++ b/test/integration/instance-lookup-test.coffee
@@ -1,5 +1,5 @@
 fs = require('fs')
-instanceLookup = require('../../src/instance-lookup').instanceLookup
+InstanceLookup = require('../../src/instance-lookup').InstanceLookup
 
 RESERVED_IP_ADDRESS = '192.0.2.0'     # Can never be used, so guaranteed to fail.
 
@@ -22,7 +22,7 @@ exports.goodInstance = (test) ->
 
     test.done()
 
-  instanceLookup({ server: config.server, instanceName: config.instanceName }, callback)
+  new InstanceLookup().instanceLookup({ server: config.server, instanceName: config.instanceName }, callback)
 
 exports.badInstance = (test) ->
   config = getConfig()
@@ -33,7 +33,7 @@ exports.badInstance = (test) ->
 
     test.done()
 
-  instanceLookup({ server: config.server, instanceName: 'badInstanceName', timeout: 100, retries: 1 }, callback)
+  new InstanceLookup().instanceLookup({ server: config.server, instanceName: 'badInstanceName', timeout: 100, retries: 1 }, callback)
 
 exports.badServer = (test) ->
   config = getConfig()
@@ -44,4 +44,4 @@ exports.badServer = (test) ->
 
     test.done()
 
-  instanceLookup({ server: RESERVED_IP_ADDRESS, instanceName: 'badInstanceName', timeout: 100, retries: 1 }, callback)
+  new InstanceLookup().instanceLookup({ server: RESERVED_IP_ADDRESS, instanceName: 'badInstanceName', timeout: 100, retries: 1 }, callback)

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -74,8 +74,7 @@ exports['instanceLookup functional unit tests'] = {
       server: 'server',
       instanceName: 'instance',
       timeout: 1000,
-      retries: 3,
-      multiSubnetFailover: true
+      retries: 3
     };
 
     this.anyPort = 1234;
@@ -90,7 +89,7 @@ exports['instanceLookup functional unit tests'] = {
     // to override the execute method on Sender so we can test instance lookup code
     // without triggering network activity.
     this.testSender = this.instanceLookup.createSender(
-      this.options.server, this.anyPort, this.anyRequest, this.options.multiSubnetFailover);
+      this.options.server, this.anyPort, this.anyRequest);
     this.createSenderStub = this.sinon.stub(this.instanceLookup, 'createSender');
     this.createSenderStub.returns(this.testSender);
     this.senderExecuteStub = this.sinon.stub(this.testSender, 'execute');
@@ -118,7 +117,7 @@ exports['instanceLookup functional unit tests'] = {
 
       test.ok(this.createSenderStub.calledOnce);
       test.strictEqual(this.createSenderStub.args[0][0], this.options.server);
-      test.strictEqual(this.createSenderStub.args[0][3], this.options.multiSubnetFailover);
+      test.strictEqual(this.createSenderStub.args[0][3]);
 
       test.ok(this.senderExecuteStub.calledOnce);
       test.ok(this.parseStub.calledOnce);
@@ -135,7 +134,7 @@ exports['instanceLookup functional unit tests'] = {
 
       test.ok(this.createSenderStub.calledOnce);
       test.strictEqual(this.createSenderStub.args[0][0], this.options.server);
-      test.strictEqual(this.createSenderStub.args[0][3], this.options.multiSubnetFailover);
+      test.strictEqual(this.createSenderStub.args[0][3]);
 
       test.ok(this.senderExecuteStub.calledOnce);
       test.strictEqual(this.parseStub.callCount, 0);
@@ -153,7 +152,7 @@ exports['instanceLookup functional unit tests'] = {
 
       test.ok(this.createSenderStub.calledOnce);
       test.strictEqual(this.createSenderStub.args[0][0], this.options.server);
-      test.strictEqual(this.createSenderStub.args[0][3], this.options.multiSubnetFailover);
+      test.strictEqual(this.createSenderStub.args[0][3]);
 
       test.ok(this.senderExecuteStub.calledOnce);
       test.ok(this.parseStub.calledOnce);
@@ -176,7 +175,7 @@ exports['instanceLookup functional unit tests'] = {
       test.ok(this.createSenderStub.callCount, 2);
       for (let j = 0; j < this.createSenderStub.callCount; j++) {
         test.strictEqual(this.createSenderStub.args[j][0], this.options.server);
-        test.strictEqual(this.createSenderStub.args[j][3], this.options.multiSubnetFailover);
+        test.strictEqual(this.createSenderStub.args[j][3]);
       }
 
       // Execute called twice but parse only called once as the first call to execute times out.
@@ -215,7 +214,7 @@ exports['instanceLookup functional unit tests'] = {
       test.strictEqual(this.createSenderStub.callCount, this.options.retries);
       for (let j = 0; j < this.createSenderStub.callCount; j++) {
         test.strictEqual(this.createSenderStub.args[j][0], this.options.server);
-        test.strictEqual(this.createSenderStub.args[j][3], this.options.multiSubnetFailover);
+        test.strictEqual(this.createSenderStub.args[j][3]);
       }
 
       // Execute called 'retries' number of times but parse is never called because

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -1,37 +1,272 @@
 'use strict';
 
-const parse = require('../../src/instance-lookup').parseBrowserResponse;
+const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
+const Sinon = require('sinon');
 
-exports.oneInstanceFound = function(test) {
-  const response = 'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;';
+exports['instanceLookup invalid args'] = {
+  setUp: function(done) {
+    this.instanceLookup = new InstanceLookup().instanceLookup;
+    done();
+  },
 
-  test.strictEqual(parse(response, 'sqlexpress'), 1433);
-  test.done();
+  'invalid server': function(test) {
+    const expectedErrorMessage = 'Invalid arguments: "server" must be a string';
+    try {
+      const notString = 4;
+      this.instanceLookup({ server: notString });
+    } catch (err) {
+      test.strictEqual(err.message, expectedErrorMessage);
+      test.done();
+    }
+  },
+
+  'invalid instanceName': function(test) {
+    const expectedErrorMessage = 'Invalid arguments: "instanceName" must be a string';
+    try {
+      const notString = 4;
+      this.instanceLookup({ server: 'serverName', instanceName: notString });
+    } catch (err) {
+      test.strictEqual(err.message, expectedErrorMessage);
+      test.done();
+    }
+  },
+
+  'invalid timeout': function(test) {
+    const expectedErrorMessage = 'Invalid arguments: "timeout" must be a number';
+    try {
+      const notNumber = 'some string';
+      this.instanceLookup({ server: 'server', instanceName: 'instance', timeout: notNumber });
+    } catch (err) {
+      test.strictEqual(err.message, expectedErrorMessage);
+      test.done();
+    }
+  },
+
+  'invalid retries': function(test) {
+    const expectedErrorMessage = 'Invalid arguments: "retries" must be a number';
+    try {
+      const notNumber = 'some string';
+      this.instanceLookup({ server: 'server', instanceName: 'instance', timeout: 1000, retries: notNumber });
+    } catch (err) {
+      test.strictEqual(err.message, expectedErrorMessage);
+      test.done();
+    }
+  },
+
+  'invalid callback': function(test) {
+    const expectedErrorMessage = 'Invalid arguments: "callback" must be a function';
+    try {
+      const notFunction = 4;
+      this.instanceLookup({ server: 'server', instanceName: 'instance', timeout: 1000, retries: 3 }, notFunction);
+    } catch (err) {
+      test.strictEqual(err.message, expectedErrorMessage);
+      test.done();
+    }
+  }
 };
 
-exports.twoInstancesFoundInFirst = function(test) {
-  const response =
-    'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;' +
-    'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
 
-  test.strictEqual(parse(response, 'sqlexpress'), 1433);
-  test.done();
+exports['instanceLookup functional unit tests'] = {
+  setUp: function(done) {
+    this.sinon = Sinon.sandbox.create();
+
+    this.options = {
+      server: 'server',
+      instanceName: 'instance',
+      timeout: 1000,
+      retries: 3,
+      multiSubnetFailover: true
+    };
+
+    this.anyPort = 1234;
+    this.anyRequest = new Buffer(0x02);
+    this.anyMessage = 'any message';
+    this.anyError = new Error('any error');
+    this.anySqlPort = 2345;
+
+    this.instanceLookup = new InstanceLookup();
+
+    // Stub out createSender method to return the Sender we create. This allows us
+    // to override the execute method on Sender so we can test instance lookup code
+    // without triggering network activity.
+    this.testSender = this.instanceLookup.createSender(
+      this.options.server, this.anyPort, this.anyRequest, this.options.multiSubnetFailover);
+    this.createSenderStub = this.sinon.stub(this.instanceLookup, 'createSender');
+    this.createSenderStub.returns(this.testSender);
+    this.senderExecuteStub = this.sinon.stub(this.testSender, 'execute');
+
+    // Stub parseBrowserResponse so we can mimic success and failure without creating
+    // elaborate responses. parseBrowserResponse itself has unit tests to ensure that
+    // it functions correctly.
+    this.parseStub = this.sinon.stub(this.instanceLookup, 'parseBrowserResponse');
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sinon.restore();
+    done();
+  },
+
+  'success': function(test) {
+    this.senderExecuteStub.callsArgWithAsync(0, null, this.anyMessage);
+    this.parseStub.withArgs(this.anyMessage, this.options.instanceName).returns(this.anySqlPort);
+
+    this.instanceLookup.instanceLookup(this.options, (error, port) => {
+      test.strictEqual(error, undefined);
+      test.strictEqual(port, this.anySqlPort);
+
+      test.ok(this.createSenderStub.calledOnce);
+      test.strictEqual(this.createSenderStub.args[0][0], this.options.server);
+      test.strictEqual(this.createSenderStub.args[0][3], this.options.multiSubnetFailover);
+
+      test.ok(this.senderExecuteStub.calledOnce);
+      test.ok(this.parseStub.calledOnce);
+      test.done();
+    });
+  },
+
+  'sender fail': function(test) {
+    this.senderExecuteStub.callsArgWithAsync(0, this.anyError, undefined);
+
+    this.instanceLookup.instanceLookup(this.options, (error, port) => {
+      test.ok(error.indexOf(this.anyError.message) !== -1);
+      test.strictEqual(port, undefined);
+
+      test.ok(this.createSenderStub.calledOnce);
+      test.strictEqual(this.createSenderStub.args[0][0], this.options.server);
+      test.strictEqual(this.createSenderStub.args[0][3], this.options.multiSubnetFailover);
+
+      test.ok(this.senderExecuteStub.calledOnce);
+      test.strictEqual(this.parseStub.callCount, 0);
+      test.done();
+    });
+  },
+
+  'parse fail': function(test) {
+    this.senderExecuteStub.callsArgWithAsync(0, null, this.anyMessage);
+    this.parseStub.withArgs(this.anyMessage, this.options.instanceName).returns(null);
+
+    this.instanceLookup.instanceLookup(this.options, (error, port) => {
+      test.ok(error.indexOf('not found') !== -1);
+      test.strictEqual(port, undefined);
+
+      test.ok(this.createSenderStub.calledOnce);
+      test.strictEqual(this.createSenderStub.args[0][0], this.options.server);
+      test.strictEqual(this.createSenderStub.args[0][3], this.options.multiSubnetFailover);
+
+      test.ok(this.senderExecuteStub.calledOnce);
+      test.ok(this.parseStub.calledOnce);
+      test.done();
+    });
+  },
+
+  'retry success': function(test) {
+    // First invocation of execute will not invoke callback. This will cause a timeout
+    // and trigger a retry. Setup to invoke callback on second invocation.
+    this.senderExecuteStub.onCall(1).callsArgWithAsync(0, null, this.anyMessage);
+    this.parseStub.withArgs(this.anyMessage, this.options.instanceName).returns(this.anySqlPort);
+
+    const clock = this.sinon.useFakeTimers();
+
+    this.instanceLookup.instanceLookup(this.options, (error, port) => {
+      test.strictEqual(error, undefined);
+      test.strictEqual(port, this.anySqlPort);
+
+      test.ok(this.createSenderStub.callCount, 2);
+      for (let j = 0; j < this.createSenderStub.callCount; j++) {
+        test.strictEqual(this.createSenderStub.args[j][0], this.options.server);
+        test.strictEqual(this.createSenderStub.args[j][3], this.options.multiSubnetFailover);
+      }
+
+      // Execute called twice but parse only called once as the first call to execute times out.
+      test.strictEqual(this.senderExecuteStub.callCount, 2);
+      test.ok(this.parseStub.calledOnce);
+
+      clock.restore();
+      test.done();
+    });
+
+    // Forward clock to trigger timeout.
+    clock.tick(this.options.timeout * 1.1);
+  },
+
+  'retry fail': function(test) {
+    const clock = this.sinon.useFakeTimers();
+
+    const forwardClock = () => {
+      clock.tick(this.options.timeout * 1.1);
+    };
+
+    const scheduleForwardClock = function() {
+      // This function is called in place of sender.execute(). We don't want to
+      // rely on when the timeout is set in relation to execute() in the calling
+      // context. So we setup to forward clock on next tick.
+      process.nextTick(forwardClock);
+    };
+
+    this.senderExecuteStub.restore();
+    this.senderExecuteStub = this.sinon.stub(this.testSender, 'execute', scheduleForwardClock);
+
+    this.instanceLookup.instanceLookup(this.options, (error, port) => {
+      test.ok(error.indexOf('Failed to get response') != -1);
+      test.strictEqual(port, undefined);
+
+      test.strictEqual(this.createSenderStub.callCount, this.options.retries);
+      for (let j = 0; j < this.createSenderStub.callCount; j++) {
+        test.strictEqual(this.createSenderStub.args[j][0], this.options.server);
+        test.strictEqual(this.createSenderStub.args[j][3], this.options.multiSubnetFailover);
+      }
+
+      // Execute called 'retries' number of times but parse is never called because
+      // all the execute calls timeout.
+      test.strictEqual(this.senderExecuteStub.callCount, this.options.retries);
+      test.strictEqual(this.parseStub.callCount, 0);
+
+      clock.restore();
+      test.done();
+    });
+  }
 };
 
-exports.twoInstancesFoundInSecond = function(test) {
-  const response =
-    'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
-    'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;';
+exports['parseBrowserResponse'] = {
+  setUp: function(done) {
+    this.parse = new InstanceLookup().parseBrowserResponse;
+    done();
+  },
 
-  test.strictEqual(parse(response, 'sqlexpress'), 1433);
-  test.done();
+  'oneInstanceFound': function(test) {
+    const response = 'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;';
+
+    test.strictEqual(this.parse(response, 'sqlexpress'), 1433);
+    test.done();
+  },
+
+  'twoInstancesFoundInFirst': function(test) {
+    const response =
+      'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;' +
+      'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
+
+    test.strictEqual(this.parse(response, 'sqlexpress'), 1433);
+    test.done();
+  },
+
+  'twoInstancesFoundInSecond': function(test) {
+    const response =
+      'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
+      'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;';
+
+    test.strictEqual(this.parse(response, 'sqlexpress'), 1433);
+    test.done();
+  },
+
+  'twoInstancesNotFound': function(test) {
+    const response =
+      'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
+      'ServerName;WINDOWS2;InstanceName;YYYYYYYYYY;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
+
+    test.strictEqual(this.parse(response, 'sqlexpress'), undefined);
+    test.done();
+  }
 };
 
-exports.twoInstancesNotFound = function(test) {
-  const response =
-    'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
-    'ServerName;WINDOWS2;InstanceName;YYYYYYYYYY;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
-
-  test.strictEqual(parse(response, 'sqlexpress'), undefined);
-  test.done();
-};

--- a/test/unit/sender-test.js
+++ b/test/unit/sender-test.js
@@ -1,0 +1,604 @@
+'use strict';
+
+const Dgram = require('dgram');
+const Sender = require('../../src/sender').Sender;
+const ParallelSendStrategy = require('../../src/sender').ParallelSendStrategy;
+const SequentialSendStrategy = require('../../src/sender').SequentialSendStrategy;
+const Sinon = require('sinon');
+
+const anyPort = 1234;
+const anyIpv4 = '1.2.3.4';
+const anyIpv6 = '2002:20:0:0:0:0:1:3';
+const anyHost = 'myhostname';
+const anyRequest = new Buffer(0x02);
+
+const udpIpv4 = 'udp4';
+const udpIpv6 = 'udp6';
+
+const sendResultSuccess = 0;
+const sendResultError = 1;
+const sendResultCancel = 2;
+
+// Stub function to mimic socket emitting 'error' and 'message' events.
+const emitEvent = function() {
+  if (this.sendResult === sendResultError) {
+    this.emit('error', this);
+  } else {
+    this.emit('message', this);
+  }
+};
+
+// Stub function to mimic socket 'send' without causing network activity.
+const sendStub = function(buffer, offset, length, port, ipAddress) {
+  process.nextTick(emitEvent.bind(this));
+};
+
+const sendToIpCommonTestSetup = function(ipAddress, udpVersion, sendResult, multiSubnetFailover) {
+  // Create socket exactly like the Sender class would create while stubbing
+  // some methods for unit testing.
+  this.testSocket = Dgram.createSocket(udpVersion);
+  this.socketSendStub = this.sinon.stub(this.testSocket, 'send', sendStub);
+  this.socketCloseStub = this.sinon.stub(this.testSocket, 'close');
+
+  // This allows the emitEvent method to emit the right event for the given test.
+  this.testSocket.sendResult = sendResult;
+
+  // Stub createSocket method to return a socket created exactly like the
+  // method would but with a few methods stubbed out above.
+  this.createSocketStub = this.sinon.stub(Dgram, 'createSocket');
+  this.createSocketStub.withArgs(udpVersion).returns(this.testSocket);
+
+  this.sender = new Sender(ipAddress, anyPort, anyRequest, multiSubnetFailover);
+};
+
+exports['Sender send to IP address'] = {
+  setUp: function(done) {
+    this.sinon = Sinon.sandbox.create();
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sinon.restore();
+    done();
+  },
+
+  'send to IPv4': function(test) {
+    const multiSubnetFailover = false;
+    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultSuccess, multiSubnetFailover);
+
+    this.sender.execute((error, message) => {
+      test.strictEqual(error, null);
+      test.strictEqual(message, this.testSocket);
+
+      test.ok(this.socketCloseStub.withArgs().calledOnce);
+      test.done();
+    });
+
+    test.ok(this.createSocketStub.calledOnce);
+    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv4).calledOnce);
+  },
+
+  'send to IPv6': function(test) {
+    const multiSubnetFailover = true;
+    sendToIpCommonTestSetup.call(this, anyIpv6, udpIpv6, sendResultSuccess, multiSubnetFailover);
+
+    this.sender.execute((error, message) => {
+      test.strictEqual(error, null);
+      test.strictEqual(message, this.testSocket);
+
+      test.ok(this.socketCloseStub.withArgs().calledOnce);
+      test.done();
+    });
+
+    test.ok(this.createSocketStub.calledOnce);
+    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv6).calledOnce);
+  },
+
+  'send fails': function(test) {
+    const multiSubnetFailover = true;
+    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultError, multiSubnetFailover);
+
+    this.sender.execute((error, message) => {
+      test.strictEqual(error, this.testSocket);
+      test.strictEqual(message, undefined);
+
+      test.ok(this.socketCloseStub.withArgs().calledOnce);
+      test.done();
+    });
+
+    test.ok(this.createSocketStub.calledOnce);
+    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv4).calledOnce);
+  },
+
+  'send cancel': function(test) {
+    const multiSubnetFailover = true;
+    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultCancel, multiSubnetFailover);
+
+    this.sender.execute((error, message) => {
+      test.ok(false, 'Should never get here.');
+    });
+
+    test.ok(this.createSocketStub.calledOnce);
+    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv4).calledOnce);
+
+    this.sender.cancel();
+    test.ok(this.socketCloseStub.withArgs().calledOnce);
+    test.done();
+  }
+};
+
+
+const sendToHostCommonTestSetup = function(lookupError, multiSubnetFailover, testStrategy, createStrategyMethod) {
+  // Since we're testing Sender class, we just want to verify that the 'send' and/or
+  // 'cancel' method on the right strategy class are/is being invoked. So we stub out
+  // the methods to validate they're invoked correctly.
+  const callback = () => { };
+  this.strategySendStub = this.sinon.stub(testStrategy, 'send');
+  this.strategySendStub.withArgs(callback);
+  this.strategyCancelStub = this.sinon.stub(testStrategy, 'cancel');
+  this.strategyCancelStub.withArgs();
+
+  this.sender = new Sender(anyHost, anyPort, anyRequest, multiSubnetFailover);
+
+  // Stub out the lookupAll method to prevent network activity from doing a DNS
+  // lookup. Succeeds or fails depending on lookupError.
+  this.lookupAllStub = this.sinon.stub(this.sender, 'invokeLookupAll');
+  this.lookupAllStub.callsArgWithAsync(1, lookupError, this.addresses);
+
+  // Stub the create strategy method for the test to return a strategy object created
+  // exactly like the method would but with a few methods stubbed.
+  this.createStrategyStub = this.sinon.stub(this.sender, createStrategyMethod);
+  this.createStrategyStub.withArgs(this.addresses, anyPort, anyRequest).returns(testStrategy);
+
+  this.sender.execute(callback);
+};
+
+exports['Sender send to hostname'] = {
+  setUp: function(done) {
+    this.sinon = Sinon.sandbox.create();
+
+    // Set of IP addresses to be returned by stubbed out lookupAll method.
+    this.addresses = [
+      { address: '127.0.0.2' },
+      { address: '2002:20:0:0:0:0:1:3' },
+      { address: '127.0.0.4' }
+    ];
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sinon.restore();
+    done();
+  },
+
+  // lookupAll is async. So we push out validation to next tick to run
+  // after lookupAll asyn callback is done in all the tests below.
+
+  'send with MultiSubnetFailover': function(test) {
+    const multiSubnetFailover = true;
+    const lookupError = null;
+    const testStrategy = new ParallelSendStrategy(this.addresses, anyPort, anyRequest);
+    const createStrategyMethod = 'createParallelSendStrategy';
+
+    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+
+    test.ok(this.lookupAllStub.calledOnce);
+
+    const validate = () => {
+      test.ok(this.createStrategyStub.calledOnce);
+      test.ok(this.strategySendStub.calledOnce);
+      test.done();
+    };
+
+    process.nextTick(validate);
+  },
+
+  'send with MultiSubnetFailover cancel': function(test) {
+    const multiSubnetFailover = true;
+    const lookupError = null;
+    const testStrategy = new ParallelSendStrategy(this.addresses, anyPort, anyRequest);
+    const createStrategyMethod = 'createParallelSendStrategy';
+
+    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+
+    test.ok(this.lookupAllStub.calledOnce);
+
+    const validate = () => {
+      test.ok(this.createStrategyStub.calledOnce);
+      test.ok(this.strategySendStub.calledOnce);
+
+      this.sender.cancel();
+      test.ok(this.strategyCancelStub.calledOnce);
+      test.done();
+    };
+
+    process.nextTick(validate);
+  },
+
+  'send without MultiSubnetFailover': function(test) {
+    const multiSubnetFailover = false;
+    const lookupError = null;
+    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
+    const createStrategyMethod = 'createSequentialSendStrategy';
+
+    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+
+    test.ok(this.lookupAllStub.calledOnce);
+
+    const validate = () => {
+      test.ok(this.createStrategyStub.calledOnce);
+      test.ok(this.strategySendStub.calledOnce);
+      test.done();
+    };
+
+    process.nextTick(validate);
+  },
+
+  'send without MultiSubnetFailover cancel': function(test) {
+    const multiSubnetFailover = false;
+    const lookupError = null;
+    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
+    const createStrategyMethod = 'createSequentialSendStrategy';
+
+    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+
+    test.ok(this.lookupAllStub.calledOnce);
+
+    const validate = () => {
+      test.ok(this.createStrategyStub.calledOnce);
+      test.ok(this.strategySendStub.calledOnce);
+
+      this.sender.cancel();
+      test.ok(this.strategyCancelStub.calledOnce);
+      test.done();
+    };
+
+    process.nextTick(validate);
+  },
+
+  'send lookup error': function(test) {
+    const multiSubnetFailover = false;
+    const lookupError = new Error('some error.');
+    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
+    const createStrategyMethod = 'createSequentialSendStrategy';
+
+    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+
+    test.ok(this.lookupAllStub.calledOnce);
+
+    const validate = () => {
+      // Strategy object should not be created on lookup error.
+      test.strictEqual(this.createStrategyStub.callCount, 0);
+      test.strictEqual(this.strategySendStub.callCount, 0);
+      test.done();
+    };
+
+    process.nextTick(validate);
+  },
+
+  'send cancel on lookup error': function(test) {
+    const multiSubnetFailover = false;
+    const lookupError = new Error('some error.');
+    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
+    const createStrategyMethod = 'createSequentialSendStrategy';
+
+    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+    this.sender.cancel();
+
+    test.ok(this.lookupAllStub.calledOnce);
+
+    const validate = () => {
+      // Strategy object should not be created on lookup error.
+      test.strictEqual(this.createStrategyStub.callCount, 0);
+      test.strictEqual(this.strategySendStub.callCount, 0);
+      test.strictEqual(this.strategyCancelStub.callCount, 0);
+      test.done();
+    };
+
+    process.nextTick(validate);
+  }
+};
+
+
+const commonStrategyTestSetup = function() {
+  // IP addresses returned by DNS reverse lookup and passed to the Strategy.
+  this.testData = [
+    { address: '1.2.3.4', udpVersion: udpIpv4 },
+    { address: '2002:20:0:0:0:0:1:3', udpVersion: udpIpv6 },
+    { address: '2002:30:0:0:0:0:2:4', udpVersion: udpIpv6 },
+    { address: '5.6.7.8', udpVersion: udpIpv4 }
+  ];
+
+  // Create sockets for each of the IP addresses with send and close stubbed out to
+  // prevent network activity.
+  for (let j = 0; j < this.testData.length; j++) {
+    this.testData[j].testSocket = Dgram.createSocket(this.testData[j].udpVersion);
+    this.testData[j].socketSendStub = this.sinon.stub(this.testData[j].testSocket, 'send', sendStub);
+    this.testData[j].socketCloseStub = this.sinon.stub(this.testData[j].testSocket, 'close');
+
+    // This allows emitEvent method to fire an 'error' or 'message' event appropriately.
+    // A given test may overwrite this value for specific sockets to test different
+    // scenarios.
+    this.testData[j].testSocket.sendResult = sendResultSuccess;
+  }
+
+  // Stub createSocket method to returns a socket created exactly like the
+  // method would but with a few methods stubbed out above.
+  this.createSocketStub = this.sinon.stub(Dgram, 'createSocket');
+  this.createSocketStub.withArgs(udpIpv4).onFirstCall().returns(this.testData[0].testSocket);
+  this.createSocketStub.withArgs(udpIpv6).onFirstCall().returns(this.testData[1].testSocket);
+  this.createSocketStub.withArgs(udpIpv6).onSecondCall().returns(this.testData[2].testSocket);
+  this.createSocketStub.withArgs(udpIpv4).onSecondCall().returns(this.testData[3].testSocket);
+};
+
+exports['ParallelSendStrategy'] = {
+  setUp: function(done) {
+    this.sinon = Sinon.sandbox.create();
+    commonStrategyTestSetup.call(this);
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sinon.restore();
+    done();
+  },
+
+  'send all IPs success.': function(test) {
+    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
+    parallelSendStrategy.send((error, message) => {
+      test.strictEqual(error, null);
+
+      // We should get the message only on the first socket.
+      test.strictEqual(message, this.testData[0].testSocket);
+
+      for (let j = 0; j < this.testData.length; j++) {
+        test.ok(this.testData[j].socketSendStub.calledOnce);
+        test.ok(this.testData[j].socketCloseStub.calledOnce);
+      }
+
+      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
+
+      test.done();
+    });
+  },
+
+  'send one IP fail.': function(test) {
+    // Setup first socket to fail on socket send.
+    this.testData[0].testSocket.sendResult = sendResultError;
+
+    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
+    parallelSendStrategy.send((error, message) => {
+      // Even though the first socket fails on send, we should not get an error
+      // as the other sockets succeed.
+      test.strictEqual(error, null);
+
+      // We setup the first send to fail. So we should get the message on the
+      // second socket.
+      test.strictEqual(message, this.testData[1].testSocket);
+
+      for (let j = 0; j < this.testData.length; j++) {
+        test.ok(this.testData[j].socketSendStub.calledOnce);
+        test.ok(this.testData[j].socketCloseStub.calledOnce);
+      }
+
+      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
+
+      test.done();
+    });
+  },
+
+  'send two IPs fail.': function(test) {
+    // Setup first two sockets to fail on socket send.
+    this.testData[0].testSocket.sendResult = sendResultError;
+    this.testData[1].testSocket.sendResult = sendResultError;
+
+    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
+    parallelSendStrategy.send((error, message) => {
+      // Even though the first two sockets fails on send, we should not get an error
+      // as the other sockets succeed.
+      test.strictEqual(error, null);
+
+      // We setup the first two sends to fail. So we should get the message on the
+      // third socket.
+      test.strictEqual(message, this.testData[2].testSocket);
+
+      for (let j = 0; j < this.testData.length; j++) {
+        test.ok(this.testData[j].socketSendStub.calledOnce);
+        test.ok(this.testData[j].socketCloseStub.calledOnce);
+      }
+
+      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
+
+      test.done();
+    });
+  },
+
+  'send all IPs fail.': function(test) {
+    // Setup all sockets to fail on socket send.
+    for (let j = 0; j < this.testData.length; j++) {
+      this.testData[j].testSocket.sendResult = sendResultError;
+    }
+
+    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
+    parallelSendStrategy.send((error, message) => {
+      // All socket sends fail. We should get an error on the last socket fail.
+      test.strictEqual(error, this.testData[this.testData.length - 1].testSocket);
+
+      test.strictEqual(message, undefined);
+
+      for (let j = 0; j < this.testData.length; j++) {
+        test.ok(this.testData[j].socketSendStub.calledOnce);
+        test.ok(this.testData[j].socketCloseStub.calledOnce);
+      }
+
+      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
+
+      test.done();
+    });
+  },
+
+  'send cancel.': function(test) {
+    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
+    parallelSendStrategy.send((error, message) => {
+      // We should not get a callback as the send got cancelled.
+      test.ok(false, 'Should never get here.');
+    });
+
+    parallelSendStrategy.cancel();
+
+    for (let j = 0; j < this.testData.length; j++) {
+      test.ok(this.testData[j].socketSendStub.calledOnce);
+      test.ok(this.testData[j].socketCloseStub.calledOnce);
+    }
+
+    test.strictEqual(this.createSocketStub.callCount, this.testData.length);
+
+    test.done();
+  }
+};
+
+exports['SequentialSendStrategy'] = {
+  setUp: function(done) {
+    this.sinon = Sinon.sandbox.create();
+    commonStrategyTestSetup.call(this);
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sinon.restore();
+    done();
+  },
+
+  'send all IPs success.': function(test) {
+    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
+    sequentialSendStrategy.send((error, message) => {
+      test.strictEqual(error, null);
+
+      // We should get the message only on the first socket.
+      test.strictEqual(message, this.testData[0].testSocket);
+
+      test.ok(this.testData[0].socketSendStub.calledOnce);
+      test.ok(this.testData[0].socketCloseStub.calledOnce);
+
+      // Send should be invoked only on the first socket.
+      for (let j = 1; j < this.testData.length; j++) {
+        test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
+        test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
+      }
+
+      test.strictEqual(this.createSocketStub.callCount, 1);
+
+      test.done();
+    });
+  },
+
+  'send one IP fail.': function(test) {
+    // Setup first socket to fail on socket send.
+    this.testData[0].testSocket.sendResult = sendResultError;
+
+    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
+    sequentialSendStrategy.send((error, message) => {
+      test.strictEqual(error, null);
+
+      // We should get the message on the second socket as the first one fails.
+      test.strictEqual(message, this.testData[1].testSocket);
+
+      // Send should be invoked only on the first two sockets.
+      for (let j = 0; j < this.testData.length; j++) {
+        if (j < 2) {
+          test.ok(this.testData[j].socketSendStub.calledOnce);
+          test.ok(this.testData[j].socketCloseStub.calledOnce);
+        } else {
+          test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
+          test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
+        }
+      }
+
+      // Since the first socket send fails, we should have two invocations of createSocket.
+      test.strictEqual(this.createSocketStub.callCount, 2);
+
+      test.done();
+    });
+  },
+
+  'send two IPs fail.': function(test) {
+    // Setup first two socket to fail on socket send.
+    this.testData[0].testSocket.sendResult = sendResultError;
+    this.testData[1].testSocket.sendResult = sendResultError;
+
+    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
+    sequentialSendStrategy.send((error, message) => {
+      test.strictEqual(error, null);
+
+      // We should get the message on the third socket as the first two fails.
+      test.strictEqual(message, this.testData[2].testSocket);
+
+      // Send should be invoked only on the first three sockets.
+      for (let j = 0; j < this.testData.length; j++) {
+        if (j < 3) {
+          test.ok(this.testData[j].socketSendStub.calledOnce);
+          test.ok(this.testData[j].socketCloseStub.calledOnce);
+        } else {
+          test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
+          test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
+        }
+      }
+
+      // Since the first two socket sends fail, we should have three invocations of createSocket.
+      test.strictEqual(this.createSocketStub.callCount, 3);
+
+      test.done();
+    });
+  },
+
+  'send all IPs fail.': function(test) {
+    // Setup all sockets to fail on socket send.
+    for (let j = 0; j < this.testData.length; j++) {
+      this.testData[j].testSocket.sendResult = sendResultError;
+    }
+
+    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
+    sequentialSendStrategy.send((error, message) => {
+      // All socket sends fail. We should get an error on the last socket fail.
+      test.strictEqual(error, this.testData[this.testData.length - 1].testSocket);
+
+      test.strictEqual(message, undefined);
+
+      // Send should be invoked on all sockets.
+      for (let j = 0; j < this.testData.length; j++) {
+        test.ok(this.testData[j].socketSendStub.calledOnce);
+        test.ok(this.testData[j].socketCloseStub.calledOnce);
+      }
+
+      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
+
+      test.done();
+    });
+  },
+
+  'send cancel.': function(test) {
+    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
+    sequentialSendStrategy.send((error, message) => {
+      // We should not get a callback as the send got cancelled.
+      test.ok(false, 'Should never get here.');
+    });
+
+    sequentialSendStrategy.cancel();
+
+    // Send should be invoked only on the first socket.
+    for (let j = 0; j < this.testData.length; j++) {
+      if (j === 0) {
+        test.ok(this.testData[j].socketSendStub.calledOnce);
+        test.ok(this.testData[j].socketCloseStub.calledOnce);
+      } else {
+        test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
+        test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
+      }
+    }
+
+    test.strictEqual(this.createSocketStub.callCount, 1);
+
+    test.done();
+  }
+};

--- a/test/unit/sender-test.js
+++ b/test/unit/sender-test.js
@@ -3,7 +3,6 @@
 const Dgram = require('dgram');
 const Sender = require('../../src/sender').Sender;
 const ParallelSendStrategy = require('../../src/sender').ParallelSendStrategy;
-const SequentialSendStrategy = require('../../src/sender').SequentialSendStrategy;
 const Sinon = require('sinon');
 
 const anyPort = 1234;
@@ -22,9 +21,13 @@ const sendResultCancel = 2;
 // Stub function to mimic socket emitting 'error' and 'message' events.
 const emitEvent = function() {
   if (this.sendResult === sendResultError) {
-    this.emit('error', this);
+    if (this.listenerCount('error') > 0) {
+      this.emit('error', this);
+    }
   } else {
-    this.emit('message', this);
+    if (this.listenerCount('message') > 0) {
+      this.emit('message', this);
+    }
   }
 };
 
@@ -33,12 +36,12 @@ const sendStub = function(buffer, offset, length, port, ipAddress) {
   process.nextTick(emitEvent.bind(this));
 };
 
-const sendToIpCommonTestSetup = function(ipAddress, udpVersion, sendResult, multiSubnetFailover) {
+const sendToIpCommonTestSetup = function(ipAddress, udpVersion, sendResult) {
   // Create socket exactly like the Sender class would create while stubbing
   // some methods for unit testing.
   this.testSocket = Dgram.createSocket(udpVersion);
   this.socketSendStub = this.sinon.stub(this.testSocket, 'send', sendStub);
-  this.socketCloseStub = this.sinon.stub(this.testSocket, 'close');
+  this.socketCloseSpy = this.sinon.spy(this.testSocket, 'close');
 
   // This allows the emitEvent method to emit the right event for the given test.
   this.testSocket.sendResult = sendResult;
@@ -48,7 +51,12 @@ const sendToIpCommonTestSetup = function(ipAddress, udpVersion, sendResult, mult
   this.createSocketStub = this.sinon.stub(Dgram, 'createSocket');
   this.createSocketStub.withArgs(udpVersion).returns(this.testSocket);
 
-  this.sender = new Sender(ipAddress, anyPort, anyRequest, multiSubnetFailover);
+  this.sender = new Sender(ipAddress, anyPort, anyRequest);
+};
+
+const sendToIpCommonTestValidation = function(test, ipAddress) {
+  test.ok(this.createSocketStub.calledOnce);
+  test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, ipAddress).calledOnce);
 };
 
 exports['Sender send to IP address'] = {
@@ -63,82 +71,75 @@ exports['Sender send to IP address'] = {
   },
 
   'send to IPv4': function(test) {
-    const multiSubnetFailover = false;
-    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultSuccess, multiSubnetFailover);
+    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultSuccess);
 
     this.sender.execute((error, message) => {
       test.strictEqual(error, null);
       test.strictEqual(message, this.testSocket);
 
-      test.ok(this.socketCloseStub.withArgs().calledOnce);
+      test.ok(this.socketCloseSpy.withArgs().calledOnce);
       test.done();
     });
 
-    test.ok(this.createSocketStub.calledOnce);
-    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv4).calledOnce);
+    sendToIpCommonTestValidation.call(this, test, anyIpv4);
   },
 
   'send to IPv6': function(test) {
-    const multiSubnetFailover = true;
-    sendToIpCommonTestSetup.call(this, anyIpv6, udpIpv6, sendResultSuccess, multiSubnetFailover);
+    sendToIpCommonTestSetup.call(this, anyIpv6, udpIpv6, sendResultSuccess);
 
     this.sender.execute((error, message) => {
       test.strictEqual(error, null);
       test.strictEqual(message, this.testSocket);
 
-      test.ok(this.socketCloseStub.withArgs().calledOnce);
+      test.ok(this.socketCloseSpy.withArgs().calledOnce);
       test.done();
     });
 
-    test.ok(this.createSocketStub.calledOnce);
-    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv6).calledOnce);
+    sendToIpCommonTestValidation.call(this, test, anyIpv6);
   },
 
   'send fails': function(test) {
-    const multiSubnetFailover = true;
-    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultError, multiSubnetFailover);
+    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultError);
 
     this.sender.execute((error, message) => {
       test.strictEqual(error, this.testSocket);
       test.strictEqual(message, undefined);
 
-      test.ok(this.socketCloseStub.withArgs().calledOnce);
+      test.ok(this.socketCloseSpy.withArgs().calledOnce);
       test.done();
     });
 
-    test.ok(this.createSocketStub.calledOnce);
-    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv4).calledOnce);
+    sendToIpCommonTestValidation.call(this, test, anyIpv4);
   },
 
   'send cancel': function(test) {
-    const multiSubnetFailover = true;
-    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultCancel, multiSubnetFailover);
+    sendToIpCommonTestSetup.call(this, anyIpv4, udpIpv4, sendResultCancel);
 
     this.sender.execute((error, message) => {
       test.ok(false, 'Should never get here.');
     });
 
-    test.ok(this.createSocketStub.calledOnce);
-    test.ok(this.socketSendStub.withArgs(anyRequest, 0, anyRequest.length, anyPort, anyIpv4).calledOnce);
+    sendToIpCommonTestValidation.call(this, test, anyIpv4);
 
     this.sender.cancel();
-    test.ok(this.socketCloseStub.withArgs().calledOnce);
+    test.ok(this.socketCloseSpy.withArgs().calledOnce);
     test.done();
   }
 };
 
 
-const sendToHostCommonTestSetup = function(lookupError, multiSubnetFailover, testStrategy, createStrategyMethod) {
-  // Since we're testing Sender class, we just want to verify that the 'send' and/or
-  // 'cancel' method on the right strategy class are/is being invoked. So we stub out
+const sendToHostCommonTestSetup = function(lookupError) {
+  // Since we're testing Sender class, we just want to verify that the 'send'/'cancel'
+  // method(s) on the ParallelSendStrategy class are/is being invoked. So we stub out
   // the methods to validate they're invoked correctly.
+  const testStrategy = new ParallelSendStrategy(this.addresses, anyPort, anyRequest);
   const callback = () => { };
   this.strategySendStub = this.sinon.stub(testStrategy, 'send');
   this.strategySendStub.withArgs(callback);
   this.strategyCancelStub = this.sinon.stub(testStrategy, 'cancel');
   this.strategyCancelStub.withArgs();
 
-  this.sender = new Sender(anyHost, anyPort, anyRequest, multiSubnetFailover);
+  this.sender = new Sender(anyHost, anyPort, anyRequest);
 
   // Stub out the lookupAll method to prevent network activity from doing a DNS
   // lookup. Succeeds or fails depending on lookupError.
@@ -147,7 +148,7 @@ const sendToHostCommonTestSetup = function(lookupError, multiSubnetFailover, tes
 
   // Stub the create strategy method for the test to return a strategy object created
   // exactly like the method would but with a few methods stubbed.
-  this.createStrategyStub = this.sinon.stub(this.sender, createStrategyMethod);
+  this.createStrategyStub = this.sinon.stub(this.sender, 'createParallelSendStrategy');
   this.createStrategyStub.withArgs(this.addresses, anyPort, anyRequest).returns(testStrategy);
 
   this.sender.execute(callback);
@@ -175,13 +176,9 @@ exports['Sender send to hostname'] = {
   // lookupAll is async. So we push out validation to next tick to run
   // after lookupAll asyn callback is done in all the tests below.
 
-  'send with MultiSubnetFailover': function(test) {
-    const multiSubnetFailover = true;
+  'send basic': function(test) {
     const lookupError = null;
-    const testStrategy = new ParallelSendStrategy(this.addresses, anyPort, anyRequest);
-    const createStrategyMethod = 'createParallelSendStrategy';
-
-    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+    sendToHostCommonTestSetup.call(this, lookupError);
 
     test.ok(this.lookupAllStub.calledOnce);
 
@@ -194,54 +191,9 @@ exports['Sender send to hostname'] = {
     process.nextTick(validate);
   },
 
-  'send with MultiSubnetFailover cancel': function(test) {
-    const multiSubnetFailover = true;
+  'send cancel': function(test) {
     const lookupError = null;
-    const testStrategy = new ParallelSendStrategy(this.addresses, anyPort, anyRequest);
-    const createStrategyMethod = 'createParallelSendStrategy';
-
-    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
-
-    test.ok(this.lookupAllStub.calledOnce);
-
-    const validate = () => {
-      test.ok(this.createStrategyStub.calledOnce);
-      test.ok(this.strategySendStub.calledOnce);
-
-      this.sender.cancel();
-      test.ok(this.strategyCancelStub.calledOnce);
-      test.done();
-    };
-
-    process.nextTick(validate);
-  },
-
-  'send without MultiSubnetFailover': function(test) {
-    const multiSubnetFailover = false;
-    const lookupError = null;
-    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
-    const createStrategyMethod = 'createSequentialSendStrategy';
-
-    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
-
-    test.ok(this.lookupAllStub.calledOnce);
-
-    const validate = () => {
-      test.ok(this.createStrategyStub.calledOnce);
-      test.ok(this.strategySendStub.calledOnce);
-      test.done();
-    };
-
-    process.nextTick(validate);
-  },
-
-  'send without MultiSubnetFailover cancel': function(test) {
-    const multiSubnetFailover = false;
-    const lookupError = null;
-    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
-    const createStrategyMethod = 'createSequentialSendStrategy';
-
-    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+    sendToHostCommonTestSetup.call(this, lookupError);
 
     test.ok(this.lookupAllStub.calledOnce);
 
@@ -258,12 +210,9 @@ exports['Sender send to hostname'] = {
   },
 
   'send lookup error': function(test) {
-    const multiSubnetFailover = false;
     const lookupError = new Error('some error.');
-    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
-    const createStrategyMethod = 'createSequentialSendStrategy';
 
-    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+    sendToHostCommonTestSetup.call(this, lookupError);
 
     test.ok(this.lookupAllStub.calledOnce);
 
@@ -278,12 +227,9 @@ exports['Sender send to hostname'] = {
   },
 
   'send cancel on lookup error': function(test) {
-    const multiSubnetFailover = false;
     const lookupError = new Error('some error.');
-    const testStrategy = new SequentialSendStrategy(this.addresses, anyPort, anyRequest);
-    const createStrategyMethod = 'createSequentialSendStrategy';
 
-    sendToHostCommonTestSetup.call(this, lookupError, multiSubnetFailover, testStrategy, createStrategyMethod);
+    sendToHostCommonTestSetup.call(this, lookupError);
     this.sender.cancel();
 
     test.ok(this.lookupAllStub.calledOnce);
@@ -310,26 +256,46 @@ const commonStrategyTestSetup = function() {
     { address: '5.6.7.8', udpVersion: udpIpv4 }
   ];
 
-  // Create sockets for each of the IP addresses with send and close stubbed out to
+  // Create sockets for IPv4 and IPv6 with send and close stubbed out to
   // prevent network activity.
-  for (let j = 0; j < this.testData.length; j++) {
-    this.testData[j].testSocket = Dgram.createSocket(this.testData[j].udpVersion);
-    this.testData[j].socketSendStub = this.sinon.stub(this.testData[j].testSocket, 'send', sendStub);
-    this.testData[j].socketCloseStub = this.sinon.stub(this.testData[j].testSocket, 'close');
+  this.testSockets = { };
+  this.testSockets[udpIpv4] = Dgram.createSocket(udpIpv4);
+  this.testSockets[udpIpv6] = Dgram.createSocket(udpIpv6);
+
+  let key;
+  for (key in this.testSockets) {
+    this.testSockets[key].socketSendStub = this.sinon.stub(this.testSockets[key], 'send', sendStub);
+    this.testSockets[key].socketCloseSpy = this.sinon.spy(this.testSockets[key], 'close');
 
     // This allows emitEvent method to fire an 'error' or 'message' event appropriately.
     // A given test may overwrite this value for specific sockets to test different
     // scenarios.
-    this.testData[j].testSocket.sendResult = sendResultSuccess;
+    this.testSockets[key].sendResult = sendResultSuccess;
+  }
+
+  for (let j = 0; j < this.testData.length; j++) {
+    this.testData[j].testSocket = this.testSockets[this.testData[j].udpVersion];
   }
 
   // Stub createSocket method to returns a socket created exactly like the
   // method would but with a few methods stubbed out above.
   this.createSocketStub = this.sinon.stub(Dgram, 'createSocket');
-  this.createSocketStub.withArgs(udpIpv4).onFirstCall().returns(this.testData[0].testSocket);
-  this.createSocketStub.withArgs(udpIpv6).onFirstCall().returns(this.testData[1].testSocket);
-  this.createSocketStub.withArgs(udpIpv6).onSecondCall().returns(this.testData[2].testSocket);
-  this.createSocketStub.withArgs(udpIpv4).onSecondCall().returns(this.testData[3].testSocket);
+  this.createSocketStub.withArgs(udpIpv4).returns(this.testSockets[udpIpv4]);
+  this.createSocketStub.withArgs(udpIpv6).returns(this.testSockets[udpIpv6]);
+
+  this.parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
+};
+
+const commonStrategyTestValidation = function(test) {
+  let key;
+  for (key in this.testSockets) {
+    test.strictEqual(this.testSockets[key].socketSendStub.callCount, 2);
+    test.strictEqual(this.testSockets[key].socketCloseSpy.callCount, 1);
+  }
+
+  test.strictEqual(this.createSocketStub.callCount, 2);
+
+  test.done();
 };
 
 exports['ParallelSendStrategy'] = {
@@ -345,260 +311,73 @@ exports['ParallelSendStrategy'] = {
   },
 
   'send all IPs success.': function(test) {
-    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
-    parallelSendStrategy.send((error, message) => {
+    this.parallelSendStrategy.send((error, message) => {
       test.strictEqual(error, null);
 
-      // We should get the message only on the first socket.
-      test.strictEqual(message, this.testData[0].testSocket);
-
-      for (let j = 0; j < this.testData.length; j++) {
-        test.ok(this.testData[j].socketSendStub.calledOnce);
-        test.ok(this.testData[j].socketCloseStub.calledOnce);
-      }
-
-      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
-
-      test.done();
+      // We should get the message only on the first socket, which is Ipv4.
+      test.strictEqual(this.testData[0].udpVersion, udpIpv4);
+      test.strictEqual(message, this.testSockets[udpIpv4]);
+      commonStrategyTestValidation.call(this, test);
     });
   },
 
-  'send one IP fail.': function(test) {
-    // Setup first socket to fail on socket send.
-    this.testData[0].testSocket.sendResult = sendResultError;
+  'send IPv4 fail.': function(test) {
+    // Setup sends to fail on Ipv4 socket.
+    this.testSockets[udpIpv4].sendResult = sendResultError;
 
-    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
-    parallelSendStrategy.send((error, message) => {
-      // Even though the first socket fails on send, we should not get an error
+    this.parallelSendStrategy.send((error, message) => {
+      // Even though the IPv4 socket sends fail, we should not get an error
       // as the other sockets succeed.
       test.strictEqual(error, null);
 
-      // We setup the first send to fail. So we should get the message on the
-      // second socket.
-      test.strictEqual(message, this.testData[1].testSocket);
+      // We setup the IPv4 socket sends to fail. So we should get the message on the
+      // Ipv6 socket.
+      test.strictEqual(message, this.testSockets[udpIpv6]);
 
-      for (let j = 0; j < this.testData.length; j++) {
-        test.ok(this.testData[j].socketSendStub.calledOnce);
-        test.ok(this.testData[j].socketCloseStub.calledOnce);
-      }
-
-      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
-
-      test.done();
+      commonStrategyTestValidation.call(this, test);
     });
   },
 
-  'send two IPs fail.': function(test) {
-    // Setup first two sockets to fail on socket send.
-    this.testData[0].testSocket.sendResult = sendResultError;
-    this.testData[1].testSocket.sendResult = sendResultError;
+  'send IPv6 fail.': function(test) {
+    // Setup sends to fail on Ipv6 socket.
+    this.testSockets[udpIpv6].sendResult = sendResultError;
 
-    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
-    parallelSendStrategy.send((error, message) => {
-      // Even though the first two sockets fails on send, we should not get an error
+    this.parallelSendStrategy.send((error, message) => {
+      // Even though the IPv6 socket sends fail, we should not get an error
       // as the other sockets succeed.
       test.strictEqual(error, null);
 
-      // We setup the first two sends to fail. So we should get the message on the
-      // third socket.
-      test.strictEqual(message, this.testData[2].testSocket);
+      // We setup the IPv6 socket sends to fail. So we should get the message on the
+      // Ipv4 socket.
+      test.strictEqual(message, this.testSockets[udpIpv4]);
 
-      for (let j = 0; j < this.testData.length; j++) {
-        test.ok(this.testData[j].socketSendStub.calledOnce);
-        test.ok(this.testData[j].socketCloseStub.calledOnce);
-      }
-
-      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
-
-      test.done();
+      commonStrategyTestValidation.call(this, test);
     });
   },
 
   'send all IPs fail.': function(test) {
-    // Setup all sockets to fail on socket send.
-    for (let j = 0; j < this.testData.length; j++) {
-      this.testData[j].testSocket.sendResult = sendResultError;
-    }
+    // Setup IPv4 and IPv6 sockets to fail on socket send.
+    this.testSockets[udpIpv4].sendResult = sendResultError;
+    this.testSockets[udpIpv6].sendResult = sendResultError;
 
-    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
-    parallelSendStrategy.send((error, message) => {
+    this.parallelSendStrategy.send((error, message) => {
       // All socket sends fail. We should get an error on the last socket fail.
-      test.strictEqual(error, this.testData[this.testData.length - 1].testSocket);
+      test.strictEqual(error, this.testSockets[this.testData[this.testData.length - 1].udpVersion]);
 
       test.strictEqual(message, undefined);
 
-      for (let j = 0; j < this.testData.length; j++) {
-        test.ok(this.testData[j].socketSendStub.calledOnce);
-        test.ok(this.testData[j].socketCloseStub.calledOnce);
-      }
-
-      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
-
-      test.done();
+      commonStrategyTestValidation.call(this, test);
     });
   },
 
   'send cancel.': function(test) {
-    const parallelSendStrategy = new ParallelSendStrategy(this.testData, anyPort, anyRequest);
-    parallelSendStrategy.send((error, message) => {
+    this.parallelSendStrategy.send((error, message) => {
       // We should not get a callback as the send got cancelled.
       test.ok(false, 'Should never get here.');
     });
 
-    parallelSendStrategy.cancel();
+    this.parallelSendStrategy.cancel();
 
-    for (let j = 0; j < this.testData.length; j++) {
-      test.ok(this.testData[j].socketSendStub.calledOnce);
-      test.ok(this.testData[j].socketCloseStub.calledOnce);
-    }
-
-    test.strictEqual(this.createSocketStub.callCount, this.testData.length);
-
-    test.done();
-  }
-};
-
-exports['SequentialSendStrategy'] = {
-  setUp: function(done) {
-    this.sinon = Sinon.sandbox.create();
-    commonStrategyTestSetup.call(this);
-    done();
-  },
-
-  tearDown: function(done) {
-    this.sinon.restore();
-    done();
-  },
-
-  'send all IPs success.': function(test) {
-    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
-    sequentialSendStrategy.send((error, message) => {
-      test.strictEqual(error, null);
-
-      // We should get the message only on the first socket.
-      test.strictEqual(message, this.testData[0].testSocket);
-
-      test.ok(this.testData[0].socketSendStub.calledOnce);
-      test.ok(this.testData[0].socketCloseStub.calledOnce);
-
-      // Send should be invoked only on the first socket.
-      for (let j = 1; j < this.testData.length; j++) {
-        test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
-        test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
-      }
-
-      test.strictEqual(this.createSocketStub.callCount, 1);
-
-      test.done();
-    });
-  },
-
-  'send one IP fail.': function(test) {
-    // Setup first socket to fail on socket send.
-    this.testData[0].testSocket.sendResult = sendResultError;
-
-    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
-    sequentialSendStrategy.send((error, message) => {
-      test.strictEqual(error, null);
-
-      // We should get the message on the second socket as the first one fails.
-      test.strictEqual(message, this.testData[1].testSocket);
-
-      // Send should be invoked only on the first two sockets.
-      for (let j = 0; j < this.testData.length; j++) {
-        if (j < 2) {
-          test.ok(this.testData[j].socketSendStub.calledOnce);
-          test.ok(this.testData[j].socketCloseStub.calledOnce);
-        } else {
-          test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
-          test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
-        }
-      }
-
-      // Since the first socket send fails, we should have two invocations of createSocket.
-      test.strictEqual(this.createSocketStub.callCount, 2);
-
-      test.done();
-    });
-  },
-
-  'send two IPs fail.': function(test) {
-    // Setup first two socket to fail on socket send.
-    this.testData[0].testSocket.sendResult = sendResultError;
-    this.testData[1].testSocket.sendResult = sendResultError;
-
-    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
-    sequentialSendStrategy.send((error, message) => {
-      test.strictEqual(error, null);
-
-      // We should get the message on the third socket as the first two fails.
-      test.strictEqual(message, this.testData[2].testSocket);
-
-      // Send should be invoked only on the first three sockets.
-      for (let j = 0; j < this.testData.length; j++) {
-        if (j < 3) {
-          test.ok(this.testData[j].socketSendStub.calledOnce);
-          test.ok(this.testData[j].socketCloseStub.calledOnce);
-        } else {
-          test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
-          test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
-        }
-      }
-
-      // Since the first two socket sends fail, we should have three invocations of createSocket.
-      test.strictEqual(this.createSocketStub.callCount, 3);
-
-      test.done();
-    });
-  },
-
-  'send all IPs fail.': function(test) {
-    // Setup all sockets to fail on socket send.
-    for (let j = 0; j < this.testData.length; j++) {
-      this.testData[j].testSocket.sendResult = sendResultError;
-    }
-
-    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
-    sequentialSendStrategy.send((error, message) => {
-      // All socket sends fail. We should get an error on the last socket fail.
-      test.strictEqual(error, this.testData[this.testData.length - 1].testSocket);
-
-      test.strictEqual(message, undefined);
-
-      // Send should be invoked on all sockets.
-      for (let j = 0; j < this.testData.length; j++) {
-        test.ok(this.testData[j].socketSendStub.calledOnce);
-        test.ok(this.testData[j].socketCloseStub.calledOnce);
-      }
-
-      test.strictEqual(this.createSocketStub.callCount, this.testData.length);
-
-      test.done();
-    });
-  },
-
-  'send cancel.': function(test) {
-    const sequentialSendStrategy = new SequentialSendStrategy(this.testData, anyPort, anyRequest);
-    sequentialSendStrategy.send((error, message) => {
-      // We should not get a callback as the send got cancelled.
-      test.ok(false, 'Should never get here.');
-    });
-
-    sequentialSendStrategy.cancel();
-
-    // Send should be invoked only on the first socket.
-    for (let j = 0; j < this.testData.length; j++) {
-      if (j === 0) {
-        test.ok(this.testData[j].socketSendStub.calledOnce);
-        test.ok(this.testData[j].socketCloseStub.calledOnce);
-      } else {
-        test.strictEqual(this.testData[j].socketSendStub.callCount, 0);
-        test.strictEqual(this.testData[j].socketCloseStub.callCount, 0);
-      }
-    }
-
-    test.strictEqual(this.createSocketStub.callCount, 1);
-
-    test.done();
+    commonStrategyTestValidation.call(this, test);
   }
 };


### PR DESCRIPTION
comprehensive unit testing.

- Refactored UDP code to send message to SQL server browser into a
  separate class 'Sender' class. Somewhat similar to Connector class.
- Added comprehensive unit tests, stubbing with Sinon.
- Wrapped code in instance-lookup.js in class to make the code more unit
  testable.
- Currently unit tests for instance-lookup are pretty light. Added more
  comprehensive tests.
- This is a squash of several commits from the branch:
	- https://github.com/tvrprasad/tedious/tree/multisubnet-failover-udpv6