### PR TITLE
Connection setup failing silently on TLS error.

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -652,6 +652,11 @@ class Connection extends EventEmitter {
     });
 
     if (preloginPayload.encryptionString === 'ON' || preloginPayload.encryptionString === 'REQ') {
+      if (!this.config.options.encrypt) {
+        this.emit('connect', new ConnectionError("Server requires encryption, set 'encrypt' config option to true."));
+        return this.close();
+      }
+
       return this.dispatchEvent('tls');
     } else {
       return this.dispatchEvent('noTls');


### PR DESCRIPTION
If SQL Server is setup to require encrypted connections, client must
specifiy encrypt: true. When this is not so, there is no error emitted.
Fixed this to emit 'connect' event with error.