### PR TITLE
Feature: initialise `Connection` without opening a connection and open function exposed

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -68,7 +68,7 @@ function deprecateNonNumberConfigValue(optionName, value) {
 }
 
 class Connection extends EventEmitter {
-  constructor(config) {
+  constructor(config, openConnection = true) {
     super();
 
     if (!config) {
@@ -488,7 +488,9 @@ class Connection extends EventEmitter {
     this.createTokenStreamParser();
     this.inTransaction = false;
     this.transactionDescriptors = [new Buffer([0, 0, 0, 0, 0, 0, 0, 0])];
-    this.transitionTo(this.STATE.CONNECTING);
+    if (openConnection) {
+      this.open();
+    }
 
     if (this.config.options.tdsVersion < '7_2') {
       // 'beginTransaction', 'commitTransaction' and 'rollbackTransaction'
@@ -508,6 +510,10 @@ class Connection extends EventEmitter {
       REDIRECT: 1,
       RETRY: 2
     };
+  }
+
+  open() {
+    this.transitionTo(this.STATE.CONNECTING);
   }
 
   close() {

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -139,6 +139,45 @@ exports.connectByPort = function(test) {
   });
 };
 
+exports.connectByPortOpeningConnectionManually = function(test) {
+  var config = getConfig();
+
+  if ((config.options != null ? config.options.port : undefined) == null) {
+    // Config says don't do this test (probably because ports are dynamic).
+    console.log('Skipping connectByPort test');
+    test.done();
+    return;
+  }
+
+  test.expect(2);
+
+  const connection = new Connection(config, false);
+  connection.open();
+
+  connection.on('connect', function(err) {
+    test.ifError(err);
+
+    connection.close();
+  });
+
+  connection.on('end', function(info) {
+    test.done();
+  });
+
+  connection.on('databaseChange', function(database) {
+    test.strictEqual(database, config.options.database);
+  });
+
+  connection.on('infoMessage', function(info) {
+    //console.log("#{info.number} : #{info.message}")
+  });
+
+  return connection.on('debug', function(text) {
+    //console.log(text)
+  });
+};
+
+
 exports.connectByInstanceName = function(test) {
   if (!getInstanceName()) {
     // Config says don't do this test (probably because SQL Server Browser is not available).
@@ -178,6 +217,46 @@ exports.connectByInstanceName = function(test) {
   });
 };
 
+exports.connectByInstanceNameOpeningConnectionManually = function(test) {
+  if (!getInstanceName()) {
+    // Config says don't do this test (probably because SQL Server Browser is not available).
+    console.log('Skipping connectByInstanceName test');
+    test.done();
+    return;
+  }
+
+  test.expect(2);
+
+  var config = getConfig();
+  delete config.options.port;
+  config.options.instanceName = getInstanceName();
+
+  const connection = new Connection(config, false);
+  connection.open();
+
+  connection.on('connect', function(err) {
+    test.ifError(err);
+
+    connection.close();
+  });
+
+  connection.on('end', function(info) {
+    test.done();
+  });
+
+  connection.on('databaseChange', function(database) {
+    test.strictEqual(database, config.options.database);
+  });
+
+  connection.on('infoMessage', function(info) {
+    //console.log("#{info.number} : #{info.message}")
+  });
+
+  return connection.on('debug', function(text) {
+    //console.log(text)
+  });
+};
+
 exports.connectByInvalidInstanceName = function(test) {
   if (!getInstanceName()) {
     // Config says don't do this test (probably because SQL Server Browser is not available).
@@ -193,6 +272,42 @@ exports.connectByInvalidInstanceName = function(test) {
   config.options.instanceName = `${getInstanceName()}X`;
 
   var connection = new Connection(config);
+
+  connection.on('connect', function(err) {
+    test.ok(err);
+
+    connection.close();
+  });
+
+  connection.on('end', function(info) {
+    test.done();
+  });
+
+  connection.on('infoMessage', function(info) {
+    //console.log("#{info.number} : #{info.message}")
+  });
+
+  return connection.on('debug', function(text) {
+    //console.log(text)
+  });
+};
+
+exports.connectByInvalidInstanceNameOpeningConnectionManually = function(test) {
+  if (!getInstanceName()) {
+    // Config says don't do this test (probably because SQL Server Browser is not available).
+    console.log('Skipping connectByInvalidInstanceName test');
+    test.done();
+    return;
+  }
+
+  test.expect(1);
+
+  var config = getConfig();
+  delete config.options.port;
+  config.options.instanceName = `${getInstanceName()}X`;
+
+  const connection = new Connection(config, false);
+  connection.open();
 
   connection.on('connect', function(err) {
     test.ok(err);


### PR DESCRIPTION
Hi guys, love the library just starting integrating with it the create full blown node package for SQL server. You probably will see me expanding on this library a lot. 

The feature i have put in is the ability to create a `Connection` instance without creating a connection straight away. I know there is times when i may want to create the connection instance but not open the connection until i physically have too. I think we should allow people to make that judgement in when there database connection is going to be opened. This ability gives flexibility for people who want to do both.

I wanted this because my library is going to work similar theme of c# `system.data` where you have to physically open the connection when you want too. I made it a optional parameter with default true so it will not break anything for anyone. 

I also want to add an `open` method to your types library (if you have one).

Thanks guys!
Josh