### PR TITLE
refactor: Reduce the number of explicit `return` statements.

### DIFF
--- a/src/bulk-load.js
+++ b/src/bulk-load.js
@@ -106,7 +106,7 @@ module.exports = class BulkLoad extends EventEmitter {
 
     this.columns.push(column);
 
-    return this.columnsByName[name] = column;
+    this.columnsByName[name] = column;
   }
 
   addRow(row) {

--- a/src/connection.js
+++ b/src/connection.js
@@ -390,12 +390,12 @@ class Connection extends EventEmitter {
   }
 
   close() {
-    return this.transitionTo(this.STATE.FINAL);
+    this.transitionTo(this.STATE.FINAL);
   }
 
   initialiseConnection() {
     this.connect();
-    return this.createConnectTimer();
+    this.createConnectTimer();
   }
 
   cleanupConnection(cleanupTypeEnum) {
@@ -416,14 +416,14 @@ class Connection extends EventEmitter {
       }
       this.closed = true;
       this.loggedIn = false;
-      return this.loginError = null;
+      this.loginError = null;
     }
   }
 
   createDebug() {
     this.debug = new Debug(this.config.options.debug);
-    return this.debug.on('debug', (message) => {
-      return this.emit('debug', message);
+    this.debug.on('debug', (message) => {
+      this.emit('debug', message);
     });
   }
 
@@ -431,7 +431,7 @@ class Connection extends EventEmitter {
     this.tokenStreamParser = new TokenStreamParser(this.debug, undefined, this.config.options);
 
     this.tokenStreamParser.on('infoMessage', (token) => {
-      return this.emit('infoMessage', token);
+      this.emit('infoMessage', token);
     });
 
     this.tokenStreamParser.on('sspichallenge', (token) => {
@@ -439,7 +439,8 @@ class Connection extends EventEmitter {
         this.ntlmpacket = token.ntlmpacket;
         this.ntlmpacketBuffer = token.ntlmpacketBuffer;
       }
-      return this.emit('sspichallenge', token);
+
+      this.emit('sspichallenge', token);
     });
 
     this.tokenStreamParser.on('errorMessage', (token) => {
@@ -466,15 +467,15 @@ class Connection extends EventEmitter {
     });
 
     this.tokenStreamParser.on('databaseChange', (token) => {
-      return this.emit('databaseChange', token.newValue);
+      this.emit('databaseChange', token.newValue);
     });
 
     this.tokenStreamParser.on('languageChange', (token) => {
-      return this.emit('languageChange', token.newValue);
+      this.emit('languageChange', token.newValue);
     });
 
     this.tokenStreamParser.on('charsetChange', (token) => {
-      return this.emit('charsetChange', token.newValue);
+      this.emit('charsetChange', token.newValue);
     });
 
     this.tokenStreamParser.on('loginack', (token) => {
@@ -494,30 +495,30 @@ class Connection extends EventEmitter {
 
       // use negotiated version
       this.config.options.tdsVersion = token.tdsVersion;
-      return this.loggedIn = true;
+      this.loggedIn = true;
     });
 
     this.tokenStreamParser.on('routingChange', (token) => {
       this.routingData = token.newValue;
-      return this.dispatchEvent('routingChange');
+      this.dispatchEvent('routingChange');
     });
 
     this.tokenStreamParser.on('packetSizeChange', (token) => {
-      return this.messageIo.packetSize(token.newValue);
+      this.messageIo.packetSize(token.newValue);
     });
 
     // A new top-level transaction was started. This is not fired
     // for nested transactions.
     this.tokenStreamParser.on('beginTransaction', (token) => {
       this.transactionDescriptors.push(token.newValue);
-      return this.inTransaction = true;
+      this.inTransaction = true;
     });
 
     // A top-level transaction was committed. This is not fired
     // for nested transactions.
     this.tokenStreamParser.on('commitTransaction', () => {
       this.transactionDescriptors.length = 1;
-      return this.inTransaction = false;
+      this.inTransaction = false;
     });
 
     // A top-level transaction was rolled back. This is not fired
@@ -527,7 +528,7 @@ class Connection extends EventEmitter {
       this.transactionDescriptors.length = 1;
       // An outermost transaction was rolled back. Reset the transaction counter
       this.inTransaction = false;
-      return this.emit('rollbackTransaction');
+      this.emit('rollbackTransaction');
     });
 
     this.tokenStreamParser.on('columnMetadata', (token) => {
@@ -544,19 +545,19 @@ class Connection extends EventEmitter {
         } else {
           columns = token.columns;
         }
-        return this.request.emit('columnMetadata', columns);
+        this.request.emit('columnMetadata', columns);
       } else {
         this.emit('error', new Error("Received 'columnMetadata' when no sqlRequest is in progress"));
-        return this.close();
+        this.close();
       }
     });
 
     this.tokenStreamParser.on('order', (token) => {
       if (this.request) {
-        return this.request.emit('order', token.orderColumns);
+        this.request.emit('order', token.orderColumns);
       } else {
         this.emit('error', new Error("Received 'order' when no sqlRequest is in progress"));
-        return this.close();
+        this.close();
       }
     });
 
@@ -573,20 +574,20 @@ class Connection extends EventEmitter {
         }
       } else {
         this.emit('error', new Error("Received 'row' when no sqlRequest is in progress"));
-        return this.close();
+        this.close();
       }
     });
 
     this.tokenStreamParser.on('returnStatus', (token) => {
       if (this.request) {
         // Keep value for passing in 'doneProc' event.
-        return this.procReturnStatusValue = token.value;
+        this.procReturnStatusValue = token.value;
       }
     });
 
     this.tokenStreamParser.on('returnValue', (token) => {
       if (this.request) {
-        return this.request.emit('returnValue', token.paramName, token.value, token.metadata);
+        this.request.emit('returnValue', token.paramName, token.value, token.metadata);
       }
     });
 
@@ -598,7 +599,7 @@ class Connection extends EventEmitter {
           this.request.rowCount += token.rowCount;
         }
         if (this.config.options.rowCollectionOnDone) {
-          return this.request.rst = [];
+          this.request.rst = [];
         }
       }
     });
@@ -610,7 +611,7 @@ class Connection extends EventEmitter {
           this.request.rowCount += token.rowCount;
         }
         if (this.config.options.rowCollectionOnDone) {
-          return this.request.rst = [];
+          this.request.rst = [];
         }
       }
     });
@@ -629,7 +630,7 @@ class Connection extends EventEmitter {
           this.request.rowCount += token.rowCount;
         }
         if (this.config.options.rowCollectionOnDone) {
-          return this.request.rst = [];
+          this.request.rst = [];
         }
       }
     });
