### PR TITLE
feat: Introduce pluggable authentication providers.

### DIFF
--- a/src/auth/default.js
+++ b/src/auth/default.js
@@ -1,0 +1,11 @@
+const EMPTY_BUFFER = new Buffer(0);
+
+class DefaultAuthProvider {
+  constructor(connection) {}
+
+  handshake(data, callback) {
+    callback(null, EMPTY_BUFFER);
+  }
+}
+
+module.exports = DefaultAuthProvider;

--- a/src/auth/ntlm.js
+++ b/src/auth/ntlm.js
@@ -1,0 +1,271 @@
+const WritableTrackingBuffer = require('./tracking-buffer/writable-tracking-buffer');
+const crypto = require('crypto');
+const BigInteger = require('big-number').n;
+
+const hex = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
+
+const NTLMFlags = {
+  NTLM_NegotiateUnicode: 0x00000001,
+  NTLM_NegotiateOEM: 0x00000002,
+  NTLM_RequestTarget: 0x00000004,
+  NTLM_Unknown9: 0x00000008,
+  NTLM_NegotiateSign: 0x00000010,
+  NTLM_NegotiateSeal: 0x00000020,
+  NTLM_NegotiateDatagram: 0x00000040,
+  NTLM_NegotiateLanManagerKey: 0x00000080,
+  NTLM_Unknown8: 0x00000100,
+  NTLM_NegotiateNTLM: 0x00000200,
+  NTLM_NegotiateNTOnly: 0x00000400,
+  NTLM_Anonymous: 0x00000800,
+  NTLM_NegotiateOemDomainSupplied: 0x00001000,
+  NTLM_NegotiateOemWorkstationSupplied: 0x00002000,
+  NTLM_Unknown6: 0x00004000,
+  NTLM_NegotiateAlwaysSign: 0x00008000,
+  NTLM_TargetTypeDomain: 0x00010000,
+  NTLM_TargetTypeServer: 0x00020000,
+  NTLM_TargetTypeShare: 0x00040000,
+  NTLM_NegotiateExtendedSecurity: 0x00080000,
+  NTLM_NegotiateIdentify: 0x00100000,
+  NTLM_Unknown5: 0x00200000,
+  NTLM_RequestNonNTSessionKey: 0x00400000,
+  NTLM_NegotiateTargetInfo: 0x00800000,
+  NTLM_Unknown4: 0x01000000,
+  NTLM_NegotiateVersion: 0x02000000,
+  NTLM_Unknown3: 0x04000000,
+  NTLM_Unknown2: 0x08000000,
+  NTLM_Unknown1: 0x10000000,
+  NTLM_Negotiate128: 0x20000000,
+  NTLM_NegotiateKeyExchange: 0x40000000,
+  NTLM_Negotiate56: 0x80000000
+};
+
+class NTLMResponsePayload {
+  constructor(loginData) {
+    this.data = this.createResponse(loginData);
+  }
+
+  toString(indent) {
+    indent || (indent = '');
+    return indent + 'NTLM Auth';
+  }
+
+  createResponse(challenge) {
+    const client_nonce = this.createClientNonce();
+    const lmv2len = 24;
+    const ntlmv2len = 16;
+    const domain = challenge.domain;
+    const username = challenge.userName;
+    const password = challenge.password;
+    let ntlmData = challenge.ntlmpacket;
+    const server_data = ntlmData.target;
+    const server_nonce = ntlmData.nonce;
+    const bufferLength = 64 + (domain.length * 2) + (username.length * 2) + lmv2len + ntlmv2len + 8 + 8 + 8 + 4 + server_data.length + 4;
+    const data = new WritableTrackingBuffer(bufferLength);
+    data.position = 0;
+    data.writeString('NTLMSSP\u0000', 'utf8');
+    data.writeUInt32LE(0x03);
+    const baseIdx = 64;
+    const dnIdx = baseIdx;
+    const unIdx = dnIdx + domain.length * 2;
+    const l2Idx = unIdx + username.length * 2;
+    const ntIdx = l2Idx + lmv2len;
+    data.writeUInt16LE(lmv2len);
+    data.writeUInt16LE(lmv2len);
+    data.writeUInt32LE(l2Idx);
+    data.writeUInt16LE(ntlmv2len);
+    data.writeUInt16LE(ntlmv2len);
+    data.writeUInt32LE(ntIdx);
+    data.writeUInt16LE(domain.length * 2);
+    data.writeUInt16LE(domain.length * 2);
+    data.writeUInt32LE(dnIdx);
+    data.writeUInt16LE(username.length * 2);
+    data.writeUInt16LE(username.length * 2);
+    data.writeUInt32LE(unIdx);
+    data.writeUInt16LE(0);
+    data.writeUInt16LE(0);
+    data.writeUInt32LE(baseIdx);
+    data.writeUInt16LE(0);
+    data.writeUInt16LE(0);
+    data.writeUInt32LE(baseIdx);
+    data.writeUInt16LE(0x8201);
+    data.writeUInt16LE(0x08);
+    data.writeString(domain, 'ucs2');
+    data.writeString(username, 'ucs2');
+    const lmv2Data = this.lmv2Response(domain, username, password, server_nonce, client_nonce);
+    data.copyFrom(lmv2Data);
+    const genTime = new Date().getTime();
+    ntlmData = this.ntlmv2Response(domain, username, password, server_nonce, server_data, client_nonce, genTime);
+    data.copyFrom(ntlmData);
+    data.writeUInt32LE(0x0101);
+    data.writeUInt32LE(0x0000);
+    const timestamp = this.createTimestamp(genTime);
+    data.copyFrom(timestamp);
+    data.copyFrom(client_nonce);
+    data.writeUInt32LE(0x0000);
+    data.copyFrom(server_data);
+    data.writeUInt32LE(0x0000);
+    return data.data;
+  }
+
+  createClientNonce() {
+    const client_nonce = new Buffer(8);
+    let nidx = 0;
+    while (nidx < 8) {
+      client_nonce.writeUInt8(Math.ceil(Math.random() * 255), nidx);
+      nidx++;
+    }
+    return client_nonce;
+  }
+
+  ntlmv2Response(domain, user, password, serverNonce, targetInfo, clientNonce, mytime) {
+    const timestamp = this.createTimestamp(mytime);
+    const hash = this.ntv2Hash(domain, user, password);
+    const dataLength = 40 + targetInfo.length;
+    const data = new Buffer(dataLength);
+    serverNonce.copy(data, 0, 0, 8);
+    data.writeUInt32LE(0x101, 8);
+    data.writeUInt32LE(0x0, 12);
+    timestamp.copy(data, 16, 0, 8);
+    clientNonce.copy(data, 24, 0, 8);
+    data.writeUInt32LE(0x0, 32);
+    targetInfo.copy(data, 36, 0, targetInfo.length);
+    data.writeUInt32LE(0x0, 36 + targetInfo.length);
+    return this.hmacMD5(data, hash);
+  }
+
+  createTimestamp(time) {
+    const tenthsOfAMicrosecond = new BigInteger(time).plus(11644473600).multiply(10000000);
+    const hexArray = [];
+
+    let pair = [];
+    while (tenthsOfAMicrosecond.val() !== '0') {
+      const idx = tenthsOfAMicrosecond.mod(16);
+      pair.unshift(hex[idx]);
+      if (pair.length === 2) {
+        hexArray.push(pair.join(''));
+        pair = [];
+      }
+    }
+
+    if (pair.length > 0) {
+      hexArray.push(pair[0] + '0');
+    }
+
+    return new Buffer(hexArray.join(''), 'hex');
+  }
+
+  lmv2Response(domain, user, password, serverNonce, clientNonce) {
+    const hash = this.ntv2Hash(domain, user, password);
+    const data = new Buffer(serverNonce.length + clientNonce.length);
+
+    serverNonce.copy(data);
+    clientNonce.copy(data, serverNonce.length, 0, clientNonce.length);
+
+    const newhash = this.hmacMD5(data, hash);
+    const response = new Buffer(newhash.length + clientNonce.length);
+
+    newhash.copy(response);
+    clientNonce.copy(response, newhash.length, 0, clientNonce.length);
+
+    return response;
+  }
+
+  ntv2Hash(domain, user, password) {
+    const hash = this.ntHash(password);
+    const identity = new Buffer(user.toUpperCase() + domain.toUpperCase(), 'ucs2');
+    return this.hmacMD5(identity, hash);
+  }
+
+  ntHash(text) {
+    const hash = new Buffer(21);
+    hash.fill(0);
+
+    const unicodeString = new Buffer(text, 'ucs2');
+    const md4 = crypto.createHash('md4').update(unicodeString).digest();
+    if (md4.copy) {
+      md4.copy(hash);
+    } else {
+      new Buffer(md4, 'ascii').copy(hash);
+    }
+    return hash;
+  }
+
+  hmacMD5(data, key) {
+    const hmac = crypto.createHmac('MD5', key);
+    hmac.update(data);
+
+    const result = hmac.digest();
+    if (result.copy) {
+      return result;
+    } else {
+      return new Buffer(result, 'ascii').slice(0, 16);
+    }
+  }
+}
+
+function getNTLMFlags() {
+  return NTLMFlags.NTLM_NegotiateUnicode + NTLMFlags.NTLM_NegotiateOEM + NTLMFlags.NTLM_RequestTarget + NTLMFlags.NTLM_NegotiateNTLM + NTLMFlags.NTLM_NegotiateOemDomainSupplied + NTLMFlags.NTLM_NegotiateOemWorkstationSupplied + NTLMFlags.NTLM_NegotiateAlwaysSign + NTLMFlags.NTLM_NegotiateVersion + NTLMFlags.NTLM_NegotiateExtendedSecurity + NTLMFlags.NTLM_Negotiate128 + NTLMFlags.NTLM_Negotiate56;
+}
+
+function createNTLMRequest(options) {
+  const domain = escape(options.domain.toUpperCase());
+  const workstation = options.workstation ? escape(options.workstation.toUpperCase()) : '';
+  const protocol = 'NTLMSSP\u0000';
+  const BODY_LENGTH = 40;
+  const bufferLength = BODY_LENGTH + domain.length;
+  const buffer = new WritableTrackingBuffer(bufferLength);
+
+  let type1flags = getNTLMFlags();
+  if (workstation === '') {
+    type1flags -= NTLMFlags.NTLM_NegotiateOemWorkstationSupplied;
+  }
+
+  buffer.writeString(protocol, 'utf8');
+  buffer.writeUInt32LE(1);
+  buffer.writeUInt32LE(type1flags);
+  buffer.writeUInt16LE(domain.length);
+  buffer.writeUInt16LE(domain.length);
+  buffer.writeUInt32LE(BODY_LENGTH + workstation.length);
+  buffer.writeUInt16LE(workstation.length);
+  buffer.writeUInt16LE(workstation.length);
+  buffer.writeUInt32LE(BODY_LENGTH);
+  buffer.writeUInt8(5);
+  buffer.writeUInt8(0);
+  buffer.writeUInt16LE(2195);
+  buffer.writeUInt8(0);
+  buffer.writeUInt8(0);
+  buffer.writeUInt8(0);
+  buffer.writeUInt8(15);
+  buffer.writeString(workstation, 'ascii');
+  buffer.writeString(domain, 'ascii');
+  return buffer.data;
+}
+
+class NTLMAuthProvider {
+  constructor(connection, options) {
+    this.connection = connection;
+    this.options = options;
+  }
+
+  handshake(data, callback) {
+    if (data) {
+      callback(null, createNTLMRequest());
+    } else {
+      const payload = new NTLMResponsePayload({
+        domain: this.config.domain,
+        userName: this.config.userName,
+        password: this.config.password,
+        ntlmpacket: data,
+        additional: this.additional
+      });
+
+      callback(null, payload.data);
+    }
+  }
+}
+
+module.exports = function(options) {
+  return function(connection) {
+    new NTLMAuthProvider(connection, options);
+  };
+};

