### PR TITLE
Prepare for a gradual move to `mocha`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.26.0",
     "benchmark": "^2.1.0",
+    "chai": "^4.1.2",
     "eslint": "^3.19.0",
     "flow-bin": "^0.72.0",
     "mitm": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint": "^3.19.0",
     "flow-bin": "^0.72.0",
     "mitm": "^1.3.2",
+    "mocha": "^5.2.0",
     "nodeunit": "^0.11.0",
     "rimraf": "^2.6.1",
     "semantic-release": "^12.2.5",

--- a/package.json
+++ b/package.json
@@ -73,9 +73,9 @@
   },
   "scripts": {
     "lint": "eslint src test && flow",
-    "test": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer",
-    "test-integration": "nodeunit --reporter minimal test/setup.js test/integration/",
-    "test-all": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
+    "test": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer && mocha test/unit/**/*-test.js",
+    "test-integration": "nodeunit --reporter minimal test/setup.js test/integration/ && mocha test/integration/**/*-test.js",
+    "test-all": "nodeunit --reporter minimal test/setup.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/ && mocha test/**/*-test.js",
     "build": "rimraf lib && babel src --out-dir lib",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/test/integration/binary-insert-test.js
+++ b/test/integration/binary-insert-test.js
@@ -1,7 +1,9 @@
 const Connection = require('../../src/connection');
 const Request = require('../../src/request');
-const fs = require('fs');
 const TYPES = require('../../src/data-type').typeByName;
+
+const fs = require('fs');
+const { assert } = require('chai');
 
 const config = JSON.parse(
   fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')
@@ -17,52 +19,54 @@ config.options.debug = {
 
 config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
-exports.insertBinary = function(test) {
-  const connection = new Connection(config);
-  connection.on('end', function() {
-    test.done();
+describe('inserting binary data', function() {
+  beforeEach(function(done) {
+    this.connection = new Connection(config);
+    this.connection.on('connect', done);
   });
 
-  connection.on('connect', function(err) {
-    test.ifError(err);
+  afterEach(function(done) {
+    if (!this.connection.closed) {
+      this.connection.on('end', done);
+      this.connection.close();
+    } else {
+      done();
+    }
+  });
 
-    const request = new Request(
-      'CREATE TABLE #test ([data] binary(4))',
-      function(err) {
-        test.ifError(err);
-
-        const request = new Request(
-          'INSERT INTO #test ([data]) VALUES (@p1)',
-          function(err) {
-            test.ifError(err);
-
-            const request = new Request('SELECT [data] FROM #test', function(
-              err
-            ) {
-              test.ifError(err);
-              connection.close();
-            });
-
-            request.on('row', function(columns) {
-              test.strictEqual(
-                columns[0].value.toString('hex'),
-                new Buffer([0x12, 0x34, 0x00, 0xce]).toString('hex')
-              );
-            });
-
-            connection.execSql(request);
-          }
-        );
-
-        request.addParameter(
-          'p1',
-          TYPES.Binary,
-          new Buffer([0x12, 0x34, 0x00, 0xce])
-        );
-        connection.execSql(request);
+  it('should correctly insert the binary data', function(done) {
+    const request = new Request('CREATE TABLE #test ([data] binary(4))', (err) => {
+      if (err) {
+        return done(err);
       }
-    );
 
-    connection.execSqlBatch(request);
+      const request = new Request('INSERT INTO #test ([data]) VALUES (@p1)', (err) => {
+        if (err) {
+          return done(err);
+        }
+
+        const values = [];
+        const request = new Request('SELECT [data] FROM #test', (err) => {
+          if (err) {
+            return done(err);
+          }
+
+          assert.deepEqual(values, [new Buffer([0x12, 0x34, 0x00, 0xce])]);
+
+          done();
+        });
+
+        request.on('row', function(columns) {
+          values.push(columns[0].value);
+        });
+
+        this.connection.execSql(request);
+      });
+
+      request.addParameter('p1', TYPES.Binary, new Buffer([0x12, 0x34, 0x00, 0xce]));
+      this.connection.execSql(request);
+    });
+
+    this.connection.execSqlBatch(request);
   });
-};
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require test/setup.js

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,1 +1,3 @@
 require('babel-register');
+
+global.describe = function() {};


### PR DESCRIPTION
`nodeunit` is officially deprecated and unsupported, since a few days. See https://github.com/caolan/nodeunit#deprecated-project for more information.

This, and the fact that `nodeunit` has been causing me grief for a long time now with it's weird behaviour, brought me back to look into a replacement. This is a second attempt to move us to `mocha` and `chai`, but this time it's inspired by a comment made by @Hadis-Fard over in https://github.com/tediousjs/tedious/pull/150#issuecomment-357076448. As suggested there, this PR lays the foundation for a gradual migration from `nodeunit` to `mocha`.

I included one example conversion for reference.