### PR TITLE
Always transpile all code when running unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint": "^2.13.1",
     "mitm": "^1.3.2",
     "nodeunit": "^0.9.1",
-    "semver": "^5.1.0",
     "sinon": "^1.17.5"
   },
   "scripts": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,4 @@
 'use strict';
 
-if (require('semver').lt(process.version, '4.0.0')) {
-  require('babel-register');
-}
-
+require('babel-register');
 require('coffee-script/register');


### PR DESCRIPTION
When we initially migrated back to ES6+, I added a check here to make sure that no future JavaScript syntax was being used that was not also supported by the current Node LTS (4.x at the time).

After having this around for some while, I no longer believe this is worth the trouble. We should just support all the syntax that was standardized and is supported by transpilation via babel. This should also be less confusing to people who contribute code to `tedious`.

/cc @tvrprasad 