--- a/src/auth/sspi.js
+++ b/src/auth/sspi.js
@@ -1,0 +1,50 @@
+const SspiClientApi = require('sspi-client').SspiClientApi;
+const Fqdn = require('sspi-client').Fqdn;
+const MakeSpn = require('sspi-client').MakeSpn;
+
+class SSPIAuthProvider {
+  constructor(connection, options) {
+    this.connection = connection;
+    this.client = undefined;
+  }
+
+  handshake(data, callback) {
+    if (data) {
+      return this.client.getNextBlob(data, 0, data.length, (responseBuffer, isDone, errorCode, errorString) => {
+        if (errorCode) {
+          return callback(new Error(errorString));
+        }
+
+        callback(null, responseBuffer);
+      });
+    }
+
+    const server = this.connection.routingData ? this.connection.routingData.server : this.connection.config.server;
+    Fqdn.getFqdn(server, (err, fqdn) => {
+      if (err) {
+        return callback(new Error('Error getting Fqdn. Error details: ' + err.message));
+      }
+
+      const spn = MakeSpn.makeSpn('MSSQLSvc', fqdn, this.connection.config.options.port);
+      this.client = new SspiClientApi.SspiClient(spn, this.options.securityPackage);
+
+      this.client.getNextBlob(null, 0, 0, (responseBuffer, isDone, errorCode, errorString) => {
+        if (errorCode) {
+          return callback(new Error(errorString));
+        }
+
+        if (isDone) {
+          return callback(new Error('Unexpected isDone=true on getNextBlob in sendLogin7Packet.'));
+        }
+
+        callback(null, responseBuffer);
+      });
+    });
+  }
+}
+
+module.exports = function(options) {
+  return function(connection) {
+    return new SSPIAuthProvider(connection, options);
+  };
+};

