### PR TITLE
nanasecondDelta rounded sometimes incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-register": "^6.24.0",
     "benchmark": "^2.1.0",
     "eslint": "^3.19.0",
+    "eslint-plugin-react": "^7.1.0",
     "mitm": "^1.3.2",
     "nodeunit": "^0.11.0",
     "rimraf": "^2.6.1",

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1286,7 +1286,8 @@ const TYPE = module.exports.TYPE = {
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        time = (time / 1000 + ((ref = parameter.value.nanosecondDelta) != null ? ref : 0)) * Math.pow(10, parameter.scale);
+        ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
+        time = ( time + ( ref * 1000 ) ) * Math.pow( 10, parameter.scale - 3 )
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1416,7 +1417,8 @@ const TYPE = module.exports.TYPE = {
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        time = (time / 1000 + ((ref = parameter.value.nanosecondDelta) != null ? ref : 0)) * Math.pow(10, parameter.scale);
+        ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
+        time = ( time + ( ref * 1000 ) ) * Math.pow( 10, parameter.scale - 3 )
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1503,7 +1505,8 @@ const TYPE = module.exports.TYPE = {
         time.setUTCFullYear(1970);
         time.setUTCMonth(0);
         time.setUTCDate(1);
-        time = (+time / 1000 + ((ref = parameter.value.nanosecondDelta) != null ? ref : 0)) * Math.pow(10, parameter.scale);
+        ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
+        time = ( time + ( ref * 1000 ) ) * Math.pow( 10, parameter.scale - 3 )
         const offset = -parameter.value.getTimezoneOffset();
         switch (parameter.scale) {
           case 0:

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1506,7 +1506,7 @@ const TYPE = module.exports.TYPE = {
         time.setUTCFullYear(1970);
         time.setUTCMonth(0);
         time.setUTCDate(1);
-        time = (time+(ref*1000))* Math.pow(10, parameter.scale - 3);
+        time = (time + (ref * 1000)) * Math.pow(10, parameter.scale - 3);
         const offset = -parameter.value.getTimezoneOffset();
         switch (parameter.scale) {
           case 0:

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1281,13 +1281,24 @@ const TYPE = module.exports.TYPE = {
     writeParameterData: function(buffer, parameter, options) {
       if (parameter.value != null) {
         const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
-        let time = new Date(+parameter.value);
+        let time = new Date(+parameter.value),
+            scale = parameter.scale - 3;
         if (options.useUTC) {
           time = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        time = (time + (ref * 1000)) * Math.pow(10, parameter.scale - 3);
+        time = (time + (ref * 1000));
+        while (scale > 0)
+        {
+            time = time * 10;
+            scale--;
+        }
+        while (scale < 0)
+        {
+            time = time / 10;
+            scale++;
+        }
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1412,13 +1423,24 @@ const TYPE = module.exports.TYPE = {
     writeParameterData: function(buffer, parameter, options) {
       if (parameter.value != null) {
         const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
-        let time = new Date(+parameter.value);
+        let time = new Date(+parameter.value),
+            scale = parameter.scale - 3;
         if (options.useUTC) {
           time = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        time = (time + (ref * 1000)) * Math.pow(10, parameter.scale - 3);
+        time = (time + (ref * 1000));
+        while (scale > 0)
+        {
+            time = time * 10;
+            scale--;
+        }
+        while (scale < 0)
+        {
+            time = time / 10;
+            scale++;
+        }
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1502,11 +1524,22 @@ const TYPE = module.exports.TYPE = {
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
-        let time = new Date(+parameter.value);
+        let time = new Date(+parameter.value),
+            scale = parameter.scale - 3;
         time.setUTCFullYear(1970);
         time.setUTCMonth(0);
         time.setUTCDate(1);
-        time = (time + (ref * 1000)) * Math.pow(10, parameter.scale - 3);
+        time = (time + (ref * 1000));
+        while (scale > 0)
+        {
+            time = time * 10;
+            scale--;
+        }
+        while (scale < 0)
+        {
+            time = time / 10;
+            scale++;
+        }
         const offset = -parameter.value.getTimezoneOffset();
         switch (parameter.scale) {
           case 0:

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1280,14 +1280,14 @@ const TYPE = module.exports.TYPE = {
 
     writeParameterData: function(buffer, parameter, options) {
       if (parameter.value != null) {
-        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;;
+        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
         let time = new Date(+parameter.value);
         if (options.useUTC) {
           time = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        time = (time+(ref*1000))* Math.pow( 10, parameter.scale - 3 );
+        time = (time + (ref * 1000)) * Math.pow(10, parameter.scale - 3);
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1418,7 +1418,7 @@ const TYPE = module.exports.TYPE = {
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        time = (time+(ref*1000))* Math.pow( 10, parameter.scale - 3 );
+        time = (time + (ref * 1000)) * Math.pow(10, parameter.scale - 3);
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1501,12 +1501,12 @@ const TYPE = module.exports.TYPE = {
     },
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
-        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;;
+        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
         let time = new Date(+parameter.value);
         time.setUTCFullYear(1970);
         time.setUTCMonth(0);
         time.setUTCDate(1);
-        time = (time+(ref*1000))* Math.pow( 10, parameter.scale - 3 );
+        time = (time+(ref*1000))* Math.pow(10, parameter.scale - 3);
         const offset = -parameter.value.getTimezoneOffset();
         switch (parameter.scale) {
           case 0:

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1280,14 +1280,14 @@ const TYPE = module.exports.TYPE = {
 
     writeParameterData: function(buffer, parameter, options) {
       if (parameter.value != null) {
-        let ref, time = new Date(+parameter.value);
+        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;;
+        let time = new Date(+parameter.value);
         if (options.useUTC) {
           time = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
-        time = ( time + ( ref * 1000 ) ) * Math.pow( 10, parameter.scale - 3 )
+        time = (time+(ref*1000))* Math.pow( 10, parameter.scale - 3 );
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1411,14 +1411,14 @@ const TYPE = module.exports.TYPE = {
 
     writeParameterData: function(buffer, parameter, options) {
       if (parameter.value != null) {
-        let ref, time = new Date(+parameter.value);
+        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
+        let time = new Date(+parameter.value);
         if (options.useUTC) {
           time = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
         } else {
           time = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
         }
-        ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
-        time = ( time + ( ref * 1000 ) ) * Math.pow( 10, parameter.scale - 3 )
+        time = (time+(ref*1000))* Math.pow( 10, parameter.scale - 3 );
         switch (parameter.scale) {
           case 0:
           case 1:
@@ -1501,12 +1501,12 @@ const TYPE = module.exports.TYPE = {
     },
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
-        let ref, time = new Date(+parameter.value);
+        const ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;;
+        let time = new Date(+parameter.value);
         time.setUTCFullYear(1970);
         time.setUTCMonth(0);
         time.setUTCDate(1);
-        ref = parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0;
-        time = ( time + ( ref * 1000 ) ) * Math.pow( 10, parameter.scale - 3 )
+        time = (time+(ref*1000))* Math.pow( 10, parameter.scale - 3 );
         const offset = -parameter.value.getTimezoneOffset();
         switch (parameter.scale) {
           case 0:


### PR DESCRIPTION
NanasecondDelta rounded sometimes incorrect, for example with this date/time: ‘2017-06-29 17:20:03.5036264’. This was caused by an addition with more than 6 decimal digits, which is not exact in JS. Fixed by executing the addition first and then the division.