### PR TITLE
Round DateTime millisecond to 0,3,7

### DIFF
--- a/src/data-type.js
+++ b/src/data-type.js
@@ -313,7 +313,7 @@ const TYPE = module.exports.TYPE = {
         }
 
         threeHundredthsOfSecond = milliseconds / (3 + (1 / 3));
-        threeHundredthsOfSecond = Math.floor(threeHundredthsOfSecond);
+        threeHundredthsOfSecond = Math.round(threeHundredthsOfSecond);
 
         buffer.writeUInt8(8);
         buffer.writeInt32LE(days);

--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -509,7 +509,7 @@ function readSmallDateTime(parser, useUTC, callback) {
 function readDateTime(parser, useUTC, callback) {
   parser.readInt32LE((days) => {
     parser.readUInt32LE((threeHundredthsOfSecond) => {
-      const milliseconds = threeHundredthsOfSecond * THREE_AND_A_THIRD;
+      const milliseconds = Math.round(threeHundredthsOfSecond * THREE_AND_A_THIRD);
 
       let value;
       if (useUTC) {


### PR DESCRIPTION
Fix #391 #428

When insert millisecond value into datatime column by SQL literal,
values are rounded as follows.
.990->990(297 * 1/300 second)
.991->990
.992->993(298 * 1/300 second)
.993->993
.994->993
.995->997(299 * 1/300 second)
.996->997
.997->997
.998->997
.999->000(300 * 1/300 second)

current code omit  the figures twice(set & get time) as follows
.990->990(297 * 1/300 second)
.991->990
.992->990
.993->990
.994->993(298 * 1/300 second)
.995->993
.996->993
.997->996(299 * 1/300 second)
.998->996
.999->996
