### PR TITLE
fix: `options.port` should not be `0` or `65536`

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -294,7 +294,7 @@ class Connection extends EventEmitter {
       }
 
       if (config.options.port) {
-        if (config.options.port < 0 || config.options.port > 65536) {
+        if (config.options.port <= 0 || config.options.port >= 65536) {
           throw new RangeError('Port must be > 0 and < 65536');
         }
 


### PR DESCRIPTION
Both of these values can't be used for ports and will cause failures further down when we try to actually establish a connection.