### PR TITLE
Fix coffee script stack traces in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "eslint": "^3.18.0",
     "mitm": "^1.3.2",
     "nodeunit": "^0.11.0",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "source-map-support": "^0.4.14"
   },
   "scripts": {
     "pretest": "eslint src test",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,2 +1,3 @@
-require('babel-register');
 require('coffee-script/register');
+require('babel-register');
+require('source-map-support').install({ handleUncaughtExceptions: false, hookRequire: true });


### PR DESCRIPTION
While looking through the travis errors of #566 at https://travis-ci.org/tediousjs/tedious/jobs/220815074, I noticed that the stack traces for Coffee Script code are all messed up.

After some fiddling around, I figured out that this is because both `coffee-script/register` as well as `babel-register` (via `source-map-support`) install a custom `Error.prepareStackTrace` function, and the former gets overwritten by the latter.

Fortunately, `coffee-script/register` generates inline source maps in the transpilation result, and `source-map-support` has optional support for these source maps, but it's not enabled in `babel-register`. But enabling it is easy, so we can make sure stack traces look good for code transpiled through `coffee-script` as well as `babel`. 👍 