### PR TITLE
Switch to `babel-preset-env`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "babel-cli": "^6.24.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.2.2",
-    "babel-preset-es2016-node4": "^6.0.1",
     "babel-register": "^6.24.0",
     "benchmark": "^2.1.0",
     "coffee-script": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "async": "^1.4.0",
     "babel-cli": "^6.24.0",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.2.2",
     "babel-preset-es2016-node4": "^6.0.1",
     "babel-register": "^6.24.0",
     "benchmark": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "babel": {
     "presets": [
-      "es2016-node4"
+      ["env", { "targets": { "node": 4 } }]
     ],
     "plugins": [
       "transform-runtime"


### PR DESCRIPTION
`babel-preset-env` is a relatively new babel preset that can automatically determine which language features need to be transpiled based on the targets environments that are specified in the configuration. In our case, the target is currently Node.JS 4 (until that version goes out of support).