### PR TITLE
Implements Request.pause() / resume()

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -577,7 +577,9 @@ class Connection extends EventEmitter {
         if (this.config.options.rowCollectionOnDone) {
           this.request.rst.push(token.columns);
         }
-        return this.request.emit('row', token.columns);
+        if (!(this.state === this.STATE.SENT_ATTENTION && this.request.paused)) {
+          this.request.emit('row', token.columns);
+        }
       } else {
         this.emit('error', new Error("Received 'row' when no sqlRequest is in progress"));
         return this.close();
@@ -641,6 +643,12 @@ class Connection extends EventEmitter {
       }
     });
 
+    this.tokenStreamParser.on('endOfMessage', () => {      // EOM pseudo token received
+      if (this.state === this.STATE.SENT_CLIENT_REQUEST) {
+        this.dispatchEvent('endOfMessageMarkerReceived');
+      }
+    });
+
     this.tokenStreamParser.on('resetConnection', () => {
       return this.emit('resetConnection');
     });
@@ -648,6 +656,12 @@ class Connection extends EventEmitter {
     this.tokenStreamParser.on('tokenStreamError', (error) => {
       this.emit('error', error);
       return this.close();
+    });
+
+    this.tokenStreamParser.on('drain', () => {
+      // Bridge the release of backpressure from the token stream parser
+      // transform to the packet stream transform.
+      this.messageIo.resume();
     });
   }
 
@@ -973,8 +987,31 @@ class Connection extends EventEmitter {
     }
   }
 
+  // Returns false to apply backpressure.
   sendDataToTokenStreamParser(data) {
     return this.tokenStreamParser.addBuffer(data);
+  }
+
+  // This is an internal method that is called from Request.pause().
+  // It has to check whether the passed Request object represents the currently
+  // active request, because the application might have called Request.pause()
+  // on an old inactive Request object.
+  pauseRequest(request) {
+    if (this.isRequestActive(request)) {
+      this.tokenStreamParser.pause();
+    }
+  }
+
+  // This is an internal method that is called from Request.resume().
+  resumeRequest(request) {
+    if (this.isRequestActive(request)) {
+      this.tokenStreamParser.resume();
+    }
+  }
+
+  // Returns true if the passed request is the currently active request of the connection.
+  isRequestActive(request) {
+    return request === this.request && this.state === this.STATE.SENT_CLIENT_REQUEST;
   }
 
   sendInitialSql() {
@@ -1266,6 +1303,7 @@ class Connection extends EventEmitter {
       }
 
       this.request = request;
+      this.request.connection = this;
       this.request.rowCount = 0;
       this.request.rows = [];
       this.request.rst = [];
@@ -1275,7 +1313,10 @@ class Connection extends EventEmitter {
       this.debug.payload(function() {
         return payload.toString('  ');
       });
-      return this.transitionTo(this.STATE.SENT_CLIENT_REQUEST);
+      this.transitionTo(this.STATE.SENT_CLIENT_REQUEST);
+      if (request.paused) {                                // Request.pause() has been called before the request was started
+        this.pauseRequest(request);
+      }
     }
   }
 