@@ -641,12 +642,12 @@ class Connection extends EventEmitter {
     });
 
     this.tokenStreamParser.on('resetConnection', () => {
-      return this.emit('resetConnection');
+      this.emit('resetConnection');
     });
 
     this.tokenStreamParser.on('tokenStreamError', (error) => {
       this.emit('error', error);
-      return this.close();
+      this.close();
     });
 
     this.tokenStreamParser.on('drain', () => {
@@ -669,9 +670,9 @@ class Connection extends EventEmitter {
           return;
         }
         if (message) {
-          return this.emit('connect', ConnectionError(message, 'EINSTLOOKUP'));
+          this.emit('connect', ConnectionError(message, 'EINSTLOOKUP'));
         } else {
-          return this.connectOnPort(port, this.config.options.multiSubnetFailover);
+          this.connectOnPort(port, this.config.options.multiSubnetFailover);
         }
       });
     }
@@ -709,13 +710,13 @@ class Connection extends EventEmitter {
   }
 
   createConnectTimer() {
-    return this.connectTimer = setTimeout(this.connectTimeout, this.config.options.connectTimeout);
+    this.connectTimer = setTimeout(this.connectTimeout, this.config.options.connectTimeout);
   }
 
   createRequestTimer() {
     this.clearRequestTimer();                              // release old timer, just to be safe
     if (this.config.options.requestTimeout) {
-      return this.requestTimer = setTimeout(this.requestTimeout, this.config.options.requestTimeout);
+      this.requestTimer = setTimeout(this.requestTimeout, this.config.options.requestTimeout);
     }
   }
 
@@ -729,13 +730,13 @@ class Connection extends EventEmitter {
     this.debug.log(message);
     this.emit('connect', ConnectionError(message, 'ETIMEOUT'));
     this.connectTimer = undefined;
-    return this.dispatchEvent('connectTimeout');
+    this.dispatchEvent('connectTimeout');
   }
 
   requestTimeout() {
     this.requestTimer = undefined;
     this.messageIo.sendMessage(TYPE.ATTENTION);
-    return this.transitionTo(this.STATE.SENT_ATTENTION);
+    this.transitionTo(this.STATE.SENT_ATTENTION);
   }
 
   retryTimeout() {
@@ -746,7 +747,7 @@ class Connection extends EventEmitter {
 
   clearConnectTimer() {
     if (this.connectTimer) {
-      return clearTimeout(this.connectTimer);
+      clearTimeout(this.connectTimer);
     }
   }
 
@@ -778,7 +779,7 @@ class Connection extends EventEmitter {
     this.state = newState;
 
     if (this.state.enter) {
-      return this.state.enter.apply(this);
+      this.state.enter.apply(this);
     }
   }
 
@@ -788,10 +789,10 @@ class Connection extends EventEmitter {
       for (let i = 0; i < args.length;) {
         args[i++] = arguments[i];
       }
-      return this.state.events[eventName].apply(this, args);
+      this.state.events[eventName].apply(this, args);
     } else {
       this.emit('error', new Error(`No event '${eventName}' in state '${this.state.name}'`));
-      return this.close();
+      this.close();
     }
   }
 
@@ -805,34 +806,34 @@ class Connection extends EventEmitter {
       this.debug.log(message);
       this.emit('error', ConnectionError(message, 'ESOCKET'));
     }
-    return this.dispatchEvent('socketError', error);
+    this.dispatchEvent('socketError', error);
   }
 
   socketConnect() {
     this.socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY);
     this.closed = false;
     this.debug.log('connected to ' + this.config.server + ':' + this.config.options.port);
-    return this.dispatchEvent('socketConnect');
+    this.dispatchEvent('socketConnect');
   }
 
   socketEnd() {
     this.debug.log('socket ended');
-    return this.transitionTo(this.STATE.FINAL);
+    this.transitionTo(this.STATE.FINAL);
   }
 
   socketClose() {
     this.debug.log('connection to ' + this.config.server + ':' + this.config.options.port + ' closed');
     if (this.state === this.STATE.REROUTING) {
       this.debug.log('Rerouting to ' + this.routingData.server + ':' + this.routingData.port);
-      return this.dispatchEvent('reconnect');
+      this.dispatchEvent('reconnect');
     } else if (this.state === this.STATE.TRANSIENT_FAILURE_RETRY) {
       const server = this.routingData ? this.routingData.server : this.server;
       const port = this.routingData ? this.routingData.port : this.config.options.port;
       this.debug.log('Retry after transient failure connecting to ' + server + ':' + port);
 
-      return this.dispatchEvent('retry');
+      this.dispatchEvent('retry');
     } else {
-      return this.transitionTo(this.STATE.FINAL);
+      this.transitionTo(this.STATE.FINAL);
     }
   }
 
@@ -841,17 +842,17 @@ class Connection extends EventEmitter {
       encrypt: this.config.options.encrypt
     });
     this.messageIo.sendMessage(TYPE.PRELOGIN, payload.data);
-    return this.debug.payload(function() {
+    this.debug.payload(function() {
       return payload.toString('  ');
     });
   }
 
   emptyMessageBuffer() {
-    return this.messageBuffer = new Buffer(0);
+    this.messageBuffer = new Buffer(0);
   }
 
   addToMessageBuffer(data) {
-    return this.messageBuffer = Buffer.concat([this.messageBuffer, data]);
+    this.messageBuffer = Buffer.concat([this.messageBuffer, data]);
   }
 
   processPreLoginResponse() {
@@ -866,9 +867,9 @@ class Connection extends EventEmitter {
         return this.close();
       }
 
-      return this.dispatchEvent('tls');
+      this.dispatchEvent('tls');
     } else {
-      return this.dispatchEvent('noTls');
+      this.dispatchEvent('noTls');
     }
   }
 
