### PR TITLE
add missing this.clearRequestTimer() to Connection.cancel()

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1001,6 +1001,7 @@ class Connection extends EventEmitter {
       this.debug.log(message);
       return false;
     } else {
+      this.clearRequestTimer();
       this.request.canceled = true;
       this.messageIo.sendMessage(TYPE.ATTENTION);
       this.transitionTo(this.STATE.SENT_ATTENTION);


### PR DESCRIPTION
Without calling clearRequestTimer() in Connection.cancel(), the old timer remains active when a request is canceled. Even after a new request is started and createRequestTimer() is called again, the old timer still remains active.