### PR TITLE
Fix: Fix deployments to Azure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "bl": "^1.2.0",
     "iconv-lite": "^0.4.11",
     "readable-stream": "^2.2.6",
-    "sprintf": "0.1.5",
-    "sspi-client": "^0.1.0"
+    "sprintf": "0.1.5"
   },
   "devDependencies": {
     "async": "^1.4.0",

--- a/src/token/sspi-token-parser.js
+++ b/src/token/sspi-token-parser.js
@@ -24,7 +24,7 @@ module.exports = function(parser, colMetadata, options, callback) {
     callback({
       name: 'SSPICHALLENGE',
       event: 'sspichallenge',
-      ntlmpacket: options.useWindowsIntegratedAuth ? {} : parseChallenge(buffer),
+      ntlmpacket: parseChallenge(buffer),
       ntlmpacketBuffer: buffer
     });
   });

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -219,7 +219,7 @@ var DomainCaseEnum = {
   Upper: 2,
 };
 
-var runNtlmTest = function(test, domainCase, isIntegratedAuth, securityPackage) {
+var runNtlmTest = function(test, domainCase) {
   if (!getNtlmConfig()) {
     console.log('Skipping ntlm test');
     test.done();
@@ -231,15 +231,8 @@ var runNtlmTest = function(test, domainCase, isIntegratedAuth, securityPackage) 
   var config = getConfig();
   var ntlmConfig = getNtlmConfig();
 
-  if (isIntegratedAuth) {
-    config.userName = '';
-    config.password = '';
-    config.securityPackage = securityPackage;
-  }
-  else {
-    config.userName = ntlmConfig.userName;
-    config.password = ntlmConfig.password;
-  }
+  config.userName = ntlmConfig.userName;
+  config.password = ntlmConfig.password;
 
   switch (domainCase) {
     case DomainCaseEnum.AsIs:
@@ -277,63 +270,15 @@ var runNtlmTest = function(test, domainCase, isIntegratedAuth, securityPackage) 
 };
 
 exports.ntlm = function(test) {
-  runNtlmTest(test, DomainCaseEnum.AsIs, false);
+  runNtlmTest(test, DomainCaseEnum.AsIs);
 };
 
 exports.ntlmLower = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Lower, false);
+  runNtlmTest(test, DomainCaseEnum.Lower);
 };
 
 exports.ntlmUpper = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Upper, false);
-};
-
-exports.integratedAuthDefault = function(test) {
-  runNtlmTest(test, DomainCaseEnum.AsIs, true);
-};
-
-exports.integratedAuthDefaultLower = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Lower, true);
-};
-
-exports.integratedAuthDefaultUpper = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Upper, true);
-};
-
-exports.integratedAuthNegotiate = function(test) {
-  runNtlmTest(test, DomainCaseEnum.AsIs, true, 'negotiate');
-};
-
-exports.integratedAuthNegotiateLower = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Lower, true, 'negotiate');
-};
-
-exports.integratedAuthNegotiateUpper = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Upper, true, 'negotiate');
-};
-
-exports.integratedAuthKerberos = function(test) {
-  runNtlmTest(test, DomainCaseEnum.AsIs, true, 'kerberos');
-};
-
-exports.integratedAuthKerberosLower = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Lower, true, 'kerberos');
-};
-
-exports.integratedAuthKerberosUpper = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Upper, true, 'kerberos');
-};
-
-exports.integratedAuthNtlm = function(test) {
-  runNtlmTest(test, DomainCaseEnum.AsIs, true, 'ntlm');
-};
-
-exports.integratedAuthNtlmLower = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Lower, true, 'ntlm');
-};
-
-exports.integratedAuthNtlmUpper = function(test) {
-  runNtlmTest(test, DomainCaseEnum.Upper, true, 'ntlm');
+  runNtlmTest(test, DomainCaseEnum.Upper);
 };
 
 exports.encrypt = function(test) {

--- a/test/unit/token/sspi-token-parser-test.js
+++ b/test/unit/token/sspi-token-parser-test.js
@@ -50,24 +50,3 @@ exports.parseChallenge = function(test) {
 
   test.done();
 };
-
-
-exports.parseChallengeSSPI = function(test) {
-  var anyData = new Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-  var source = new WriteBuffer(68);
-  source.writeUInt8(0xED);
-  source.writeUInt16LE(anyData.length);
-  source.copyFrom(anyData);
-
-  var parser = new Parser({ token() {} }, {}, { useWindowsIntegratedAuth: true });
-  parser.write(source.data);
-  var challenge = parser.read();
-
-  var expected = {};
-
-  test.deepEqual(challenge.ntlmpacket, expected);
-
-  test.ok(challenge.ntlmpacketBuffer.equals(anyData));
-
-  test.done();
-};


### PR DESCRIPTION
The `sspi-client` that was added to support native windows
authentication requires a small amount of C++ code to be compiled via
`node-gyp` during installation. This is not support on Azure out-of-the
box.

As the native windows authentication was never documented and only
accidentally included in the 2.1.0 release, we can remove the code to
support it to fix deployments for Azure users.

Native windows authentication will be brought back and supported in
future `tedious` releases.