@@ -1563,6 +1604,7 @@ Connection.prototype.STATE = {
     name: 'SentClientRequest',
     exit: function() {
       this.clearRequestTimer();
+      this.tokenStreamParser.resume();
     },
     events: {
       socketError: function(err) {
@@ -1573,9 +1615,20 @@ Connection.prototype.STATE = {
       },
       data: function(data) {
         this.clearRequestTimer();                          // request timer is stopped on first data package
-        return this.sendDataToTokenStreamParser(data);
+        const ret = this.sendDataToTokenStreamParser(data);
+        if (ret === false) {
+          // Bridge backpressure from the token stream parser transform to the
+          // packet stream transform.
+          this.messageIo.pause();
+        }
       },
       message: function() {
+        // We have to channel the 'message' (EOM) event through the token stream
+        // parser transform, to keep it in line with the flow of the tokens, when
+        // the incoming data flow is paused and resumed.
+        return this.tokenStreamParser.addEndOfMessageMarker();
+      },
+      endOfMessageMarkerReceived: function() {
         this.transitionTo(this.STATE.LOGGED_IN);
         const sqlRequest = this.request;
         this.request = undefined;

--- a/src/connection.js
+++ b/src/connection.js
@@ -780,7 +780,7 @@ class Connection extends EventEmitter {
     }
 
     if (this.state && this.state.exit) {
-      this.state.exit.apply(this);
+      this.state.exit.call(this, newState);
     }
 
     this.debug.log('State change: ' + (this.state ? this.state.name : undefined) + ' -> ' + newState.name);
@@ -1602,9 +1602,12 @@ Connection.prototype.STATE = {
   },
   SENT_CLIENT_REQUEST: {
     name: 'SentClientRequest',
-    exit: function() {
+    exit: function(nextState) {
       this.clearRequestTimer();
-      this.tokenStreamParser.resume();
+
+      if (nextState !== this.STATE.FINAL) {
+        this.tokenStreamParser.resume();
+      }
     },
     events: {
       socketError: function(err) {

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -179,4 +179,14 @@ module.exports = class MessageIO extends EventEmitter {
     this.debug.packet(direction, packet);
     return this.debug.data(packet);
   }
+
+  // Temporarily suspends the flow of incoming packets.
+  pause() {
+    this.packetStream.pause();
+  }
+
+  // Resumes the flow of incoming packets.
+  resume() {
+    this.packetStream.resume();
+  }
 };

--- a/src/token/stream-parser.js
+++ b/src/token/stream-parser.js
@@ -24,6 +24,7 @@ module.exports = class Parser extends Transform {
     this.debug = debug;
     this.colMetadata = colMetadata;
     this.options = options;
+    this.endOfMessageMarker = {};
 
     this.buffer = new Buffer(0);
     this.position = 0;
@@ -33,6 +34,13 @@ module.exports = class Parser extends Transform {
   }
 
   _transform(input, encoding, done) {
+    if (input === this.endOfMessageMarker) {
+      done(null, {                                         // generate endOfMessage pseudo token
+        name: 'EOM',
+        event: 'endOfMessage'
+      });
+      return;
+    }
     if (this.position === this.buffer.length) {
       this.buffer = input;
     } else {

--- a/src/token/token-stream-parser.js
+++ b/src/token/token-stream-parser.js
@@ -25,14 +25,36 @@ class Parser extends EventEmitter {
         this.emit(token.event, token);
       }
     });
+    this.parser.on('drain', () => {
+      this.emit('drain');
+    });
   }
 
+  // Returns false to apply backpressure.
   addBuffer(buffer) {
     return this.parser.write(buffer);
   }
 
+  // Writes an end-of-message (EOM) marker into the parser transform input
+  // queue. StreamParser will emit a 'data' event with an 'endOfMessage'
+  // pseudo token when the EOM marker has passed through the transform stream.
+  // Returns false to apply backpressure.
+  addEndOfMessageMarker() {
+    return this.parser.write(this.parser.endOfMessageMarker);
+  }
+
   isEnd() {
     return this.parser.buffer.length === this.parser.position;
+  }
+
+  // Temporarily suspends the token stream parser transform from emitting events.
+  pause() {
+    this.parser.pause();
+  }
+
+  // Resumes the token stream parser transform.
+  resume() {
+    this.parser.resume();
   }
 }
 module.exports.Parser = Parser;

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -1,9 +1,7 @@
-// This module contains tests cases for the Request.pause()/resume() methods.
+const fs = require('fs');
 
 const Connection = require('../../src/connection');
 const Request = require('../../src/request');
-const fs = require('fs');
-const semver = require('semver');
 
 function getConfig() {
   const config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config;
@@ -117,10 +115,8 @@ exports.testLargeQuery = function(test) {
   function verifyStreamStatesAfterPause() {
     const packetSize = connection.messageIo.packetSize();
     const socketRs = connection.socket._readableState;
-    if (semver.gte(process.version, '0.12.18')) {
-      test.ok(!socketRs.flowing,
-        'Socket is not paused.');
-    }
+    test.ok(!socketRs.flowing, 'Socket is not paused.');
+
     const minimalSocketFillTestLevel = 0x2000;             // (heuristic value)
     const highWaterReserve = 512;                          // (heuristic value)
     test.ok(socketRs.length >= Math.min(socketRs.highWaterMark - highWaterReserve, minimalSocketFillTestLevel),

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -52,7 +52,7 @@ exports.tearDown = function(tearDownDone) {
 exports.testLargeQuery = function(test) {
   const debugMode = false;
   const totalRows = 200000;                                // total number of rows to read
-  const delayTime = 500;                                   // pause delay time in ms
+  const delayTime = 1000;                                  // pause delay time in ms
   const connection = this.connection;
   let request;
   let rowsReceived = 0;
@@ -121,7 +121,7 @@ exports.testLargeQuery = function(test) {
       test.ok(!socketRs.flowing,
         'Socket is not paused.');
     }
-    const minimalSocketFillTestLevel = 0x4000;             // (heuristic value)
+    const minimalSocketFillTestLevel = 0x2000;             // (heuristic value)
     const highWaterReserve = 512;                          // (heuristic value)
     test.ok(socketRs.length >= Math.min(socketRs.highWaterMark - highWaterReserve, minimalSocketFillTestLevel),
       'Socket does not feel backpressure.');

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -6,35 +6,19 @@ const Request = require('../../src/request');
 function getConfig() {
   const config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config;
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
-  config.options.requestTimeout = 250;                     // 250 ms timeout until the first response package is received
+  // 250 ms timeout until the first response package is received
+  config.options.requestTimeout = 250;
   return config;
 }
 
-exports.setUp = function(setUpDone) {
-  const connection = new Connection(getConfig());
-  connection.on('connect', (err) => {
-    if (err) {
-      setUpDone(err);
-      return;
-    }
-    this.connection = connection;
-    setUpDone();
-  });
-  connection.on('end', () => {
-    this.connection = undefined;
-  });
+exports.setUp = function(done) {
+  this.connection = new Connection(getConfig());
+  this.connection.on('connect', done);
 };
 
-exports.tearDown = function(tearDownDone) {
-  const connection = this.connection;
-  if (!connection) {
-    tearDownDone();
-    return;
-  }
-  connection.on('end', function() {
-    tearDownDone();
-  });
-  connection.close();
+exports.tearDown = function(done) {
+  this.connection.on('end', done);
+  this.connection.close();
 };
 
 // This test reads a large number of rows from the database.

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -1,0 +1,250 @@
+// This module contains tests cases for the Request.pause()/resume() methods.
+
+'use strict';
+
+const Connection = require('../../src/connection');
+const Request = require('../../src/request');
+const fs = require('fs');
+const semver = require('semver');
+
+function getConfig() {
+  const config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config;
+  config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
+  return config;
+}
+
+exports.setUp = function(setUpDone) {
+  const connection = new Connection(getConfig());
+  connection.on('connect', (err) => {
+    if (err) {
+      setUpDone(err);
+      return;
+    }
+    this.connection = connection;
+    setUpDone();
+  });
+  connection.on('end', () => {
+    this.connection = undefined;
+  });
+};
+
+exports.tearDown = function(tearDownDone) {
+  const connection = this.connection;
+  if (!connection) {
+    tearDownDone();
+    return;
+  }
+  connection.on('end', function() {
+    tearDownDone();
+  });
+  connection.close();
+};
+
+// This test reads a large number of rows from the database.
+// At 1/4 of the rows, Request.pause() is called.
+// After a delay, Request.resume() is called.
+// This test verifies that:
+//  - No 'row' events are received during the pause.
+//  - The socket and the two transforms are stopped during the pause.
+//  - No large amounts of data are accumulated within the transforms during the pause.
+//  - No data is lost.
+exports.testLargeQuery = function(test) {
+  const debugMode = false;
+  const totalRows = 200000;                                // total number of rows to read
+  const delayTime = 500;                                   // pause delay time in ms
+  const connection = this.connection;
+  let request;
+  let rowsReceived = 0;
+  let failed = false;                                      // used to suppress further error messages
+  let paused = false;
+
+  connection.on('error', function(err) {
+    test.ifError(err);
+  });
+  openRequest();
+
+  function openRequest() {
+    const sql =                                            // recursive CTE to generate rows
+      'with cte1 as ' +
+        '(select 1 as i union all select i + 1 from cte1 where i < ' + totalRows + ') ' +
+      'select i from cte1 option (maxrecursion 0)';
+    request = new Request(sql, onRequestCompletion);
+    request.on('row', processRow);
+    connection.execSql(request);
+  }
+
+  function onRequestCompletion(err) {
+    test.ifError(err);
+    test.equal(rowsReceived, totalRows, 'Invalid row count.');
+    test.done();
+  }
+
+  function processRow(columns) {
+    if (paused) {
+      fail('Row received in paused state.');
+    }
+    rowsReceived++;
+    if (columns[0].value !== rowsReceived) {
+      fail('Invalid row counter value, value=' + columns[0].value + ', expected=' + rowsReceived + '.');
+      return;
+    }
+    if (rowsReceived === Math.round(totalRows / 4)) {
+      pause();
+    }
+  }
+
+  function pause() {
+    if (debugMode) {
+      dumpStreamStates(connection);
+      console.log('Start pause.');
+    }
+    paused = true;
+    request.pause();
+    setTimeout(resume, delayTime);
+  }
+
+  function resume() {
+    if (debugMode) {
+      console.log('End pause.');
+      dumpStreamStates(connection);
+    }
+    verifyStreamStatesAfterPause();
+    paused = false;
+    request.resume();
+  }
+
+  function verifyStreamStatesAfterPause() {
+    const packetSize = connection.messageIo.packetSize();
+    const socketRs = connection.socket._readableState;
+    if (semver.gte(process.version, '0.12.18')) {
+      test.ok(!socketRs.flowing,
+        'Socket is not paused.');
+    }
+    const minimalSocketFillTestLevel = 0x4000;             // (heuristic value)
+    const highWaterReserve = 512;                          // (heuristic value)
+    test.ok(socketRs.length >= Math.min(socketRs.highWaterMark - highWaterReserve, minimalSocketFillTestLevel),
+      'Socket does not feel backpressure.');
+    const packetTransformWs = connection.messageIo.packetStream._writableState;
+    const packetTransformRs = connection.messageIo.packetStream._readableState;
+    test.ok(!packetTransformRs.flowing,
+      'Packet transform is not paused.');
+    test.ok(packetTransformWs.length <= packetTransformWs.highWaterMark &&
+      packetTransformRs.length <= packetTransformRs.highWaterMark,
+      'Packet transform has large amount of data buffered.');
+    const tokenTransformWs = connection.tokenStreamParser.parser._writableState;
+    const tokenTransformRs = connection.tokenStreamParser.parser._readableState;
+    test.ok(!tokenTransformRs.flowing,
+      'Token transform is not paused.');
+    test.ok(tokenTransformWs.length <= tokenTransformWs.highWaterMark,
+      'Token transform input buffer overflow.');
+    test.ok(tokenTransformRs.length < packetSize / 3,
+      'Token transform output buffer has large amount of data buffered.');
+  }
+
+  function fail(msg) {
+    if (failed) {
+      return;
+    }
+    failed = true;
+    test.ok(false, msg);
+    connection.close();
+  }
+};
+
+// This test reads only a few rows and makes a short pause after each row.
+// This test verifies that:
+//  - Pause/resume works correctly when applied after the last packet of a TDS
+//    message has already been dispatched by MessageIO.ReadablePacketStream.
+//    This is the case when EOM / packet.isLast() has already been detected
+//    at the time when Request.pause() is called.
+//    The 'message' event emitted by MessageIO has to be channeled through
+//    the token parser transform.
+//  - No more 'row' events are emitted after a paused request has been canceled.
+//  - The internal data flow is resumed after a paused request has been canceled.
+exports.testTransitions = function(test) {
+  const totalRequests = 3;
+  const rowsPerRequest = 4;
+  const delayTime = 100;                                   // pause delay time in ms
+  const requestToCancel = 2;                               // 1-based position of request to be canceled
+  const rowToCancel = 2;                                   // 1-based position of row at which connection.cancel() will be called
+  const connection = this.connection;
+  let request;
+  let requestCount = 0;
+  let rowCount;
+  let paused = false;
+  let canceled = false;
+
+  connection.on('error', function(err) {
+    test.ifError(err);
+  });
+  openRequest();
+
+  function openRequest() {
+    let sql = 'select 1';
+    for (let i = 2; i <= rowsPerRequest; i++) {
+      sql = sql + ' union all select ' + i;
+    }
+    request = new Request(sql, onRequestCompletion);
+    request.on('row', processRow);
+    rowCount = 0;
+    paused = false;
+    canceled = false;
+    connection.execSql(request);
+  }
+
+  function onRequestCompletion(err) {
+    requestCount++;
+    if (requestCount === requestToCancel) {
+      test.ok(err && err.code === 'ECANCEL');
+      test.equal(rowCount, rowToCancel);
+    } else {
+      test.ifError(err);
+      test.equal(rowCount, rowsPerRequest);
+    }
+    if (requestCount < totalRequests) {
+      openRequest();
+    } else {
+      test.done();
+    }
+  }
+
+  function processRow(columns) {
+    test.ok(!canceled, 'Row received in canceled state, requestCount=' + requestCount + ' rowCount=' + rowCount);
+    test.ok(!paused, 'Row received in paused state, requestCount=' + requestCount + ' rowCount=' + rowCount);
+    rowCount++;
+    test.equal(columns[0].value, rowCount);
+    paused = true;
+    request.pause();
+    setTimeout(afterDelay, delayTime);
+  }
+
+  function afterDelay() {
+    if (requestCount === requestToCancel - 1 && rowCount === rowToCancel) {
+      canceled = true;
+      connection.cancel();
+    } else {
+      paused = false;
+      request.resume();
+    }
+  }
+};
+
+function dumpStreamStates(connection) {
+  dumpStreamState('Socket', connection.socket);
+  dumpStreamState('Packet transform', connection.messageIo.packetStream);
+  dumpStreamState('Token transform', connection.tokenStreamParser.parser);
+}
+
+function dumpStreamState(name, stream) {
+  console.log();
+  console.log(name + ' state:');
+  const ws = stream._writableState;
+  console.log(' ws.length: ' + ws.length);
+  console.log(' ws.bufferedRequestCount: ' + ws.bufferedRequestCount);
+  console.log(' ws.highWaterMark: ' + ws.highWaterMark);
+  const rs = stream._readableState;
+  console.log(' rs.length: ' + rs.length);
+  console.log(' rs.buffer.length: ' + rs.buffer.length);
+  console.log(' rs.highWaterMark: ' + rs.highWaterMark);
+  console.log(' rs.flowing: ' + rs.flowing);
+}

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -21,6 +21,26 @@ exports.tearDown = function(done) {
   this.connection.close();
 };
 
+function dumpStreamStates(connection) {
+  dumpStreamState('Socket', connection.socket);
+  dumpStreamState('Packet transform', connection.messageIo.packetStream);
+  dumpStreamState('Token transform', connection.tokenStreamParser.parser);
+}
+
+function dumpStreamState(name, stream) {
+  console.log();
+  console.log(name + ' state:');
+  const ws = stream._writableState;
+  console.log(' ws.length: ' + ws.length);
+  console.log(' ws.bufferedRequestCount: ' + ws.bufferedRequestCount);
+  console.log(' ws.highWaterMark: ' + ws.highWaterMark);
+  const rs = stream._readableState;
+  console.log(' rs.length: ' + rs.length);
+  console.log(' rs.buffer.length: ' + rs.buffer.length);
+  console.log(' rs.highWaterMark: ' + rs.highWaterMark);
+  console.log(' rs.flowing: ' + rs.flowing);
+}
+
 // This test reads a large number of rows from the database.
 // At 1/4 of the rows, Request.pause() is called.
 // After a delay, Request.resume() is called.
@@ -197,23 +217,3 @@ exports.testImmediatelyPausedRequestDoesNotEmitRowsUntilResumed = function(test)
     request.resume();
   }, 100);
 };
-
-function dumpStreamStates(connection) {
-  dumpStreamState('Socket', connection.socket);
-  dumpStreamState('Packet transform', connection.messageIo.packetStream);
-  dumpStreamState('Token transform', connection.tokenStreamParser.parser);
-}
-
-function dumpStreamState(name, stream) {
-  console.log();
-  console.log(name + ' state:');
-  const ws = stream._writableState;
-  console.log(' ws.length: ' + ws.length);
-  console.log(' ws.bufferedRequestCount: ' + ws.bufferedRequestCount);
-  console.log(' ws.highWaterMark: ' + ws.highWaterMark);
-  const rs = stream._readableState;
-  console.log(' rs.length: ' + rs.length);
-  console.log(' rs.buffer.length: ' + rs.buffer.length);
-  console.log(' rs.highWaterMark: ' + rs.highWaterMark);
-  console.log(' rs.flowing: ' + rs.flowing);
-}

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -43,7 +43,7 @@ exports.testPausedRequestDoesNotEmitRowsAfterConnectionClose = function(test) {
       setTimeout(() => {
         this.connection.on('end', () => {
           process.nextTick(() => {
-            test.done()
+            test.done();
           });
         });
         this.connection.close();

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -1,7 +1,5 @@
 // This module contains tests cases for the Request.pause()/resume() methods.
 
-'use strict';
-
 const Connection = require('../../src/connection');
 const Request = require('../../src/request');
 const fs = require('fs');

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -47,7 +47,7 @@ exports.testPausedRequestDoesNotEmitRowsAfterConnectionClose = function(test) {
           });
         });
         this.connection.close();
-      }, 100);
+      }, 200);
     }
   });
 
@@ -86,7 +86,7 @@ exports.testPausedRequestCanBeResumed = function(test) {
       setTimeout(() => {
         paused = false;
         request.resume();
-      }, 100);
+      }, 200);
     }
   });
 
@@ -115,7 +115,7 @@ exports.testPausingRequestPausesTransforms = function(test) {
         test.ok(this.connection.tokenStreamParser.parser.isPaused());
 
         request.resume();
-      }, 100);
+      }, 200);
     }
   });
 
@@ -147,7 +147,7 @@ exports.testPausedRequestCanBeCancelled = function(test) {
 
         setTimeout(() => {
           this.connection.cancel();
-        }, 100);
+        }, 200);
       } else if (columns[0].value > 1000) {
         test.ok(false, 'Received rows after pause');
       }
@@ -194,5 +194,5 @@ exports.testImmediatelyPausedRequestDoesNotEmitRowsUntilResumed = function(test)
   setTimeout(() => {
     paused = false;
     request.resume();
-  }, 100);
+  }, 200);
 };


### PR DESCRIPTION
This pull request adds the two methods Request.pause() and Request.resume() to the public Tedious API. They can be used to pause and resume the flow of data rows from a query result. A test case is included.

See #181 for the reasons why this extension is important.