### PR TITLE
chore: Only run the linter once during CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 
 stages:
   - test
+  - lint
   - name: release
     if: (branch = master) AND (type = push)
 
@@ -46,10 +47,14 @@ script:
   - TEDIOUS_TDS_VERSION=7_3_A npm run test-integration
   - TEDIOUS_TDS_VERSION=7_2   npm run test-integration
   - TEDIOUS_TDS_VERSION=7_1   npm run test-integration
-  - npm run lint
 
 jobs:
   include:
+    - stage: lint
+      node_js: 4
+      before_install: skip
+      before_script: skip
+      script: npm run lint
     - stage: release
       node_js: 4
       before_install: skip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,4 @@ test_script:
       SET TEDIOUS_TDS_VERSION=7_1
       npm run-script test-integration || SET EXITVAL=1
 
-      npm run-script lint
-
       EXIT /B %EXITVAL%


### PR DESCRIPTION
Instead of running the linter on each CI build on Appveyor and Travis,
we now run it once in a separate build step on Travis. This should stop
us from spending time performing the same checks multiple times.