### PR TITLE
Automatic releases via `semantic-release`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
   - "6"
   - "7"
 
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/
+
 services:
   - docker
 
@@ -32,6 +36,9 @@ before_install:
       }
     }' > ~/.tedious/test-connection.json
 
+before_script:
+  - npm prune
+
 script:
   - npm run test
   - TEDIOUS_TDS_VERSION=7_4   npm run test-integration
@@ -39,3 +46,6 @@ script:
   - TEDIOUS_TDS_VERSION=7_3_A npm run test-integration
   - TEDIOUS_TDS_VERSION=7_2   npm run test-integration
   - TEDIOUS_TDS_VERSION=7_1   npm run test-integration
+
+after_success:
+  - npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/tediousjs/tedious",
   "bugs": "https://github.com/tediousjs/tedious/issues",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "0.0.0-dev",
   "main": "./lib/tedious.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "^3.18.0",
     "mitm": "^1.3.2",
     "nodeunit": "^0.11.0",
+    "semantic-release": "^6.3.2",
     "sinon": "^1.17.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "test-all": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
     "pretest-integration": "eslint src test",
     "test-integration": "nodeunit --reporter minimal test/setup.js test/integration/",
-    "prepublish": "coffee scripts/build.coffee"
+    "prepublish": "coffee scripts/build.coffee",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   "engines": {
     "node": ">= 4"
   },
+  "publishConfig": {
+    "tag": "next"
+  },
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "big-number": "0.3.1",


### PR DESCRIPTION
Now that we run the full integration test suite across all supported Node.JS versions on travis (#564), we can use `semantic-release` to automatically publish new versions of `tedious` after each merge to `master`.


