### PR TITLE
Drop support for unsupported Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ sudo: false
 before_install:
   - npm install -g npm
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
   - "6"
   - "7"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,7 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
-    - nodejs_version: "5"
     - nodejs_version: "6"
     - nodejs_version: "7"
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/tediousjs/tedious.git"
   },
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 4"
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",


### PR DESCRIPTION
As discussed in https://github.com/tediousjs/tedious/issues/495, this removes support for unsupported Node.js versions and removes them from our CI builds. It also updates our `package.json` to highlight the fact we support Node.js 4+ only.

Fixes https://github.com/tediousjs/tedious/issues/495 and https://github.com/tediousjs/tedious/pull/496.