--- a/test/unit/login7-payload-test.js
+++ b/test/unit/login7-payload-test.js
@@ -9,7 +9,8 @@ exports.create = function(test) {
     language: 'lang',
     database: 'db',
     packetSize: 1024,
-    tdsVersion: '7_2'
+    tdsVersion: '7_2',
+    sspiBlob: new Buffer(0)
   };
 
   //start = new Date().getTime()
@@ -52,7 +53,7 @@ exports.create = function(test) {
     payload.clientId.length +
     2 +
     2 +
-    2 * payload.sspi.length +
+    2 * 0 +
     2 +
     2 +
     2 * payload.attachDbFile.length +
@@ -81,12 +82,11 @@ exports.createNTLM = function(test) {
     password: 'pw',
     appName: 'app',
     serverName: 'server',
-    domain: 'domain',
-    workstation: 'workstation',
     language: 'lang',
     database: 'db',
     packetSize: 1024,
-    tdsVersion: '7_2'
+    tdsVersion: '7_2',
+    sspiBlob: new Buffer(0)
   };
 
   var payload = new Login7Payload(loginData);
@@ -135,20 +135,6 @@ exports.createNTLM = function(test) {
 
   test.strictEqual(payload.data.length, expectedLength);
 
-  var protocolHeader = payload.ntlmPacket.slice(0, 8).toString('utf8');
-  test.strictEqual(protocolHeader, 'NTLMSSP\u0000');
-
-  var workstationName = payload.ntlmPacket
-    .slice(payload.ntlmPacket.length - 17)
-    .toString('ascii')
-    .substr(0, 11);
-  test.strictEqual(workstationName, 'WORKSTATION');
-
-  var domainName = payload.ntlmPacket
-    .slice(payload.ntlmPacket.length - 6)
-    .toString('ascii');
-  test.strictEqual(domainName, 'DOMAIN');
-
   var passwordStart = payload.data.readUInt16LE(4 + 32 + 2 * 4);
   var passwordEnd = passwordStart + 2 * loginData.password.length;
   var passwordExpected = new Buffer([0xa2, 0xa5, 0xd2, 0xa5]);
@@ -165,8 +151,6 @@ exports.createSSPI = function(test) {
     password: '',
     appName: 'app',
     serverName: 'server',
-    domain: 'domain',
-    workstation: 'workstation',
     language: 'lang',
     database: 'db',
     packetSize: 1024,


### PR DESCRIPTION
In preparation of a new `tedious` release, I was going through all changes since `v2.0.1`. One thing I want to cleanup before the release is the integration with `sspi-client`.

I'm not super happy about the current situation where `sspi-client` is a hard dependency of `tedious`, and seeing that SQL Server actually supports more authentication methods and that there is another authentication related pull request in flight (#612) that adds `node-kerberos` as another hard dependency, I feel that the current approach for authentication methods is not scalable.

In this pull request, I explore the addition of what I call "authentication" providers (they're called "Security Support Providers" in the MS-TDS specification). The whole pull request is still very much in flux and a work in progress, but I believe the direction proposed here to be sound.

Authentication providers are simply objects that implement a `.handshake(input, callback)` method that is responsible for taking in authentication handshake data coming from SQL Server, and calling the passed `callback` with the handshake data that should be sent back to the SQL Server.

The long-term goal is to ship tedious with only a "default" dummy provider that does not actually do anything. Other providers like for NTLM, Kerberos or the native SSPI support will be extracted into separate npm modules organization. This way, we can extract both the implementation of these providers out of `tedious`, and keep `tedious` free from dependencies that are not required for all users.

The authentication provider to use for connecting to SQL Server will be specifiable via a new option when establishing a connection, and each provider will be able to handle options that are specific to it in it's own way.

For example, when using NTLM (domain) authentication I imagine connection creation could look like this:

```js
new Connection({
  "server": "localhost",
  "userName": "sa",
  "password": "yourStrong(!)Password",
  "authProvider": require("tedious-auth-ntlm")({
    "domain": "MYDOMAIN.COM",
    "workstation": "FOOBARBAZ"
  }),
  "options": {
    "port": 1433,
    "database": "master"
  }
});
```

While native SSPI could look like this:

```js
new Connection({
  "server": "localhost",
  "userName": "sa",
  "password": "yourStrong(!)Password",
  "authProvider": require("tedious-auth-native")({
    "securityProvider": "negotiate"
  }),
  "options": {
    "port": 1433,
    "database": "master"
  }
});
```

@tvrprasad @v-suhame What do you think?