### PR TITLE
fix: Do not send username and password via LOGIN7 when a domain is set.

### DIFF
--- a/src/login7-payload.js
+++ b/src/login7-payload.js
@@ -173,8 +173,8 @@ module.exports = class Login7Payload {
     this.attachDbFile = '';
     this.changePassword = '';
     this.addVariableDataString(variableData, this.hostname);
-    this.addVariableDataString(variableData, this.loginData.userName);
-    this.addVariableDataBuffer(variableData, this.createPasswordBuffer());
+    this.addVariableDataString(variableData, this.loginData.domain ? '' : this.loginData.userName);
+    this.addVariableDataBuffer(variableData, this.loginData.domain ? Buffer.alloc(0) : this.createPasswordBuffer());
     this.addVariableDataString(variableData, this.loginData.appName);
     this.addVariableDataString(variableData, this.loginData.serverName);
     this.addVariableDataString(variableData, '');

--- a/test/unit/login7-payload-test.js
+++ b/test/unit/login7-payload-test.js
@@ -99,10 +99,10 @@ exports.createNTLM = function(test) {
     2 * payload.hostname.length +
     2 +
     2 +
-    2 * loginData.userName.length +
+    2 * 0 +
     2 +
     2 +
-    2 * loginData.password.length +
+    2 * 0 +
     2 +
     2 +
     2 * loginData.appName.length +
@@ -148,13 +148,6 @@ exports.createNTLM = function(test) {
     .slice(payload.ntlmPacket.length - 6)
     .toString('ascii');
   test.strictEqual(domainName, 'DOMAIN');
-
-  var passwordStart = payload.data.readUInt16LE(4 + 32 + 2 * 4);
-  var passwordEnd = passwordStart + 2 * loginData.password.length;
-  var passwordExpected = new Buffer([0xa2, 0xa5, 0xd2, 0xa5]);
-  test.ok(
-    payload.data.slice(passwordStart, passwordEnd).equals(passwordExpected)
-  );
 
   test.done();
 };


### PR DESCRIPTION
This fixes a potentially security relevant issue where `tedious` would send username and password in plaintext via the LOGIN7 token, even if the `domain` option was specified and the credentials were sent as hashes via NTLM.

The security impact of this is rather low, as NTLM hashes are not really much more secure than plain text credentials, but this is still something we should fix.