### PR TITLE
If encrypt not specified, escalate if required by default

### DIFF
--- a/examples/minimal.js
+++ b/examples/minimal.js
@@ -14,8 +14,7 @@ var config = {
       token: false,
       log: true
     },
-    database: 'DBName',
-    encrypt: true // for Azure users
+    database: 'DBName'
   }
   */
 };

--- a/src/connection.js
+++ b/src/connection.js
@@ -69,7 +69,7 @@ class Connection extends EventEmitter {
         },
         enableArithAbort: false,
         enableAnsiNullDefault: true,
-        encrypt: false,
+        encrypt: undefined,
         fallbackToDefaultDb: false,
         instanceName: undefined,
         isolationLevel: ISOLATION_LEVEL.READ_COMMITTED,
@@ -715,7 +715,9 @@ class Connection extends EventEmitter {
   socketClose() {
     this.debug.log('connection to ' + this.config.server + ':' + this.config.options.port + ' closed');
     if (this.state === this.STATE.REROUTING) {
-      this.debug.log('Rerouting to ' + this.routingData.server + ':' + this.routingData.port);
+      if (typeof this.routingData !== 'undefined') {
+        this.debug.log('Rerouting to ' + this.routingData.server + ':' + this.routingData.port);
+      }
       return this.dispatchEvent('reconnect');
     } else if (this.state === this.STATE.TRANSIENT_FAILURE_RETRY) {
       const server = this.routingData ? this.routingData.server : this.server;
@@ -753,12 +755,15 @@ class Connection extends EventEmitter {
     });
 
     if (preloginPayload.encryptionString === 'ON' || preloginPayload.encryptionString === 'REQ') {
-      if (!this.config.options.encrypt) {
+      if (this.config.options.encrypt === false) {
         this.emit('connect', ConnectionError("Server requires encryption, set 'encrypt' config option to true.", 'EENCRYPT'));
         return this.close();
+      } else if (typeof this.config.options.encrypt === 'undefined') {
+        this.config.options.encrypt = true;
+        return this.transitionTo(this.STATE.REROUTING);
+      } else {
+        return this.dispatchEvent('tls');
       }
-
-      return this.dispatchEvent('tls');
     } else {
       return this.dispatchEvent('noTls');
     }


### PR DESCRIPTION
Changes the behaviour of the pre-login to automatically try again if the server requires
encryption to be enabled but the user hasn't configured the client in that way.

Still allows for the user to explicitly state that they do not ever want to use
encryption by specifying the value as false.  Or to always use and require encryption by setting the value as true.

This commit partially undoes the work done in ceaa8dc15994fe600b01c5e0d84949f3be0984a0 and is a  change in the behaviour, but brings this driver more inline with other TDS drivers such as jTDS.