### PR TITLE
chore: Prune unused node modules from the Appveyor build cache.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ cache:
 build: off
 
 before_test:
+  - npm prune
+
   - sc config sqlbrowser start= auto
   - net start sqlbrowser
 


### PR DESCRIPTION
I noticed that some builds on Appveyor started to get really slow. I figured that one of the reasons for this was that we never remove no-longer used modules from the module cache on Appveyor. 😓