### PR TITLE
Drop dependency on `dns-lookup-all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "babel-runtime": "^6.23.0",
     "big-number": "0.3.1",
     "bl": "^1.0.0",
-    "dns-lookup-all": "^1.0.2",
     "iconv-lite": "^0.4.11",
     "readable-stream": "^2.0.2",
     "sprintf": "0.1.5"

--- a/src/connector.js
+++ b/src/connector.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const net = require('net');
-const lookupAll = require('dns-lookup-all');
+const dns = require('dns');
 
 class Connector {
   constructor(options, multiSubnetFailover) {
@@ -41,7 +41,7 @@ class Connector {
   }
 
   executeForHostname(cb) {
-    lookupAll(this.options.host, (err, addresses) => {
+    dns.lookup(this.options.host, { all: true }, (err, addresses) => {
       if (err) {
         return cb(err);
       }

--- a/src/sender.js
+++ b/src/sender.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dgram = require('dgram');
-const lookupAll = require('dns-lookup-all');
+const dns = require('dns');
 const net = require('net');
 
 class Sender {
@@ -27,7 +27,7 @@ class Sender {
 
   // Wrapper for stubbing. Sinon does not have support for stubbing module functions.
   invokeLookupAll(host, cb) {
-    lookupAll(host, cb);
+    dns.lookup(host, { all: true }, cb);
   }
 
   executeForHostname(cb) {


### PR DESCRIPTION
We used `dns-lookup-all` to support older Node.js versions that lacked support for the `all` option of `dns.lookup`. Now that we dropped support for older Node.js versions, we can also stop using `dns-lookup-all`.