### PR TITLE
 feature: Deprecate data type aliases.

### DIFF
--- a/src/data-type.js
+++ b/src/data-type.js
@@ -1,3 +1,5 @@
+const deprecate = require('depd')('tedious');
+
 const Null = require('./data-types/null');
 const TinyInt = require('./data-types/tinyint');
 const Bit = require('./data-types/bit');
@@ -14,7 +16,7 @@ const SmallMoney = require('./data-types/smallmoney');
 const BigInt = require('./data-types/bigint');
 const Image = require('./data-types/image');
 const Text = require('./data-types/text');
-const UniqueIdentifierN = require('./data-types/uniqueidentifiern');
+const UniqueIdentifier = require('./data-types/uniqueidentifier');
 const IntN = require('./data-types/intn');
 const NText = require('./data-types/ntext');
 const BitN = require('./data-types/bitn');
@@ -30,15 +32,15 @@ const Char = require('./data-types/char');
 const NVarChar = require('./data-types/nvarchar');
 const NChar = require('./data-types/nchar');
 const Xml = require('./data-types/xml');
-const TimeN = require('./data-types/timen');
-const DateN = require('./data-types/daten');
-const DateTime2N = require('./data-types/datetime2n');
-const DateTimeOffsetN = require('./data-types/datetimeoffsetn');
+const Time = require('./data-types/time');
+const Date = require('./data-types/date');
+const DateTime2 = require('./data-types/datetime2');
+const DateTimeOffset = require('./data-types/datetimeoffset');
 const UDT = require('./data-types/udt');
 const TVP = require('./data-types/tvp');
 const Variant = require('./data-types/sql-variant');
 
