### PR TITLE
fix: avoid (repeatedly) emitting 'prepared' event on error

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -38,7 +38,7 @@ module.exports = class Request extends EventEmitter {
   error: ?Error;
   connection: ?any; // TODO: This should be `Connection`, not `any`.
 
-  callback: () => void;
+  callback: (?Error) => void;
 
   constructor(sqlTextOrProcedure: ?string, callback: CompletionCallback) {
     super();
@@ -54,10 +54,14 @@ module.exports = class Request extends EventEmitter {
     this.error = undefined;
     this.connection = undefined;
     this.userCallback = callback;
-    this.callback = function() {
+    this.callback = function(err: ?Error) {
       if (this.preparing) {
-        this.emit('prepared');
         this.preparing = false;
+        if (err) {
+          this.emit('error', err);
+        } else {
+          this.emit('prepared');
+        }
       } else {
         this.userCallback.apply(this, arguments);
         this.emit('requestCompleted');


### PR DESCRIPTION
'prepared' was emitted on error because the callback error argument was not checked.

'prepared' was emitted again if an error occurred again before the emit call returned
because the prepared flag was only updated after emitting the event.