@@ -1039,61 +1040,64 @@ class Connection extends EventEmitter {
 
   processedInitialSql() {
     this.clearConnectTimer();
-    return this.emit('connect');
+    this.emit('connect');
   }
 
   processLogin7Response() {
     if (this.loggedIn) {
-      return this.dispatchEvent('loggedIn');
+      this.dispatchEvent('loggedIn');
     } else {
       if (this.loginError) {
         this.emit('connect', this.loginError);
       } else {
         this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
       }
-      return this.dispatchEvent('loginFailed');
+      this.dispatchEvent('loginFailed');
     }
   }
 
   processLogin7NTLMResponse() {
     if (this.ntlmpacket) {
-      return this.dispatchEvent('receivedChallenge');
+      this.dispatchEvent('receivedChallenge');
     } else {
       if (this.loginError) {
         this.emit('connect', this.loginError);
       } else {
         this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
       }
-      return this.dispatchEvent('loginFailed');
+      this.dispatchEvent('loginFailed');
     }
   }
 
   processLogin7NTLMAck() {
     if (this.loggedIn) {
-      return this.dispatchEvent('loggedIn');
+      this.dispatchEvent('loggedIn');
     } else {
       if (this.loginError) {
         this.emit('connect', this.loginError);
       } else {
         this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
       }
-      return this.dispatchEvent('loginFailed');
+      this.dispatchEvent('loginFailed');
     }
   }
 
   execSqlBatch(request) {
-    return this.makeRequest(request, TYPE.SQL_BATCH, new SqlBatchPayload(request.sqlTextOrProcedure, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.SQL_BATCH, new SqlBatchPayload(request.sqlTextOrProcedure, this.currentTransactionDescriptor(), this.config.options));
   }
 
   execSql(request) {
     request.transformIntoExecuteSqlRpc();
+
     if (request.error != null) {
-      return process.nextTick(() => {
+      process.nextTick(() => {
         this.debug.log(request.error.message);
-        return request.callback(request.error);
+        request.callback(request.error);
       });
+      return;
     }
-    return this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
   }
 
   /**
@@ -1124,44 +1128,52 @@ class Connection extends EventEmitter {
           error.message += ' This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.';
         }
         bulkLoad.error = error;
-        return bulkLoad.callback(error);
+        bulkLoad.callback(error);
       } else {
-        return this.makeRequest(bulkLoad, TYPE.BULK_LOAD, bulkLoad.getPayload());
+        this.makeRequest(bulkLoad, TYPE.BULK_LOAD, bulkLoad.getPayload());
       }
     });
-    return this.execSqlBatch(request);
+
+    this.execSqlBatch(request);
   }
 
   prepare(request) {
     request.transformIntoPrepareRpc();
-    return this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
   }
 
   unprepare(request) {
     request.transformIntoUnprepareRpc();
-    return this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
   }
 
   execute(request, parameters) {
     request.transformIntoExecuteRpc(parameters);
+
     if (request.error != null) {
-      return process.nextTick(() => {
+      process.nextTick(() => {
         this.debug.log(request.error.message);
-        return request.callback(request.error);
+        request.callback(request.error);
       });
+
+      return;
     }
-    return this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
   }
 
   callProcedure(request) {
     request.validateParameters();
+
     if (request.error != null) {
-      return process.nextTick(() => {
+      process.nextTick(() => {
         this.debug.log(request.error.message);
-        return request.callback(request.error);
+        request.callback(request.error);
       });
+      return;
     }
-    return this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
   }
 
   beginTransaction(callback, name, isolationLevel) {
@@ -1298,7 +1310,7 @@ class Connection extends EventEmitter {
     if (this.state !== this.STATE.LOGGED_IN) {
       const message = 'Requests can only be made in the ' + this.STATE.LOGGED_IN.name + ' state, not the ' + this.state.name + ' state';
       this.debug.log(message);
-      return request.callback(RequestError(message, 'EINVALIDSTATE'));
+      request.callback(RequestError(message, 'EINVALIDSTATE'));
     } else {
       if (packetType === TYPE.SQL_BATCH) {
         this.isSqlBatch = true;
@@ -1375,69 +1387,69 @@ Connection.prototype.STATE = {
   CONNECTING: {
     name: 'Connecting',
     enter: function() {
-      return this.initialiseConnection();
+      this.initialiseConnection();
     },
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       socketConnect: function() {
         this.sendPreLogin();
-        return this.transitionTo(this.STATE.SENT_PRELOGIN);
+        this.transitionTo(this.STATE.SENT_PRELOGIN);
       }
     }
   },
   SENT_PRELOGIN: {
     name: 'SentPrelogin',
     enter: function() {
-      return this.emptyMessageBuffer();
+      this.emptyMessageBuffer();
     },
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.addToMessageBuffer(data);
+        this.addToMessageBuffer(data);
       },
       message: function() {
-        return this.processPreLoginResponse();
+        this.processPreLoginResponse();
       },
       noTls: function() {
         this.sendLogin7Packet(() => {
           if (this.config.domain) {
-            return this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
+            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
           } else {
-            return this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
           }
         });
       },
       tls: function() {
         this.messageIo.startTls(this.config.options.cryptoCredentialsDetails, this.config.server, this.config.options.trustServerCertificate);
-        return this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
+        this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
       }
     }
   },
   REROUTING: {
     name: 'ReRouting',
     enter: function() {
-      return this.cleanupConnection(this.cleanupTypeEnum.REDIRECT);
+      this.cleanupConnection(this.cleanupTypeEnum.REDIRECT);
     },
     events: {
       message: function() {},
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       reconnect: function() {
-        return this.transitionTo(this.STATE.CONNECTING);
+        this.transitionTo(this.STATE.CONNECTING);
       }
     }
   },
@@ -1445,15 +1457,15 @@ Connection.prototype.STATE = {
     name: 'TRANSIENT_FAILURE_RETRY',
     enter: function() {
       this.curTransientRetryCount++;
-      return this.cleanupConnection(this.cleanupTypeEnum.RETRY);
+      this.cleanupConnection(this.cleanupTypeEnum.RETRY);
     },
     events: {
       message: function() {},
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       retry: function() {
         this.createRetryTimer();
@@ -1464,21 +1476,21 @@ Connection.prototype.STATE = {
     name: 'SentTLSSSLNegotiation',
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.messageIo.tlsHandshakeData(data);
+        this.messageIo.tlsHandshakeData(data);
       },
       message: function() {
         if (this.messageIo.tlsNegotiationComplete) {
           this.sendLogin7Packet(() => {
             if (this.config.domain) {
-              return this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
             } else {
-              return this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
             }
           });
         }
@@ -1489,25 +1501,25 @@ Connection.prototype.STATE = {
     name: 'SentLogin7WithStandardLogin',
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.sendDataToTokenStreamParser(data);
+        this.sendDataToTokenStreamParser(data);
       },
       loggedIn: function() {
-        return this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
+        this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
       },
       routingChange: function() {
-        return this.transitionTo(this.STATE.REROUTING);
+        this.transitionTo(this.STATE.REROUTING);
       },
       loginFailed: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       message: function() {
-        return this.processLogin7Response();
+        this.processLogin7Response();
       }
     }
   },
@@ -1515,22 +1527,22 @@ Connection.prototype.STATE = {
     name: 'SentLogin7WithNTLMLogin',
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.sendDataToTokenStreamParser(data);
+        this.sendDataToTokenStreamParser(data);
       },
       receivedChallenge: function() {
-        return this.sendNTLMResponsePacket();
+        this.sendNTLMResponsePacket();
       },
       loginFailed: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       message: function() {
-        return this.processLogin7NTLMResponse();
+        this.processLogin7NTLMResponse();
       }
     }
   },
@@ -1538,43 +1550,43 @@ Connection.prototype.STATE = {
     name: 'SentNTLMResponse',
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.sendDataToTokenStreamParser(data);
+        this.sendDataToTokenStreamParser(data);
       },
       loggedIn: function() {
-        return this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
+        this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
       },
       loginFailed: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       routingChange: function() {
-        return this.transitionTo(this.STATE.REROUTING);
+        this.transitionTo(this.STATE.REROUTING);
       },
       message: function() {
-        return this.processLogin7NTLMAck();
+        this.processLogin7NTLMAck();
       }
     }
   },
   LOGGED_IN_SENDING_INITIAL_SQL: {
     name: 'LoggedInSendingInitialSql',
     enter: function() {
-      return this.sendInitialSql();
+      this.sendInitialSql();
     },
     events: {
       connectTimeout: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.sendDataToTokenStreamParser(data);
+        this.sendDataToTokenStreamParser(data);
       },
       message: function() {
         this.transitionTo(this.STATE.LOGGED_IN);
-        return this.processedInitialSql();
+        this.processedInitialSql();
       }
     }
   },
@@ -1582,7 +1594,7 @@ Connection.prototype.STATE = {
     name: 'LoggedIn',
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       }
     }
   },
@@ -1600,7 +1612,7 @@ Connection.prototype.STATE = {
         const sqlRequest = this.request;
         this.request = undefined;
         sqlRequest.callback(err);
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
         this.clearRequestTimer();                          // request timer is stopped on first data package
@@ -1615,7 +1627,7 @@ Connection.prototype.STATE = {
         // We have to channel the 'message' (EOM) event through the token stream
         // parser transform, to keep it in line with the flow of the tokens, when
         // the incoming data flow is paused and resumed.
-        return this.tokenStreamParser.addEndOfMessageMarker();
+        this.tokenStreamParser.addEndOfMessageMarker();
       },
       endOfMessageMarkerReceived: function() {
         this.transitionTo(this.STATE.LOGGED_IN);
@@ -1624,24 +1636,24 @@ Connection.prototype.STATE = {
         if (this.config.options.tdsVersion < '7_2' && sqlRequest.error && this.isSqlBatch) {
           this.inTransaction = false;
         }
-        return sqlRequest.callback(sqlRequest.error, sqlRequest.rowCount, sqlRequest.rows);
+        sqlRequest.callback(sqlRequest.error, sqlRequest.rowCount, sqlRequest.rows);
       }
     }
   },
   SENT_ATTENTION: {
     name: 'SentAttention',
     enter: function() {
-      return this.attentionReceived = false;
+      this.attentionReceived = false;
     },
     events: {
       socketError: function() {
-        return this.transitionTo(this.STATE.FINAL);
+        this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {
-        return this.sendDataToTokenStreamParser(data);
+        this.sendDataToTokenStreamParser(data);
       },
       attention: function() {
-        return this.attentionReceived = true;
+        this.attentionReceived = true;
       },
       message: function() {
         // 3.2.5.7 Sent Attention State
@@ -1651,10 +1663,10 @@ Connection.prototype.STATE = {
           this.request = undefined;
           this.transitionTo(this.STATE.LOGGED_IN);
           if (sqlRequest.canceled) {
-            return sqlRequest.callback(RequestError('Canceled.', 'ECANCEL'));
+            sqlRequest.callback(RequestError('Canceled.', 'ECANCEL'));
           } else {
             const message = 'Timeout: Request failed to complete in ' + this.config.options.requestTimeout + 'ms';
-            return sqlRequest.callback(RequestError(message, 'ETIMEOUT'));
+            sqlRequest.callback(RequestError(message, 'ETIMEOUT'));
           }
         }
       }
@@ -1663,7 +1675,7 @@ Connection.prototype.STATE = {
   FINAL: {
     name: 'Final',
     enter: function() {
-      return this.cleanupConnection(this.cleanupTypeEnum.NORMAL);
+      this.cleanupConnection(this.cleanupTypeEnum.NORMAL);
     },
     events: {
       loginFailed: function() {

--- a/src/data-type.js
+++ b/src/data-type.js
@@ -25,15 +25,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.IntN.id);
-      return buffer.writeUInt8(1);
+      buffer.writeUInt8(1);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(1);
-        return buffer.writeUInt8(parseInt(parameter.value));
+        buffer.writeUInt8(parseInt(parameter.value));
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -62,15 +62,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.BitN.id);
-      return buffer.writeUInt8(1);
+      buffer.writeUInt8(1);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (typeof parameter.value === 'undefined' || parameter.value === null) {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       } else {
         buffer.writeUInt8(1);
-        return buffer.writeUInt8(parameter.value ? 1 : 0);
+        buffer.writeUInt8(parameter.value ? 1 : 0);
       }
     },
 
@@ -96,15 +96,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.IntN.id);
-      return buffer.writeUInt8(2);
+      buffer.writeUInt8(2);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(2);
-        return buffer.writeInt16LE(parseInt(parameter.value));
+        buffer.writeInt16LE(parseInt(parameter.value));
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -133,15 +133,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.IntN.id);
-      return buffer.writeUInt8(4);
+      buffer.writeUInt8(4);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(4);
-        return buffer.writeInt32LE(parseInt(parameter.value));
+        buffer.writeInt32LE(parseInt(parameter.value));
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -170,7 +170,7 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.DateTimeN.id);
-      return buffer.writeUInt8(4);
+      buffer.writeUInt8(4);
     },
 
     writeParameterData: function(buffer, parameter, options) {
@@ -188,9 +188,9 @@ const TYPE = module.exports.TYPE = {
         buffer.writeUInt8(4);
         buffer.writeUInt16LE(days);
 
-        return buffer.writeUInt16LE(minutes);
+        buffer.writeUInt16LE(minutes);
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -221,15 +221,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.FloatN.id);
-      return buffer.writeUInt8(4);
+      buffer.writeUInt8(4);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(4);
-        return buffer.writeFloatLE(parseFloat(parameter.value));
+        buffer.writeFloatLE(parseFloat(parameter.value));
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -255,15 +255,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.MoneyN.id);
-      return buffer.writeUInt8(8);
+      buffer.writeUInt8(8);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(8);
-        return buffer.writeMoney(parameter.value * 10000);
+        buffer.writeMoney(parameter.value * 10000);
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -289,7 +289,7 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.DateTimeN.id);
-      return buffer.writeUInt8(8);
+      buffer.writeUInt8(8);
     },
 
     writeParameterData: function(buffer, parameter, options) {
@@ -316,9 +316,9 @@ const TYPE = module.exports.TYPE = {
         buffer.writeUInt8(8);
         buffer.writeInt32LE(days);
 
-        return buffer.writeUInt32LE(threeHundredthsOfSecond);
+        buffer.writeUInt32LE(threeHundredthsOfSecond);
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -346,15 +346,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.FloatN.id);
-      return buffer.writeUInt8(8);
+      buffer.writeUInt8(8);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(8);
-        return buffer.writeDoubleLE(parseFloat(parameter.value));
+        buffer.writeDoubleLE(parseFloat(parameter.value));
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -410,7 +410,7 @@ const TYPE = module.exports.TYPE = {
         buffer.writeUInt8(17);
       }
       buffer.writeUInt8(parameter.precision);
-      return buffer.writeUInt8(parameter.scale);
+      buffer.writeUInt8(parameter.scale);
     },
 
     writeParameterData: function(buffer, parameter) {
@@ -420,25 +420,25 @@ const TYPE = module.exports.TYPE = {
         if (parameter.precision <= 9) {
           buffer.writeUInt8(5);
           buffer.writeUInt8(sign);
-          return buffer.writeUInt32LE(value);
+          buffer.writeUInt32LE(value);
         } else if (parameter.precision <= 19) {
           buffer.writeUInt8(9);
           buffer.writeUInt8(sign);
-          return buffer.writeUInt64LE(value);
+          buffer.writeUInt64LE(value);
         } else if (parameter.precision <= 28) {
           buffer.writeUInt8(13);
           buffer.writeUInt8(sign);
           buffer.writeUInt64LE(value);
-          return buffer.writeUInt32LE(0x00000000);
+          buffer.writeUInt32LE(0x00000000);
         } else {
           buffer.writeUInt8(17);
           buffer.writeUInt8(sign);
           buffer.writeUInt64LE(value);
           buffer.writeUInt32LE(0x00000000);
-          return buffer.writeUInt32LE(0x00000000);
+          buffer.writeUInt32LE(0x00000000);
         }
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -494,7 +494,7 @@ const TYPE = module.exports.TYPE = {
         buffer.writeUInt8(17);
       }
       buffer.writeUInt8(parameter.precision);
-      return buffer.writeUInt8(parameter.scale);
+      buffer.writeUInt8(parameter.scale);
     },
 
     writeParameterData: function(buffer, parameter) {
@@ -504,25 +504,25 @@ const TYPE = module.exports.TYPE = {
         if (parameter.precision <= 9) {
           buffer.writeUInt8(5);
           buffer.writeUInt8(sign);
-          return buffer.writeUInt32LE(value);
+          buffer.writeUInt32LE(value);
         } else if (parameter.precision <= 19) {
           buffer.writeUInt8(9);
           buffer.writeUInt8(sign);
-          return buffer.writeUInt64LE(value);
+          buffer.writeUInt64LE(value);
         } else if (parameter.precision <= 28) {
           buffer.writeUInt8(13);
           buffer.writeUInt8(sign);
           buffer.writeUInt64LE(value);
-          return buffer.writeUInt32LE(0x00000000);
+          buffer.writeUInt32LE(0x00000000);
         } else {
           buffer.writeUInt8(17);
           buffer.writeUInt8(sign);
           buffer.writeUInt64LE(value);
           buffer.writeUInt32LE(0x00000000);
-          return buffer.writeUInt32LE(0x00000000);
+          buffer.writeUInt32LE(0x00000000);
         }
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -548,15 +548,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.MoneyN.id);
-      return buffer.writeUInt8(4);
+      buffer.writeUInt8(4);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(4);
-        return buffer.writeInt32LE(parameter.value * 10000);
+        buffer.writeInt32LE(parameter.value * 10000);
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -585,16 +585,16 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.IntN.id);
-      return buffer.writeUInt8(8);
+      buffer.writeUInt8(8);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         const val = typeof parameter.value !== 'number' ? parameter.value : parseInt(parameter.value);
         buffer.writeUInt8(8);
-        return buffer.writeInt64LE(val);
+        buffer.writeInt64LE(val);
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -639,15 +639,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
-      return buffer.writeInt32LE(parameter.length);
+      buffer.writeInt32LE(parameter.length);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeInt32LE(parameter.length);
-        return buffer.writeBuffer(parameter.value);
+        buffer.writeBuffer(parameter.value);
       } else {
-        return buffer.writeInt32LE(parameter.length);
+        buffer.writeInt32LE(parameter.length);
       }
     },
 
@@ -684,16 +684,16 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(typeByName.Text.id);
-      return buffer.writeInt32LE(parameter.length);
+      buffer.writeInt32LE(parameter.length);
     },
 
     writeParameterData: function(buffer, parameter) {
       buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
       if (parameter.value != null) {
         buffer.writeInt32LE(parameter.length);
-        return buffer.writeString(parameter.value.toString(), 'ascii');
+        buffer.writeString(parameter.value.toString(), 'ascii');
       } else {
-        return buffer.writeInt32LE(parameter.length);
+        buffer.writeInt32LE(parameter.length);
       }
     },
 
@@ -727,15 +727,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer) {
       buffer.writeUInt8(typeByName.UniqueIdentifierN.id);
-      return buffer.writeUInt8(0x10);
+      buffer.writeUInt8(0x10);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt8(0x10);
-        return buffer.writeBuffer(new Buffer(guidParser.guidToArray(parameter.value)));
+        buffer.writeBuffer(new Buffer(guidParser.guidToArray(parameter.value)));
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -845,25 +845,25 @@ const TYPE = module.exports.TYPE = {
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
       if (parameter.length <= this.maximumLength) {
-        return buffer.writeUInt16LE(this.maximumLength);
+        buffer.writeUInt16LE(this.maximumLength);
       } else {
-        return buffer.writeUInt16LE(MAX);
+        buffer.writeUInt16LE(MAX);
       }
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         if (parameter.length <= this.maximumLength) {
-          return buffer.writeUsVarbyte(parameter.value);
+          buffer.writeUsVarbyte(parameter.value);
         } else {
-          return buffer.writePLPBody(parameter.value);
+          buffer.writePLPBody(parameter.value);
         }
       } else {
         if (parameter.length <= this.maximumLength) {
-          return buffer.writeUInt16LE(NULL);
+          buffer.writeUInt16LE(NULL);
         } else {
           buffer.writeUInt32LE(0xFFFFFFFF);
-          return buffer.writeUInt32LE(0xFFFFFFFF);
+          buffer.writeUInt32LE(0xFFFFFFFF);
         }
       }
     },
@@ -926,22 +926,22 @@ const TYPE = module.exports.TYPE = {
       } else {
         buffer.writeUInt16LE(MAX);
       }
-      return buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
+      buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         if (parameter.length <= this.maximumLength) {
-          return buffer.writeUsVarbyte(parameter.value, 'ascii');
+          buffer.writeUsVarbyte(parameter.value, 'ascii');
         } else {
-          return buffer.writePLPBody(parameter.value, 'ascii');
+          buffer.writePLPBody(parameter.value, 'ascii');
         }
       } else {
         if (parameter.length <= this.maximumLength) {
-          return buffer.writeUInt16LE(NULL);
+          buffer.writeUInt16LE(NULL);
         } else {
           buffer.writeUInt32LE(0xFFFFFFFF);
-          return buffer.writeUInt32LE(0xFFFFFFFF);
+          buffer.writeUInt32LE(0xFFFFFFFF);
         }
       }
     },
@@ -990,15 +990,15 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
-      return buffer.writeUInt16LE(parameter.length);
+      buffer.writeUInt16LE(parameter.length);
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         buffer.writeUInt16LE(parameter.length);
-        return buffer.writeBuffer(parameter.value.slice(0, Math.min(parameter.length, this.maximumLength)));
+        buffer.writeBuffer(parameter.value.slice(0, Math.min(parameter.length, this.maximumLength)));
       } else {
-        return buffer.writeUInt16LE(NULL);
+        buffer.writeUInt16LE(NULL);
       }
     },
 
@@ -1056,14 +1056,14 @@ const TYPE = module.exports.TYPE = {
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
       buffer.writeUInt16LE(parameter.length);
-      return buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
+      buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
-        return buffer.writeUsVarbyte(parameter.value, 'ascii');
+        buffer.writeUsVarbyte(parameter.value, 'ascii');
       } else {
-        return buffer.writeUInt16LE(NULL);
+        buffer.writeUInt16LE(NULL);
       }
     },
 
@@ -1128,22 +1128,22 @@ const TYPE = module.exports.TYPE = {
       } else {
         buffer.writeUInt16LE(MAX);
       }
-      return buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
+      buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
         if (parameter.length <= this.maximumLength) {
-          return buffer.writeUsVarbyte(parameter.value, 'ucs2');
+          buffer.writeUsVarbyte(parameter.value, 'ucs2');
         } else {
-          return buffer.writePLPBody(parameter.value, 'ucs2');
+          buffer.writePLPBody(parameter.value, 'ucs2');
         }
       } else {
         if (parameter.length <= this.maximumLength) {
-          return buffer.writeUInt16LE(NULL);
+          buffer.writeUInt16LE(NULL);
         } else {
           buffer.writeUInt32LE(0xFFFFFFFF);
-          return buffer.writeUInt32LE(0xFFFFFFFF);
+          buffer.writeUInt32LE(0xFFFFFFFF);
         }
       }
     },
@@ -1205,14 +1205,14 @@ const TYPE = module.exports.TYPE = {
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
       buffer.writeUInt16LE(parameter.length * 2);
-      return buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
+      buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00]));
     },
 
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
-        return buffer.writeUsVarbyte(parameter.value, 'ucs2');
+        buffer.writeUsVarbyte(parameter.value, 'ucs2');
       } else {
-        return buffer.writeUInt16LE(NULL);
+        buffer.writeUInt16LE(NULL);
       }
     },
 
@@ -1275,7 +1275,7 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
-      return buffer.writeUInt8(parameter.scale);
+      buffer.writeUInt8(parameter.scale);
     },
 
     writeParameterData: function(buffer, parameter, options) {
@@ -1298,19 +1298,19 @@ const TYPE = module.exports.TYPE = {
           case 1:
           case 2:
             buffer.writeUInt8(3);
-            return buffer.writeUInt24LE(timestamp);
+            buffer.writeUInt24LE(timestamp);
           case 3:
           case 4:
             buffer.writeUInt8(4);
-            return buffer.writeUInt32LE(timestamp);
+            buffer.writeUInt32LE(timestamp);
           case 5:
           case 6:
           case 7:
             buffer.writeUInt8(5);
-            return buffer.writeUInt40LE(timestamp);
+            buffer.writeUInt40LE(timestamp);
         }
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -1341,20 +1341,20 @@ const TYPE = module.exports.TYPE = {
     },
 
     writeTypeInfo: function(buffer) {
-      return buffer.writeUInt8(this.id);
+      buffer.writeUInt8(this.id);
     },
 
     writeParameterData: function(buffer, parameter, options) {
       if (parameter.value != null) {
         buffer.writeUInt8(3);
         if (options.useUTC) {
-          return buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
+          buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
         } else {
           const dstDiff = -(parameter.value.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000;
-          return buffer.writeUInt24LE(Math.floor((+parameter.value - YEAR_ONE + dstDiff) / 86400000));
+          buffer.writeUInt24LE(Math.floor((+parameter.value - YEAR_ONE + dstDiff) / 86400000));
         }
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -1411,7 +1411,7 @@ const TYPE = module.exports.TYPE = {
 
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
-      return buffer.writeUInt8(parameter.scale);
+      buffer.writeUInt8(parameter.scale);
     },
 
     writeParameterData: function(buffer, parameter, options) {
@@ -1448,13 +1448,13 @@ const TYPE = module.exports.TYPE = {
             buffer.writeUInt40LE(timestamp);
         }
         if (options.useUTC) {
-          return buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
+          buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
         } else {
           const dstDiff = -(parameter.value.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000;
-          return buffer.writeUInt24LE(Math.floor((+parameter.value - YEAR_ONE + dstDiff) / 86400000));
+          buffer.writeUInt24LE(Math.floor((+parameter.value - YEAR_ONE + dstDiff) / 86400000));
         }
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
 
@@ -1507,7 +1507,7 @@ const TYPE = module.exports.TYPE = {
     },
     writeTypeInfo: function(buffer, parameter) {
       buffer.writeUInt8(this.id);
-      return buffer.writeUInt8(parameter.scale);
+      buffer.writeUInt8(parameter.scale);
     },
     writeParameterData: function(buffer, parameter) {
       if (parameter.value != null) {
@@ -1540,9 +1540,9 @@ const TYPE = module.exports.TYPE = {
             buffer.writeUInt40LE(timestamp);
         }
         buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
-        return buffer.writeInt16LE(offset);
+        buffer.writeInt16LE(offset);
       } else {
-        return buffer.writeUInt8(0);
+        buffer.writeUInt8(0);
       }
     },
     validate: function(value) {

--- a/src/instance-lookup.js
+++ b/src/instance-lookup.js
@@ -44,7 +44,7 @@ class InstanceLookup {
 
     const onTimeout = () => {
       sender.cancel();
-      return makeAttempt();
+      makeAttempt();
     };
 
     const makeAttempt = () => {
@@ -56,26 +56,27 @@ class InstanceLookup {
         sender.execute((err, message) => {
           clearTimeout(timer);
           if (err) {
-            return callback('Failed to lookup instance on ' + server + ' - ' + err.message);
+            callback('Failed to lookup instance on ' + server + ' - ' + err.message);
+            return;
           } else {
             message = message.toString('ascii', MYSTERY_HEADER_LENGTH);
             const port = this.parseBrowserResponse(message, instanceName);
 
             if (port) {
-              return callback(undefined, port);
+              callback(undefined, port);
             } else {
-              return callback('Port for ' + instanceName + ' not found in ' + message);
+              callback('Port for ' + instanceName + ' not found in ' + message);
             }
           }
         });
 
-        return timer = setTimeout(onTimeout, timeout);
+        timer = setTimeout(onTimeout, timeout);
       } else {
-        return callback('Failed to get response from SQL Server Browser on ' + server);
+        callback('Failed to get response from SQL Server Browser on ' + server);
       }
     };
 
-    return makeAttempt();
+    makeAttempt();
   }
 
   parseBrowserResponse(response, instanceName) {

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -177,7 +177,7 @@ module.exports = class MessageIO extends EventEmitter {
 
   logPacket(direction, packet) {
     this.debug.packet(direction, packet);
-    return this.debug.data(packet);
+    this.debug.data(packet);
   }
 
   // Temporarily suspends the flow of incoming packets.

--- a/src/packet.js
+++ b/src/packet.js
@@ -62,7 +62,7 @@ class Packet {
   }
 
   setLength() {
-    return this.buffer.writeUInt16BE(this.buffer.length, OFFSET.Length);
+    this.buffer.writeUInt16BE(this.buffer.length, OFFSET.Length);
   }
 
   length() {
@@ -76,7 +76,7 @@ class Packet {
     } else {
       status &= 0xFF - STATUS.RESETCONNECTION;
     }
-    return this.buffer.writeUInt8(status, OFFSET.Status);
+    this.buffer.writeUInt8(status, OFFSET.Status);
   }
 
   last(last) {

--- a/src/prelogin-payload.js
+++ b/src/prelogin-payload.js
@@ -86,7 +86,7 @@ module.exports = class PreloginPayload {
       optionDataOffset += option.data.length;
     }
 
-    return this.data.writeUInt8(TOKEN.TERMINATOR, optionOffset);
+    this.data.writeUInt8(TOKEN.TERMINATOR, optionOffset);
   }
 
   createVersionOption() {
@@ -168,7 +168,7 @@ module.exports = class PreloginPayload {
   }
 
   extractVersion(offset) {
-    return this.version = {
+    this.version = {
       major: this.data.readUInt8(offset + 0),
       minor: this.data.readUInt8(offset + 1),
       patch: this.data.readUInt8(offset + 2),
@@ -179,20 +179,20 @@ module.exports = class PreloginPayload {
 
   extractEncryption(offset) {
     this.encryption = this.data.readUInt8(offset);
-    return this.encryptionString = encryptByValue[this.encryption];
+    this.encryptionString = encryptByValue[this.encryption];
   }
 
   extractInstance(offset) {
-    return this.instance = this.data.readUInt8(offset);
+    this.instance = this.data.readUInt8(offset);
   }
 
   extractThreadId(offset) {
-    return this.threadId = this.data.readUInt32BE(offset);
+    this.threadId = this.data.readUInt32BE(offset);
   }
 
   extractMars(offset) {
     this.mars = this.data.readUInt8(offset);
-    return this.marsString = marsByValue[this.mars];
+    this.marsString = marsByValue[this.mars];
   }
 
   toString(indent) {

--- a/src/request.js
+++ b/src/request.js
@@ -85,7 +85,7 @@ module.exports = class Request extends EventEmitter {
       scale: options.scale
     };
     this.parameters.push(parameter);
-    return this.parametersByName[name] = parameter;
+    this.parametersByName[name] = parameter;
   }
 
   // TODO: `type` must be a valid TDS value type
@@ -94,7 +94,7 @@ module.exports = class Request extends EventEmitter {
       options = {};
     }
     options.output = true;
-    return this.addParameter(name, type, value, options);
+    this.addParameter(name, type, value, options);
   }
 
   makeParamsParameter(parameters: Parameter[]) {
@@ -129,7 +129,7 @@ module.exports = class Request extends EventEmitter {
       const parameter = this.originalParameters[i];
       this.parameters.push(parameter);
     }
-    return this.sqlTextOrProcedure = 'sp_executesql';
+    this.sqlTextOrProcedure = 'sp_executesql';
   }
 
   transformIntoPrepareRpc() {
@@ -140,11 +140,11 @@ module.exports = class Request extends EventEmitter {
     this.addParameter('stmt', TYPES.NVarChar, this.sqlTextOrProcedure);
     this.sqlTextOrProcedure = 'sp_prepare';
     this.preparing = true;
-    return this.on('returnValue', (name, value) => {
+    this.on('returnValue', (name, value) => {
       if (name === 'handle') {
-        return this.handle = value;
+        this.handle = value;
       } else {
-        return this.error = RequestError('Tedious > Unexpected output parameter ' + name + ' from sp_prepare');
+        this.error = RequestError(`Tedious > Unexpected output parameter ${name} from sp_prepare`);
       }
     });
   }
@@ -152,7 +152,7 @@ module.exports = class Request extends EventEmitter {
   transformIntoUnprepareRpc() {
     this.parameters = [];
     this.addParameter('handle', TYPES.Int, this.handle);
-    return this.sqlTextOrProcedure = 'sp_unprepare';
+    this.sqlTextOrProcedure = 'sp_unprepare';
   }
 
   transformIntoExecuteRpc(parameters: { [string]: mixed }) {
@@ -169,7 +169,7 @@ module.exports = class Request extends EventEmitter {
       return;
     }
 
-    return this.sqlTextOrProcedure = 'sp_execute';
+    this.sqlTextOrProcedure = 'sp_execute';
   }
 
   validateParameters() {

--- a/src/tracking-buffer/writable-tracking-buffer.js
+++ b/src/tracking-buffer/writable-tracking-buffer.js
@@ -44,7 +44,7 @@ module.exports = class WritableTrackingBuffer {
     const length = buffer.length;
     this.makeRoomFor(length);
     buffer.copy(this.buffer, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   makeRoomFor(requiredLength) {
@@ -54,9 +54,9 @@ module.exports = class WritableTrackingBuffer {
         while (size < requiredLength) {
           size *= 2;
         }
-        return this.newBuffer(size);
+        this.newBuffer(size);
       } else {
-        return this.newBuffer(requiredLength);
+        this.newBuffer(requiredLength);
       }
     }
   }
@@ -65,32 +65,32 @@ module.exports = class WritableTrackingBuffer {
     const buffer = this.buffer.slice(0, this.position);
     this.compositeBuffer = Buffer.concat([this.compositeBuffer, buffer]);
     this.buffer = (size === 0) ? ZERO_LENGTH_BUFFER : new Buffer(size).fill(0);
-    return this.position = 0;
+    this.position = 0;
   }
 
   writeUInt8(value: number) {
     const length = 1;
     this.makeRoomFor(length);
     this.buffer.writeUInt8(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeUInt16LE(value: number) {
     const length = 2;
     this.makeRoomFor(length);
     this.buffer.writeUInt16LE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeUShort(value: number) {
-    return this.writeUInt16LE(value);
+    this.writeUInt16LE(value);
   }
 
   writeUInt16BE(value: number) {
     const length = 2;
     this.makeRoomFor(length);
     this.buffer.writeUInt16BE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeUInt24LE(value: number) {
@@ -99,86 +99,86 @@ module.exports = class WritableTrackingBuffer {
     this.buffer[this.position + 2] = (value >>> 16) & 0xff;
     this.buffer[this.position + 1] = (value >>> 8) & 0xff;
     this.buffer[this.position] = value & 0xff;
-    return this.position += length;
+    this.position += length;
   }
 
   writeUInt32LE(value: number) {
     const length = 4;
     this.makeRoomFor(length);
     this.buffer.writeUInt32LE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeInt64LE(value: number) {
     const buf = bigint.numberToInt64LE(value);
-    return this.copyFrom(buf);
+    this.copyFrom(buf);
   }
 
   writeUInt32BE(value: number) {
     const length = 4;
     this.makeRoomFor(length);
     this.buffer.writeUInt32BE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeUInt40LE(value: number) {
     // inspired by https://github.com/dpw/node-buffer-more-ints
     this.writeInt32LE(value & -1);
-    return this.writeUInt8(Math.floor(value * SHIFT_RIGHT_32));
+    this.writeUInt8(Math.floor(value * SHIFT_RIGHT_32));
   }
 
   writeUInt64LE(value: number) {
     this.writeInt32LE(value & -1);
-    return this.writeUInt32LE(Math.floor(value * SHIFT_RIGHT_32));
+    this.writeUInt32LE(Math.floor(value * SHIFT_RIGHT_32));
   }
 
   writeInt8(value: number) {
     const length = 1;
     this.makeRoomFor(length);
     this.buffer.writeInt8(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeInt16LE(value: number) {
     const length = 2;
     this.makeRoomFor(length);
     this.buffer.writeInt16LE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeInt16BE(value: number) {
     const length = 2;
     this.makeRoomFor(length);
     this.buffer.writeInt16BE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeInt32LE(value: number) {
     const length = 4;
     this.makeRoomFor(length);
     this.buffer.writeInt32LE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeInt32BE(value: number) {
     const length = 4;
     this.makeRoomFor(length);
     this.buffer.writeInt32BE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeFloatLE(value: number) {
     const length = 4;
     this.makeRoomFor(length);
     this.buffer.writeFloatLE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeDoubleLE(value: number) {
     const length = 8;
     this.makeRoomFor(length);
     this.buffer.writeDoubleLE(value, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeString(value: string, encoding: ?Encoding) {
@@ -190,20 +190,18 @@ module.exports = class WritableTrackingBuffer {
     this.makeRoomFor(length);
 
     // $FlowFixMe https://github.com/facebook/flow/pull/5398
-    const bytesWritten = this.buffer.write(value, this.position, encoding);
+    this.buffer.write(value, this.position, encoding);
     this.position += length;
-
-    return bytesWritten;
   }
 
   writeBVarchar(value: string, encoding: ?Encoding) {
     this.writeUInt8(value.length);
-    return this.writeString(value, encoding);
+    this.writeString(value, encoding);
   }
 
   writeUsVarchar(value: string, encoding: ?Encoding) {
     this.writeUInt16LE(value.length);
-    return this.writeString(value, encoding);
+    this.writeString(value, encoding);
   }
 
   // TODO: Figure out what types are passed in other than `Buffer`
@@ -222,12 +220,12 @@ module.exports = class WritableTrackingBuffer {
     this.writeUInt16LE(length);
 
     if (value instanceof Buffer) {
-      return this.writeBuffer(value);
+      this.writeBuffer(value);
     } else {
       this.makeRoomFor(length);
       // $FlowFixMe https://github.com/facebook/flow/pull/5398
       this.buffer.write(value, this.position, encoding);
-      return this.position += length;
+      this.position += length;
     }
   }
 
@@ -264,18 +262,18 @@ module.exports = class WritableTrackingBuffer {
     }
 
     // PLP_TERMINATOR (no more chunks).
-    return this.writeUInt32LE(0);
+    this.writeUInt32LE(0);
   }
 
   writeBuffer(value: Buffer) {
     const length = value.length;
     this.makeRoomFor(length);
     value.copy(this.buffer, this.position);
-    return this.position += length;
+    this.position += length;
   }
 
   writeMoney(value: number) {
     this.writeInt32LE(Math.floor(value * SHIFT_RIGHT_32));
-    return this.writeInt32LE(value & -1);
+    this.writeInt32LE(value & -1);
   }
 };


### PR DESCRIPTION
While working on adding flow type information to the `tedious` source code, some CoffeeScript leftovers started to get in the way. 😞 

One of the leftovers from the conversion are stray `return` statements. In CoffeeScript, the last statement in a function was implicitly and automatically used as the return value of the function. This is really annoying when adding types to functions, as that means functions can have different result types depending on the execution path taken through the function. Even more annoying when we consider the fact that many of these functions were not supposed to have a return value in the first place (and the `return` statement generated by CoffeeScript returned useless information).

This gets rid of many of these return statements, cleaning up the code and paving the way for adding type information later. 👍