### PR TITLE
chore: Drop the use and dependency on `source-map-support`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "nodeunit": "^0.11.0",
     "rimraf": "^2.6.1",
     "semantic-release": "^6.3.2",
-    "sinon": "^1.17.5",
-    "source-map-support": "^0.4.14"
+    "sinon": "^1.17.5"
   },
   "scripts": {
     "lint": "eslint src test",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,1 @@
 require('babel-register');
-require('source-map-support').install({
-  handleUncaughtExceptions: false,
-  hookRequire: true
-});


### PR DESCRIPTION
This was required to get correct stack-traces back when tedious was still written in CoffeeScript, but is not required anymore.