### PR TITLE
feat: replace recursive callbacks with async await

### DIFF
--- a/src/message-io.js
+++ b/src/message-io.js
@@ -62,14 +62,30 @@ module.exports = class MessageIO extends EventEmitter {
     this.packetStream = new ReadablePacketStream();
     this.packetStream.on('data', (packet) => {
       this.logPacket('Received', packet);
-      this.emit('data', packet.data());
-      if (packet.isLast()) {
-        this.emit('message');
+
+      if (this.asyncAwaitFlow) {
+        this.emit('data', packet);
+      }
+      else {
+        this.emit('data', packet.data());
+        if (packet.isLast()) {
+          this.emit('message');
+        }
       }
     });
 
     this.socket.pipe(this.packetStream);
     this.packetDataSize = this._packetSize - packetHeaderLength;
+  }
+
+  setAsyncAwaitFlow(asyncAwaitFlow) {
+    this.asyncAwaitFlow = asyncAwaitFlow;
+  }
+
+  isLastPacket(packet) {
+    if (packet.isLast()) {
+      this.emit('message');
+    }
   }
 
   packetSize(packetSize) {

--- a/src/token/token-stream-parser.js
+++ b/src/token/token-stream-parser.js
@@ -28,6 +28,9 @@ class Parser extends EventEmitter {
     this.parser.on('drain', () => {
       this.emit('drain');
     });
+    this.parser.on('checkIfLastPacket', () => {
+      this.emit('checkIfLastPacket');
+    });
   }
 
   // Returns false to apply backpressure.

--- a/src/tracking-buffer/bigint.js
+++ b/src/tracking-buffer/bigint.js
@@ -39,26 +39,29 @@ function invert(array) {
   }
 }
 
-module.exports.convertLEBytesToString = convertLEBytesToString;
-function convertLEBytesToString(buffer) {
-  const array = Array.prototype.slice.call(buffer, 0, buffer.length);
-  if (isZero(array)) {
-    return '0';
-  } else {
-    let sign;
-    if (array[array.length - 1] & 0x80) {
-      sign = '-';
-      invert(array);
+module.exports.convertLEBytesToString = _convertLEBytesToString;
+function _convertLEBytesToString(buffer) {
+  return new Promise((resolve, reject) => {
+    const array = Array.prototype.slice.call(buffer, 0, buffer.length);
+    if (isZero(array)) {
+      resolve ('0');
     } else {
-      sign = '';
+      let sign;
+      if (array[array.length - 1] & 0x80) {
+        sign = '-';
+        invert(array);
+      } else {
+        sign = '';
+      }
+      let result = '';
+      while (!isZero(array)) {
+        const t = getNextRemainder(array);
+        result = t + result;
+      }
+      resolve(sign + result);
     }
-    let result = '';
-    while (!isZero(array)) {
-      const t = getNextRemainder(array);
-      result = t + result;
-    }
-    return sign + result;
-  }
+  });
+
 }
 
 module.exports.numberToInt64LE = numberToInt64LE;


### PR DESCRIPTION
This PR replaces portion of parser to use async/await instead of nested callbacks. This is an initial draft to gather feedback. It works for int/smallint/bigint/tinyint and varchar types, we can extend it based on initial review. CI tests are expected to fail as I have commented out support for other data-types.

This initial draft works for `SENT_CLIENT_REQUEST` state, so I had to add few extra functions to switch between callbacks and async/await while entering and exiting this state.