### PR TITLE
doc: Correct the UDP port number used by SQL Server Browser.

### DIFF
--- a/api-connection.html
+++ b/api-connection.html
@@ -105,7 +105,7 @@ var connection = new Connection(config);
       <dd>
         The instance name to connect to.
         The SQL Server Browser service must be running on the database server,
-        and UDP port 1444 on the database server must be reachable.
+        and UDP port 1434 on the database server must be reachable.
         <br/>
         (no default)
         <br/>


### PR DESCRIPTION
Correcting the typo in port number used by SQL Server Browser Service to [1434 ](https://technet.microsoft.com/en-us/library/ms181087(v=sql.105).aspx#Anchor_0):smile: 
