### PR TITLE
chore: Run travis builds against Node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "4"
   - "6"
   - "7"
+  - "8"
 
 branches:
   except:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "7"
+    - nodejs_version: "8"
 
 branches:
   only:


### PR DESCRIPTION
Node 8 was released, so we probably should start running our CI builds against it.