### PR TITLE
fix: error should not expose all port numbers and instance names of SQL Server

### DIFF
--- a/src/instance-lookup.js
+++ b/src/instance-lookup.js
@@ -65,7 +65,7 @@ class InstanceLookup {
             if (port) {
               callback(undefined, port);
             } else {
-              callback('Port for ' + instanceName + ' not found in ' + message);
+              callback('Port for ' + instanceName + ' not found in ' + options.server);
             }
           }
         });

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -264,6 +264,25 @@ exports['instanceLookup functional unit tests'] = {
       clock.restore();
       test.done();
     });
+  },
+
+  'incorrect instanceName': function(test) {
+    const message = 'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
+      'ServerName;WINDOWS2;InstanceName;YYYYYYYYYY;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
+    this.senderExecuteStub.callsArgWithAsync(0, null, message);
+    this.parseStub
+      .withArgs(message, this.options.instanceName);
+
+    this.instanceLookup.instanceLookup(this.options, (error, port) => {
+      test.ok(error.indexOf('XXXXXXXXXX') == -1);
+      test.ok(error.indexOf('YYYYYYYYYY') == -1);
+      test.strictEqual(port, undefined);
+
+      test.ok(this.createSenderStub.calledOnce);
+      test.ok(this.senderExecuteStub.calledOnce);
+      test.ok(this.parseStub.calledOnce);
+      test.done();
+    });
   }
 };
 


### PR DESCRIPTION
Using incorrect/non-existent instanceName in config throws an error that lists all the instance names (in that SQL Server), along with their port number and few other details. This PR alters the error to contain just the Server name.

Current message looks like:
> Port for <> not found in ServerName;Rx:<>;InstanceName;<instance1>;IsClustered;<>;Version;<>;tcp;<>;;ServerName;Rx:<>;InstanceName;<instance2>;IsClustered;<>;Version;<>;tcp;<>; ......