### PR TITLE
chore: Remove auto-release configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,6 @@ node_js:
   - "6"
   - "7"
 
-branches:
-  only:
-    - master
-    - /^maint\/.+/
-    - /v\d+\.\d+\.\d+/
-
 cache:
   directories:
     - node_modules
-
-deploy:
-  provider: npm
-  skip_cleanup: true
-  email: "schreiber.arthur@googlemail.com"
-  api_key:
-    secure: pSwLyKvYC3sxv0qxvbZy2W4ENXeE7/7emnnFJ8BMEYBTel/g+An0fN9lbtZSPoOaCEUVWEa2DzCHvU0jZ+qiOB1iZ+Swav9Ka0aOW54mtiig7oQY3GZpNvMkBhMPmkyIloECjFKNpxnZyi/ZHUjJLhu04o36xcAWASowfs3Mdwg=
-  on:
-    tags: true
-    repo: tediousjs/tedious
-    node: "0.10"


### PR DESCRIPTION
This removes the auto-release configuration I had put in place a while ago. I plan to re-introduce this using `semantic-release` in the future, but let's just remove this for now.