### PR TITLE
fix: Ensure `Buffer`s are zero-filled on creation.

### DIFF
--- a/src/ntlm-payload.js
+++ b/src/ntlm-payload.js
@@ -73,7 +73,7 @@ module.exports = class NTLMResponsePayload {
   }
 
   createClientNonce() {
-    const client_nonce = new Buffer(8);
+    const client_nonce = new Buffer(8).fill(0);
     let nidx = 0;
     while (nidx < 8) {
       client_nonce.writeUInt8(Math.ceil(Math.random() * 255), nidx);
@@ -86,7 +86,7 @@ module.exports = class NTLMResponsePayload {
     const timestamp = this.createTimestamp(mytime);
     const hash = this.ntv2Hash(domain, user, password);
     const dataLength = 40 + targetInfo.length;
-    const data = new Buffer(dataLength);
+    const data = new Buffer(dataLength).fill(0);
     serverNonce.copy(data, 0, 0, 8);
     data.writeUInt32LE(0x101, 8);
     data.writeUInt32LE(0x0, 12);
@@ -121,13 +121,13 @@ module.exports = class NTLMResponsePayload {
 
   lmv2Response(domain, user, password, serverNonce, clientNonce) {
     const hash = this.ntv2Hash(domain, user, password);
-    const data = new Buffer(serverNonce.length + clientNonce.length);
+    const data = new Buffer(serverNonce.length + clientNonce.length).fill(0);
 
     serverNonce.copy(data);
     clientNonce.copy(data, serverNonce.length, 0, clientNonce.length);
 
     const newhash = this.hmacMD5(data, hash);
-    const response = new Buffer(newhash.length + clientNonce.length);
+    const response = new Buffer(newhash.length + clientNonce.length).fill(0);
 
     newhash.copy(response);
     clientNonce.copy(response, newhash.length, 0, clientNonce.length);
@@ -142,7 +142,7 @@ module.exports = class NTLMResponsePayload {
   }
 
   ntHash(text) {
-    const hash = new Buffer(21);
+    const hash = new Buffer(21).fill(0);
     hash.fill(0);
 
     const unicodeString = new Buffer(text, 'ucs2');

--- a/src/packet.js
+++ b/src/packet.js
@@ -51,7 +51,7 @@ class Packet {
       this.buffer = typeOrBuffer;
     } else {
       const type = typeOrBuffer;
-      this.buffer = new Buffer(HEADER_LENGTH);
+      this.buffer = new Buffer(HEADER_LENGTH).fill(0);
       this.buffer.writeUInt8(type, OFFSET.Type);
       this.buffer.writeUInt8(STATUS.NORMAL, OFFSET.Status);
       this.buffer.writeUInt16BE(DEFAULT_SPID, OFFSET.SPID);

--- a/src/prelogin-payload.js
+++ b/src/prelogin-payload.js
@@ -72,7 +72,7 @@ module.exports = class PreloginPayload {
       length += 5 + option.data.length;
     }
     length++; // terminator
-    this.data = new Buffer(length);
+    this.data = new Buffer(length).fill(0);
     let optionOffset = 0;
     let optionDataOffset = 5 * options.length + 1;
 

--- a/src/tracking-buffer/bigint.js
+++ b/src/tracking-buffer/bigint.js
@@ -68,7 +68,7 @@ function numberToInt64LE(num) {
   let hi = Math.abs(num);
   let lo = hi % 0x100000000;
   hi = (hi / 0x100000000) | 0;
-  const buf = new Buffer(8);
+  const buf = new Buffer(8).fill(0);
   for (let i = 0; i <= 7; i++) {
     buf[i] = lo & 0xff;
     lo = i === 3 ? hi : lo >>> 8;

--- a/src/tracking-buffer/writable-tracking-buffer.js
+++ b/src/tracking-buffer/writable-tracking-buffer.js
@@ -29,7 +29,7 @@ module.exports = class WritableTrackingBuffer {
     this.initialSize = initialSize;
     this.encoding = encoding || 'ucs2';
     this.doubleSizeGrowth = doubleSizeGrowth || false;
-    this.buffer = new Buffer(this.initialSize);
+    this.buffer = new Buffer(this.initialSize).fill(0);
     this.compositeBuffer = new Buffer(0);
     this.position = 0;
   }
@@ -64,7 +64,7 @@ module.exports = class WritableTrackingBuffer {
   newBuffer(size) {
     const buffer = this.buffer.slice(0, this.position);
     this.compositeBuffer = Buffer.concat([this.compositeBuffer, buffer]);
-    this.buffer = (size === 0) ? ZERO_LENGTH_BUFFER : new Buffer(size);
+    this.buffer = (size === 0) ? ZERO_LENGTH_BUFFER : new Buffer(size).fill(0);
     return this.position = 0;
   }
 

--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -436,7 +436,7 @@ function readMax(parser, callback) {
 }
 
 function readMaxKnownLength(parser, totalLength, callback) {
-  const data = new Buffer(totalLength);
+  const data = new Buffer(totalLength).fill(0);
 
   let offset = 0;
   function next(done) {


### PR DESCRIPTION
Prior to Node.js 8.0.0, `Buffer` objects created via `new Buffer(size)` were not zero filled by default.

---

`new Buffer` has been deprecated since Node.js 6.0.0 in favor of `Buffer.alloc`, but as we still support 4.0.0, we can't switch to the new `Buffer.alloc` yet. 😞 

I don't think this fix is security relevant, as `WritableTrackingBuffer` always kept track of how many bytes were actually written to the buffer and never returned non-initialized data from the buffer. Still, zero filling the `Buffer` objects is good practice, so let's do that.