### PR TITLE
Added range validation for BigInt data type.

### DIFF
--- a/src/data-type.js
+++ b/src/data-type.js
@@ -604,6 +604,16 @@ const TYPE = module.exports.TYPE = {
       if (value == null) {
         return null;
       }
+      if (isNaN(value)) {
+        return new TypeError('Invalid number.');
+      }
+      if (value < -9007199254740991 || value > 9007199254740991) {
+        // Number.MIN_SAFE_INTEGER = -9007199254740991
+        // Number.MAX_SAFE_INTEGER = 9007199254740991
+        // 9007199254740991 = (2**53) - 1
+        return new TypeError('Value must be between -9007199254740991 and 9007199254740991, inclusive.' +
+          ' For bigger numbers, use VarChar type.');
+      }
       return value;
     }
   },

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -611,6 +611,8 @@ const TYPE = module.exports.TYPE = {
         // Number.MIN_SAFE_INTEGER = -9007199254740991
         // Number.MAX_SAFE_INTEGER = 9007199254740991
         // 9007199254740991 = (2**53) - 1
+        // Can't use Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER directly though
+        // as these constants are not available in node 0.10.
         return new TypeError('Value must be between -9007199254740991 and 9007199254740991, inclusive.' +
           ' For bigger numbers, use VarChar type.');
       }

--- a/test/integration/parameterised-statements-test.coffee
+++ b/test/integration/parameterised-statements-test.coffee
@@ -52,13 +52,13 @@ exports.int = (test) ->
   execSql(test, TYPES.Int, 8)
 
 exports.bigint = (test) ->
-  execSql(test, TYPES.BigInt, 9007199254740992)
+  execSql(test, TYPES.BigInt, 9007199254740991)
 
 exports.bigint1 = (test) ->
   execSql(test, TYPES.BigInt, 1)
 
 exports.bigintsmall = (test) ->
-  execSql(test, TYPES.BigInt, -9007199254740992)
+  execSql(test, TYPES.BigInt, -9007199254740991)
 
 exports.bigintsmall1 = (test) ->
   execSql(test, TYPES.BigInt, -1)
@@ -242,13 +242,13 @@ exports.outputInt = (test) ->
   execSqlOutput(test, TYPES.Int, 3)
 
 exports.outputBigInt = (test) ->
-  execSqlOutput(test, TYPES.BigInt, 9007199254740992)
+  execSqlOutput(test, TYPES.BigInt, 9007199254740991)
 
 exports.outputBigInt1 = (test) ->
   execSqlOutput(test, TYPES.BigInt, 1)
 
 exports.outputBigIntSmall = (test) ->
-  execSqlOutput(test, TYPES.BigInt, -9007199254740992)
+  execSqlOutput(test, TYPES.BigInt, -9007199254740991)
 
 exports.outputBigIntSmall1 = (test) ->
   execSqlOutput(test, TYPES.BigInt, -1)

--- a/test/unit/validations.coffee
+++ b/test/unit/validations.coffee
@@ -67,16 +67,16 @@ exports.BigInt = (test) ->
   value = TYPE.BigInt.validate 2147483647
   test.strictEqual value, 2147483647
 
-  value = TYPE.BigInt.validate Number.MIN_SAFE_INTEGER
+  value = TYPE.BigInt.validate -9007199254740991
   test.strictEqual value, -9007199254740991
 
-  value = TYPE.BigInt.validate Number.MAX_SAFE_INTEGER
+  value = TYPE.BigInt.validate 9007199254740991
   test.strictEqual value, 9007199254740991
 
-  value = TYPE.BigInt.validate Number.MIN_SAFE_INTEGER - 1
+  value = TYPE.BigInt.validate -9007199254740992
   test.ok value instanceof TypeError
   
-  value = TYPE.BigInt.validate Number.MAX_SAFE_INTEGER + 1
+  value = TYPE.BigInt.validate 9007199254740992
   test.ok value instanceof TypeError
 
   test.done()

--- a/test/unit/validations.coffee
+++ b/test/unit/validations.coffee
@@ -67,6 +67,18 @@ exports.BigInt = (test) ->
   value = TYPE.BigInt.validate 2147483647
   test.strictEqual value, 2147483647
 
+  value = TYPE.BigInt.validate Number.MIN_SAFE_INTEGER
+  test.strictEqual value, -9007199254740991
+
+  value = TYPE.BigInt.validate Number.MAX_SAFE_INTEGER
+  test.strictEqual value, 9007199254740991
+
+  value = TYPE.BigInt.validate Number.MIN_SAFE_INTEGER - 1
+  test.ok value instanceof TypeError
+  
+  value = TYPE.BigInt.validate Number.MAX_SAFE_INTEGER + 1
+  test.ok value instanceof TypeError
+
   test.done()
 
 exports.SmallDateTime = (test) ->


### PR DESCRIPTION
This addresses https://github.com/tediousjs/tedious/issues/490 opened by @beautifulcoder

@arthurschreiber This fixes what amounts to data corruption on insertions, which makes it important to fix soon. But this is also a breaking change in terms of behavior. Any thoughts on if should we wait for 2.0 to check this in or get this into the up coming 1.x release?
