### PR TITLE
Remove tls.createSecurePair usage, closes #515

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "big-number": "0.3.1",
     "bl": "^1.2.0",
     "depd": "^1.1.2",
+    "duplexpair": "1.0.1",
     "iconv-lite": "^0.4.11",
     "readable-stream": "^2.2.6",
     "sprintf-js": "^1.1.1",

--- a/test/integration/connection-retry-test.js
+++ b/test/integration/connection-retry-test.js
@@ -74,8 +74,6 @@ exports['connection retry tests'] = {
     const config = getConfig();
     config.options.connectTimeout = config.options.connectionRetryInterval / 2;
 
-    const clock = this.sinon.useFakeTimers();
-
     test.expect(1);
 
     this.sinon.stub(TransientErrorLookup.prototype, 'isTransientError', (error) => {
@@ -88,17 +86,11 @@ exports['connection retry tests'] = {
       test.ok(false);
     });
 
-    connection.on('errorMessage', () => {
-      // Forward clock past connectTimeout which is less than retry interval.
-      clock.tick(config.options.connectTimeout + 1);
-    });
-
     connection.on('connect', (err) => {
       test.ok(err);
     });
 
     connection.on('end', (info) => {
-      clock.restore();
       test.done();
     });
   },


### PR DESCRIPTION
The changes replace `tls.createSecurePair` with `TLSSocket & DuplexPair` on Node 8 and newer.

Some notes:
- Node 6 & 7 crashes on `TLSSocket` when a `DuplexPair` socket passed to the constructor. Therefore the old `tls.createSecurePair` is still used for anything before Node 8.
- ~~the Sinon fake timers used in `connection-retry-test.js` somehow break `DuplexPair` internally, the bytes just aren't passed through it. Removing the timer faking does not cause the tests to fail when using an encrypted connection, but it does cause a failure when using an unencrypted connection (so probably just based on luck regarding timing). Any ideas how to address this? Use the fake timers if the connection used is unencrypted? Or maybe debug the root cause further?~~ Faking just `setTimeout` seems to fix `DuplexPair`.