### PR TITLE
Fixed a bug in datefirst validation.

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -130,7 +130,7 @@ class Connection extends EventEmitter {
       }
 
       if (config.options.datefirst) {
-        if (config.options.datefirst < 1 || config.options.port > 7) {
+        if (config.options.datefirst < 1 || config.options.datefirst > 7) {
           throw new RangeError('DateFirst should be >= 1 and <= 7');
         }
 


### PR DESCRIPTION
This creeped in PR https://github.com/tediousjs/tedious/pull/503.
Curiously enough the unit tests added as part of the CL caught the bug
when I ran tests on my machine whereas they succeeded on AppVeyor. The
difference is that I happened to have a 'port' config value set in my
local setup whereas AppVeyor did not. Just a freak coincidence that this
would trigger the bug.