### PR TITLE
chore: Upgrade Node.js versions used for CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ cache:
     - node_modules
 
 before_install:
-  - npm install -g npm
-
   - docker pull microsoft/mssql-server-linux
   - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -p 1433:1433 -d microsoft/mssql-server-linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "4"
   - "6"
   - "8"
+  - "9"
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 node_js:
   - "4"
   - "6"
-  - "7"
   - "8"
 
 stages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"
-    - nodejs_version: "7"
     - nodejs_version: "8"
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "9"
 
 branches:
   only:


### PR DESCRIPTION
This updates the Node.js versions that we use to run our tests on during CI on Travis and Appveyor. Node.js 7.x is no longer maintained or supported, 8.x became the new long-term support release, and new development happens on 9.x now.