### PR TITLE
chore: Add `depd@1.1.2`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-runtime": "^6.26.0",
     "big-number": "0.3.1",
     "bl": "^1.2.0",
+    "depd": "^1.1.2",
     "iconv-lite": "^0.4.11",
     "readable-stream": "^2.2.6",
     "sprintf": "0.1.5"


### PR DESCRIPTION
I want to pull in `depd` to allow us to deprecate uses of `tedious` that will change in the future.