### PR TITLE
Connection error to use port or instance name

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -549,7 +549,14 @@ class Connection extends EventEmitter {
   }
 
   connectTimeout() {
-    const message = 'Failed to connect to ' + this.config.server + ':' + this.config.options.port + ' in ' + this.config.options.connectTimeout + 'ms';
+    let tail = '';
+    if(!!this.config.options.instanceName) {
+      tail = '\\' + this.config.options.instanceName;
+    }
+    if(!!this.config.options.port) {
+      tail = ':' + this.config.options.port;
+    }
+    const message = 'Failed to connect to ' + this.config.server + tail + ' in ' + this.config.options.connectTimeout + 'ms';
     this.debug.log(message);
     this.emit('connect', ConnectionError(message, 'ETIMEOUT'));
     this.connectTimer = undefined;

--- a/src/connection.js
+++ b/src/connection.js
@@ -550,10 +550,10 @@ class Connection extends EventEmitter {
 
   connectTimeout() {
     let tail = '';
-    if(!!this.config.options.instanceName) {
+    if (this.config.options.instanceName) {
       tail = '\\' + this.config.options.instanceName;
     }
-    if(!!this.config.options.port) {
+    if (this.config.options.port) {
       tail = ':' + this.config.options.port;
     }
     const message = 'Failed to connect to ' + this.config.server + tail + ' in ' + this.config.options.connectTimeout + 'ms';


### PR DESCRIPTION
Related to and fixes one of two issues raised by #373
Current connection error shows port as undefined wasting time debugging an issue that doesn't exist if the user instead defined instance name. This will show the instanceName if it is defined and there is no port defined.