### PR TITLE
Use Date constructors over unpredictable setters (fixes #625)

### DIFF
--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -492,13 +492,9 @@ function readSmallDateTime(parser, useUTC, callback) {
     parser.readUInt16LE((minutes) => {
       let value;
       if (useUTC) {
-        value = new Date(Date.UTC(1900, 0, 1));
-        value.setUTCDate(value.getUTCDate() + days);
-        value.setUTCMinutes(value.getUTCMinutes() + minutes);
+        value = new Date(Date.UTC(1900, 0, 1 + days, 0, minutes));
       } else {
-        value = new Date(1900, 0, 1);
-        value.setDate(value.getDate() + days);
-        value.setMinutes(value.getMinutes() + minutes);
+        value = new Date(1900, 0, 1 + days, 0, minutes);
       }
       callback(value);
     });
@@ -512,13 +508,9 @@ function readDateTime(parser, useUTC, callback) {
 
       let value;
       if (useUTC) {
-        value = new Date(Date.UTC(1900, 0, 1));
-        value.setUTCDate(value.getUTCDate() + days);
-        value.setUTCMilliseconds(value.getUTCMilliseconds() + milliseconds);
+        value = new Date(Date.UTC(1900, 0, 1 + days, 0, 0, 0, milliseconds));
       } else {
-        value = new Date(1900, 0, 1);
-        value.setDate(value.getDate() + days);
-        value.setMilliseconds(value.getMilliseconds() + milliseconds);
+        value = new Date(1900, 0, 1 + days, 0, 0, 0, milliseconds);
       }
 
       callback(value);


### PR DESCRIPTION
As documented in bug #625, setters are a bit on the unpredictable side, `setDate` can, under certain circumstances, change the time of the `Date` object, preventing other calls from working correctly.

Missing unit tests of which I'm unsure of how to approach.