-const TYPE = module.exports.TYPE = {
+module.exports.TYPE = {
   [Null.id]: Null,
   [TinyInt.id]: TinyInt,
   [Bit.id]: Bit,
@@ -55,7 +57,7 @@ const TYPE = module.exports.TYPE = {
   [BigInt.id]: BigInt,
   [Image.id]: Image,
   [Text.id]: Text,
-  [UniqueIdentifierN.id]: UniqueIdentifierN,
+  [UniqueIdentifier.id]: UniqueIdentifier,
   [IntN.id]: IntN,
   [NText.id]: NText,
   [BitN.id]: BitN,
@@ -71,29 +73,76 @@ const TYPE = module.exports.TYPE = {
   [NVarChar.id]: NVarChar,
   [NChar.id]: NChar,
   [Xml.id]: Xml,
-  [TimeN.id]: TimeN,
-  [DateN.id]: DateN,
-  [DateTime2N.id]: DateTime2N,
-  [DateTimeOffsetN.id]: DateTimeOffsetN,
+  [Time.id]: Time,
+  [Date.id]: Date,
+  [DateTime2.id]: DateTime2,
+  [DateTimeOffset.id]: DateTimeOffset,
   [UDT.id]: UDT,
   [TVP.id]: TVP,
   [Variant.id]: Variant,
 };
 
-const typeByName = module.exports.typeByName = {};
+const typeByName = module.exports.typeByName = {
+  Null,
+  TinyInt,
+  Bit,
+  SmallInt,
+  Int,
+  SmallDateTime,
+  Real,
+  Money,
+  DateTime,
+  Float,
+  Decimal,
+  Numeric,
+  SmallMoney,
+  BigInt,
+  Image,
+  Text,
+  UniqueIdentifier,
+  NText,
+  VarBinary,
+  VarChar,
+  Binary,
+  Char,
+  NVarChar,
+  NChar,
+  Xml,
+  Time,
+  Date,
+  DateTime2,
+  DateTimeOffset,
+  UDT,
+  TVP,
+  Variant,
 
-for (const id in TYPE) {
-  const type = TYPE[id];
-  typeByName[type.name] = type;
-  if ((type.aliases != null) && type.aliases instanceof Array) {
-    const ref = type.aliases;
-    const len = ref.length;
+  // These are all internal and should not be used directly.
+  IntN,
+  BitN,
+  FloatN,
+  MoneyN,
+  DateTimeN,
+  DecimalN,
+  NumericN,
 
-    for (let i = 0; i < len; i++) {
-      const alias = ref[i];
-      if (!typeByName[alias]) {
-        typeByName[alias] = type;
-      }
-    }
-  }
-}
+  // These are all deprecated aliases.
+  DateN: Date,
+  DateTimeOffsetN: DateTimeOffset,
+  DateTime2N: DateTime2,
+  TimeN: Time,
+  UniqueIdentifierN: UniqueIdentifier,
+};
+
+[
+  ['DateN', 'Date'],
+  ['DateTimeOffsetN', 'DateTimeOffset'],
+  ['DateTime2N', 'DateTime2'],
+  ['TimeN', 'Time'],
+  ['UniqueIdentifierN', 'UniqueIdentifier']
+].forEach(function([alias, name]) {
+  deprecate.property(typeByName, alias, 'The `' + alias + '` data type alias is deprecated, please use `' + name + '` instead.');
+});
+
+['IntN', 'BitN', 'FloatN', 'MoneyN', 'DateTimeN', 'DecimalN', 'NumericN'].forEach(function(name) {
+  deprecate.property(typeByName, name, 'The `' + name + '` data type is internal and will be removed.');
+});

--- a/src/data-types/date.js
+++ b/src/data-types/date.js
@@ -4,8 +4,7 @@ const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
 module.exports = {
   id: 0x28,
   type: 'DATEN',
-  name: 'DateN',
-  aliases: ['Date'],
+  name: 'Date',
   dataLengthLength: 1,
   fixedDataLength: 3,
 

--- a/src/data-types/datetime2.js
+++ b/src/data-types/datetime2.js
@@ -4,8 +4,7 @@ const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
 module.exports = {
   id: 0x2A,
   type: 'DATETIME2N',
-  name: 'DateTime2N',
-  aliases: ['DateTime2'],
+  name: 'DateTime2',
   hasScale: true,
   dataLengthLength: 1,
 

--- a/src/data-types/datetimeoffset.js
+++ b/src/data-types/datetimeoffset.js
@@ -1,11 +1,11 @@
+const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
+
 module.exports = {
-  id: 0x29,
-  type: 'TIMEN',
-  name: 'TimeN',
-  aliases: ['Time'],
+  id: 0x2B,
+  type: 'DATETIMEOFFSETN',
+  name: 'DateTimeOffset',
   hasScale: true,
   dataLengthLength: 1,
-
   dataLengthFromScale: function(scale) {
     switch (scale) {
       case 0:
@@ -21,11 +21,9 @@ module.exports = {
         return 5;
     }
   },
-
   declaration: function(parameter) {
-    return 'time(' + (this.resolveScale(parameter)) + ')';
+    return 'datetimeoffset(' + (this.resolveScale(parameter)) + ')';
   },
-
   resolveScale: function(parameter) {
     if (parameter.scale != null) {
       return parameter.scale;
@@ -35,58 +33,55 @@ module.exports = {
       return 7;
     }
   },
-
   writeTypeInfo: function(buffer, parameter) {
     buffer.writeUInt8(this.id);
     buffer.writeUInt8(parameter.scale);
   },
-
-  writeParameterData: function(buffer, parameter, options) {
+  writeParameterData: function(buffer, parameter) {
     if (parameter.value != null) {
       const time = new Date(+parameter.value);
+      time.setUTCFullYear(1970);
+      time.setUTCMonth(0);
+      time.setUTCDate(1);
 
-      let timestamp;
-      if (options.useUTC) {
-        timestamp = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
-      } else {
-        timestamp = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
-      }
-
-      timestamp = timestamp * Math.pow(10, parameter.scale - 3);
+      let timestamp = time * Math.pow(10, parameter.scale - 3);
       timestamp += (parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0) * Math.pow(10, parameter.scale);
       timestamp = Math.round(timestamp);
 
+      const offset = -parameter.value.getTimezoneOffset();
       switch (parameter.scale) {
         case 0:
         case 1:
         case 2:
-          buffer.writeUInt8(3);
+          buffer.writeUInt8(8);
           buffer.writeUInt24LE(timestamp);
+          break;
         case 3:
         case 4:
-          buffer.writeUInt8(4);
+          buffer.writeUInt8(9);
           buffer.writeUInt32LE(timestamp);
+          break;
         case 5:
         case 6:
         case 7:
-          buffer.writeUInt8(5);
+          buffer.writeUInt8(10);
           buffer.writeUInt40LE(timestamp);
       }
+      buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
+      buffer.writeInt16LE(offset);
     } else {
       buffer.writeUInt8(0);
     }
   },
-
   validate: function(value) {
     if (value == null) {
       return null;
     }
-    if (value instanceof Date) {
-      return value;
+    if (!(value instanceof Date)) {
+      value = Date.parse(value);
     }
-    value = Date.parse(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid time.');
+      return new TypeError('Invalid date.');
     }
     return value;
   }

--- a/src/data-types/time.js
+++ b/src/data-types/time.js
@@ -1,12 +1,10 @@
-const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
-
 module.exports = {
-  id: 0x2B,
-  type: 'DATETIMEOFFSETN',
-  name: 'DateTimeOffsetN',
-  aliases: ['DateTimeOffset'],
+  id: 0x29,
+  type: 'TIMEN',
+  name: 'Time',
   hasScale: true,
   dataLengthLength: 1,
+
   dataLengthFromScale: function(scale) {
     switch (scale) {
       case 0:
@@ -22,9 +20,11 @@ module.exports = {
         return 5;
     }
   },
+
   declaration: function(parameter) {
-    return 'datetimeoffset(' + (this.resolveScale(parameter)) + ')';
+    return 'time(' + (this.resolveScale(parameter)) + ')';
   },
+
   resolveScale: function(parameter) {
     if (parameter.scale != null) {
       return parameter.scale;
@@ -34,55 +34,58 @@ module.exports = {
       return 7;
     }
   },
+
   writeTypeInfo: function(buffer, parameter) {
     buffer.writeUInt8(this.id);
     buffer.writeUInt8(parameter.scale);
   },
-  writeParameterData: function(buffer, parameter) {
+
+  writeParameterData: function(buffer, parameter, options) {
     if (parameter.value != null) {
       const time = new Date(+parameter.value);
-      time.setUTCFullYear(1970);
-      time.setUTCMonth(0);
-      time.setUTCDate(1);
 
-      let timestamp = time * Math.pow(10, parameter.scale - 3);
+      let timestamp;
+      if (options.useUTC) {
+        timestamp = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
+      } else {
+        timestamp = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
+      }
+
+      timestamp = timestamp * Math.pow(10, parameter.scale - 3);
       timestamp += (parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0) * Math.pow(10, parameter.scale);
       timestamp = Math.round(timestamp);
 
-      const offset = -parameter.value.getTimezoneOffset();
       switch (parameter.scale) {
         case 0:
         case 1:
         case 2:
-          buffer.writeUInt8(8);
+          buffer.writeUInt8(3);
           buffer.writeUInt24LE(timestamp);
-          break;
         case 3:
         case 4:
-          buffer.writeUInt8(9);
+          buffer.writeUInt8(4);
           buffer.writeUInt32LE(timestamp);
-          break;
         case 5:
         case 6:
         case 7:
-          buffer.writeUInt8(10);
+          buffer.writeUInt8(5);
           buffer.writeUInt40LE(timestamp);
       }
-      buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
-      buffer.writeInt16LE(offset);
     } else {
       buffer.writeUInt8(0);
     }
   },
+
   validate: function(value) {
     if (value == null) {
       return null;
     }
-    if (!(value instanceof Date)) {
-      value = Date.parse(value);
+    if (value instanceof Date) {
+      return value;
     }
+    value = Date.parse(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid date.');
+      return new TypeError('Invalid time.');
     }
     return value;
   }

--- a/src/data-types/uniqueidentifier.js
+++ b/src/data-types/uniqueidentifier.js
@@ -3,8 +3,7 @@ const guidParser = require('../guid-parser');
 module.exports = {
   id: 0x24,
   type: 'GUIDN',
-  name: 'UniqueIdentifierN',
-  aliases: ['UniqueIdentifier'],
+  name: 'UniqueIdentifier',
   dataLengthLength: 1,
 
   declaration: function() {

--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -240,28 +240,28 @@ function valueParse(parser, metaData, options, callback) {
               return readDateTime(parser, options.useUTC, callback);
           }
 
-        case 'TimeN':
+        case 'Time':
           if (dataLength === 0) {
             return callback(null);
           } else {
             return readTime(parser, dataLength, metaData.scale, options.useUTC, callback);
           }
 
-        case 'DateN':
+        case 'Date':
           if (dataLength === 0) {
             return callback(null);
           } else {
             return readDate(parser, options.useUTC, callback);
           }
 
-        case 'DateTime2N':
+        case 'DateTime2':
           if (dataLength === 0) {
             return callback(null);
           } else {
             return readDateTime2(parser, dataLength, metaData.scale, options.useUTC, callback);
           }
 
-        case 'DateTimeOffsetN':
+        case 'DateTimeOffset':
           if (dataLength === 0) {
             return callback(null);
           } else {
@@ -300,7 +300,7 @@ function valueParse(parser, metaData, options, callback) {
             });
           }
 
-        case 'UniqueIdentifierN':
+        case 'UniqueIdentifier':
           switch (dataLength) {
             case 0:
               return callback(null);

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -133,10 +133,10 @@ exports.money = function(test) {
   execSql(test, TYPES.Money, 956455842.4566);
 };
 
-exports.uniqueIdentifierN = function(test) {
+exports.uniqueIdentifier = function(test) {
   execSql(
     test,
-    TYPES.UniqueIdentifierN,
+    TYPES.UniqueIdentifier,
     '01234567-89AB-CDEF-0123-456789ABCDEF'
   );
 };
@@ -508,10 +508,10 @@ exports.outputFloat = function(test) {
   execSqlOutput(test, TYPES.Float, 9654.2546456567565767644);
 };
 
-exports.outputUniqueIdentifierN = function(test) {
+exports.outputUniqueIdentifier = function(test) {
   execSqlOutput(
     test,
-    TYPES.UniqueIdentifierN,
+    TYPES.UniqueIdentifier,
     '01234567-89AB-CDEF-0123-456789ABCDEF'
   );
 };
@@ -840,7 +840,7 @@ var execSql = function(test, type, value, tdsVersion, options, expectedValue) {
       test.strictEqual(columns[0].value.getTime(), expectedValue.getTime());
     } else if (type === TYPES.BigInt) {
       test.strictEqual(columns[0].value, expectedValue.toString());
-    } else if (type === TYPES.UniqueIdentifierN) {
+    } else if (type === TYPES.UniqueIdentifier) {
       test.deepEqual(columns[0].value, expectedValue);
     } else {
       test.strictEqual(columns[0].value, expectedValue);
@@ -897,7 +897,7 @@ var execSqlOutput = function(test, type, value, expectedValue) {
       test.strictEqual(returnValue.getTime(), expectedValue.getTime());
     } else if (type === TYPES.BigInt) {
       test.strictEqual(returnValue, expectedValue.toString());
-    } else if (type === TYPES.UniqueIdentifierN) {
+    } else if (type === TYPES.UniqueIdentifier) {
       test.deepEqual(returnValue, expectedValue);
     } else {
       test.strictEqual(returnValue, expectedValue);

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -1,3 +1,11 @@
+const MoneyN = require('../../../src/data-types/moneyn');
+const Money = require('../../../src/data-types/money');
+const SmallMoney = require('../../../src/data-types/smallmoney');
+const IntN = require('../../../src/data-types/intn');
+const FloatN = require('../../../src/data-types/floatn');
+const DateTimeN = require('../../../src/data-types/datetimen');
+const NumericN = require('../../../src/data-types/numericn');
+
 var Parser = require('../../../src/token/stream-parser');
 var dataTypeByName = require('../../../src/data-type').typeByName;
 var WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
@@ -110,12 +118,12 @@ module.exports.float = function(test) {
 
 module.exports.money = function(test) {
   var colMetaData = [
-    { type: dataTypeByName.SmallMoney },
-    { type: dataTypeByName.Money },
-    { type: dataTypeByName.MoneyN },
-    { type: dataTypeByName.MoneyN },
-    { type: dataTypeByName.MoneyN },
-    { type: dataTypeByName.MoneyN }
+    { type: SmallMoney },
+    { type: Money },
+    { type: MoneyN },
+    { type: MoneyN },
+    { type: MoneyN },
+    { type: MoneyN }
   ];
   var value = 123.456;
   var valueLarge = 123456789012345.11;
@@ -498,18 +506,18 @@ module.exports.varBinaryMaxUnknownLength = function(test) {
 
 module.exports.intN = function(test) {
   var colMetaData = [
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN },
-    { type: dataTypeByName.IntN }
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN },
+    { type: IntN }
   ];
 
   var buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -644,8 +652,8 @@ module.exports.intN = function(test) {
 
 module.exports.guidN = function(test) {
   var colMetaData = [
-    { type: dataTypeByName.UniqueIdentifierN },
-    { type: dataTypeByName.UniqueIdentifierN }
+    { type: dataTypeByName.UniqueIdentifier },
+    { type: dataTypeByName.UniqueIdentifier }
   ];
 
   var buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -691,9 +699,9 @@ module.exports.guidN = function(test) {
 
 module.exports.floatN = function(test) {
   var colMetaData = [
-    { type: dataTypeByName.FloatN },
-    { type: dataTypeByName.FloatN },
-    { type: dataTypeByName.FloatN }
+    { type: FloatN },
+    { type: FloatN },
+    { type: FloatN }
   ];
 
   var buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -771,7 +779,7 @@ module.exports.datetime = function(test) {
 };
 
 module.exports.datetimeN = function(test) {
-  var colMetaData = [{ type: dataTypeByName.DateTimeN }];
+  var colMetaData = [{ type: DateTimeN }];
 
   var buffer = new WritableTrackingBuffer(0, 'ucs2');
   buffer.writeUInt8(0xd1);
@@ -793,7 +801,7 @@ module.exports.datetimeN = function(test) {
 module.exports.numeric4Bytes = function(test) {
   var colMetaData = [
     {
-      type: dataTypeByName.NumericN,
+      type: NumericN,
       precision: 3,
       scale: 1
     }
@@ -823,7 +831,7 @@ module.exports.numeric4Bytes = function(test) {
 module.exports.numeric4BytesNegative = function(test) {
   var colMetaData = [
     {
-      type: dataTypeByName.NumericN,
+      type: NumericN,
       precision: 3,
       scale: 1
     }
@@ -853,7 +861,7 @@ module.exports.numeric4BytesNegative = function(test) {
 module.exports.numeric8Bytes = function(test) {
   var colMetaData = [
     {
-      type: dataTypeByName.NumericN,
+      type: NumericN,
       precision: 13,
       scale: 1
     }
@@ -884,7 +892,7 @@ module.exports.numeric8Bytes = function(test) {
 module.exports.numeric12Bytes = function(test) {
   var colMetaData = [
     {
-      type: dataTypeByName.NumericN,
+      type: NumericN,
       precision: 23,
       scale: 1
     }
@@ -916,7 +924,7 @@ module.exports.numeric12Bytes = function(test) {
 module.exports.numeric16Bytes = function(test) {
   var colMetaData = [
     {
-      type: dataTypeByName.NumericN,
+      type: NumericN,
       precision: 33,
       scale: 1
     }
@@ -954,7 +962,7 @@ module.exports.numeric16Bytes = function(test) {
 module.exports.numericNull = function(test) {
   var colMetaData = [
     {
-      type: dataTypeByName.NumericN,
+      type: NumericN,
       precision: 3,
       scale: 1
     }


### PR DESCRIPTION
This deprecates data type aliases  `DateN`, `DateTime2N`, `DateTimeOffsetN`, `TimeN` and `UniqueIdentifierN` in favor of their 'proper' names.

* `DateN` -> `Date`
* `DateTime2N` -> `DateTime2`
* `DateTimeOffsetN` -> `DateTimeOffset`
* `TimeN` -> `Time`
* `UniqueIdentifierN` -> `UniqueIdentifier`

The deprecated aliases will be removed in the next major version, together with types that shouldn't have been exposed in the first place (`IntN`, `BitN`, `DateTimeN`, etc.).