### PR TITLE
feat: deprecations around `options.encrypt`

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -348,6 +348,8 @@ class Connection extends EventEmitter {
       if (config.options.encrypt != undefined) {
         deprecateNonBooleanConfigValue('options.encrypt', config.options.encrypt);
         this.config.options.encrypt = config.options.encrypt;
+      } else {
+        deprecate('The default value for `options.encrypt` will change from `false` to `true`. Please pass `false` explicitly if you want to retain current behaviour.');
       }
       deprecateNullConfigValue('options.encrypt', config.options.encrypt);
 

--- a/test/unit/connection-config-validation.js
+++ b/test/unit/connection-config-validation.js
@@ -3,7 +3,7 @@ const Connection = require('../../src/tedious').Connection;
 exports['Connection configuration validation'] = {
   setUp: function(done) {
     this.config = {};
-    this.config.options = {};
+    this.config.options = { encrypt: false };
     this.config.server = 'localhost';
     done();
   },

--- a/test/unit/tedious-test.js
+++ b/test/unit/tedious-test.js
@@ -28,6 +28,7 @@ exports.connectionDoesNotModifyPassedConfig = function(test) {
     userName: 'sa',
     password: 'sapwd',
     options: {
+      encrypt: false,
       port: 1234,
       cryptoCredentialsDetails: {
         ciphers: 'RC4-MD5'


### PR DESCRIPTION
This change ~deprecates the passing of non-`boolean` values for `options.encrypt`, and also~ deprecates relying on the current default value for `options.encrypt`.

This is in preparation for future breaking changes. See #694 for more information.