### PR TITLE
chore: Upgrade `babel` related packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tag": "next"
   },
   "dependencies": {
-    "babel-runtime": "^6.23.0",
+    "babel-runtime": "^6.26.0",
     "big-number": "0.3.1",
     "bl": "^1.2.0",
     "iconv-lite": "^0.4.11",
@@ -49,11 +49,11 @@
   },
   "devDependencies": {
     "async": "^1.4.0",
-    "babel-cli": "^6.24.0",
-    "babel-eslint": "^7.2.1",
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.2.2",
-    "babel-register": "^6.24.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-register": "^6.26.0",
     "benchmark": "^2.1.0",
     "eslint": "^3.19.0",
     "mitm": "^1.3.2",


### PR DESCRIPTION
* `babel-cli@6.26.0`
* `babel-eslint@7.2.3`
* `babel-register@6.26.0`
* `babel-runtime@6.26.0`
* `babel-preset-env@1.6.1`

This is mostly to get `babel` parsing support for some of the newer `flow` features, before we introduce `flow` typing to the tedious source.