### PR TITLE
chore: Only run `eslint` once.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
   - TEDIOUS_TDS_VERSION=7_3_A npm run test-integration
   - TEDIOUS_TDS_VERSION=7_2   npm run test-integration
   - TEDIOUS_TDS_VERSION=7_1   npm run test-integration
+  - npm run lint
 
 after_success:
   - npm run semantic-release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,4 +54,6 @@ test_script:
       SET TEDIOUS_TDS_VERSION=7_1
       npm run-script test-integration || SET EXITVAL=1
 
+      npm run-script lint
+
       EXIT /B %EXITVAL%

--- a/package.json
+++ b/package.json
@@ -66,9 +66,7 @@
   "scripts": {
     "pretest": "eslint src test",
     "test": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer",
-    "pretest-all": "eslint src test",
     "test-all": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
-    "pretest-integration": "eslint src test",
     "test-integration": "nodeunit --reporter minimal test/setup.js test/integration/",
     "build": "rimraf lib && babel src --out-dir lib",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "source-map-support": "^0.4.14"
   },
   "scripts": {
-    "pretest": "eslint src test",
+    "lint": "eslint src test",
     "test": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer",
-    "test-all": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
     "test-integration": "nodeunit --reporter minimal test/setup.js test/integration/",
+    "test-all": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
     "build": "rimraf lib && babel src --out-dir lib",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
Instead of running `eslint` before `test`, `test-integration` and
`test-all` scripts, we only run it before `test`.