### PR TITLE
chore: Run `semantic-release` in separate build stage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
 stages:
   - test
   - name: release
-    if: branch = master
+    if: (branch = master) AND (type = push)
 
 services:
   - docker
@@ -52,7 +52,6 @@ script:
 jobs:
   include:
     - stage: release
-      if: branch = master
       node_js: 4
       before_install: skip
       before_script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,6 @@ jobs:
   include:
     - stage: release
       node_js: 7
+      before_install: skip
+      before_script: skip
       script: npm run semantic-release || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ jobs:
       node_js: 4
       before_install: skip
       before_script: skip
-      script: npm run semantic-release || true
+      script: npm run semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ node_js:
   - "7"
   - "8"
 
-branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/
+stages:
+  - test
+  - name: release
+    if: branch = master
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ jobs:
   include:
     - stage: release
       node_js: 7
-      script: npm run semantic-release
+      script: npm run semantic-release || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,8 @@ script:
   - TEDIOUS_TDS_VERSION=7_2   npm run test-integration
   - TEDIOUS_TDS_VERSION=7_1   npm run test-integration
 
-after_success:
-  - npm run semantic-release
+jobs:
+  include:
+    - stage: release
+      node_js: 7
+      script: npm run semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ node_js:
   - "7"
   - "8"
 
+stages:
+  - test
+  - name: release
+    if: branch = master
+
 services:
   - docker
 
@@ -46,8 +51,7 @@ script:
 
 jobs:
   include:
-    - if: branch = master
-      stage: release
+    - stage: release
       node_js: 4
       before_install: skip
       before_script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
 jobs:
   include:
     - stage: release
+      if: branch = master
       node_js: 4
       before_install: skip
       before_script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 jobs:
   include:
     - stage: release
-      node_js: 7
+      node_js: 4
       before_install: skip
       before_script: skip
       script: npm run semantic-release || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ node_js:
   - "7"
   - "8"
 
-stages:
-  - test
-  - name: release
-    if: branch = master
-
 services:
   - docker
 
@@ -51,7 +46,8 @@ script:
 
 jobs:
   include:
-    - stage: release
+    - if: branch = master
+      stage: release
       node_js: 4
       before_install: skip
       before_script: skip


### PR DESCRIPTION
This switches us to run `npm run semantic-release` in a separate build stage on Travis CI.

More information about build stages can be found here: https://docs.travis-ci.com/user/build-stages/