### PR TITLE
chore: re-enable default `verifyConditions` for `semantic-release`

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,5 @@
     "plugins": [
       "transform-runtime"
     ]
-  },
-  "release": {
-    "verifyConditions": "semantic-release/src/lib/plugin-noop"
   }
 }


### PR DESCRIPTION
I disabled `verifyConditions` some while ago to make `semantic-release` work with Travis build stages.

There's now build in support for Travis build stages. Also `plugin-noop` does not exist anymore and causes `semantic-release` to fail right now. 😞 