### PR TITLE
datetime fix method undefined errors

### DIFF
--- a/src/data-types/date.js
+++ b/src/data-types/date.js
@@ -1,5 +1,6 @@
-const YEAR_ONE = new Date(2000, 0, -730118);
-const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
+const DateTimeN = require('./datetimen');
+const YEAR_ONE = DateTimeN.YEAR_ONE;
+const UTC_YEAR_ONE = DateTimeN.UTC_YEAR_ONE;
 
 module.exports = {
   id: 0x28,
@@ -18,28 +19,17 @@ module.exports = {
 
   writeParameterData: function(buffer, parameter, options) {
     if (parameter.value != null) {
+      const _date = new Date(parameter.value);
       buffer.writeUInt8(3);
       if (options.useUTC) {
-        buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
+        buffer.writeUInt24LE(Math.floor((+_date - UTC_YEAR_ONE) / 86400000));
       } else {
-        const dstDiff = -(parameter.value.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000;
-        buffer.writeUInt24LE(Math.floor((+parameter.value - YEAR_ONE + dstDiff) / 86400000));
+        const dstDiff = -(_date.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000;
+        buffer.writeUInt24LE(Math.floor((+_date - YEAR_ONE + dstDiff) / 86400000));
       }
     } else {
       buffer.writeUInt8(0);
     }
   },
-
-  validate: function(value) {
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Date)) {
-      value = Date.parse(value);
-    }
-    if (isNaN(value)) {
-      return new TypeError('Invalid date.');
-    }
-    return value;
-  }
+  validate: DateTimeN.validate
 };

--- a/src/data-types/datetime.js
+++ b/src/data-types/datetime.js
@@ -1,7 +1,7 @@
 const DateTimeN = require('./datetimen');
 
-const EPOCH_DATE = new Date(1900, 0, 1);
-const UTC_EPOCH_DATE = new Date(Date.UTC(1900, 0, 1));
+const EPOCH_DATE = DateTimeN.EPOCH_DATE;
+const UTC_EPOCH_DATE = DateTimeN.UTC_EPOCH_DATE;
 
 module.exports = {
   id: 0x3D,
@@ -20,19 +20,20 @@ module.exports = {
   writeParameterData: function(buffer, parameter, options) {
     if (parameter.value != null) {
       let days, dstDiff, milliseconds, seconds, threeHundredthsOfSecond;
+      const _date = new Date(parameter.value);
       if (options.useUTC) {
-        days = Math.floor((parameter.value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
-        seconds = parameter.value.getUTCHours() * 60 * 60;
-        seconds += parameter.value.getUTCMinutes() * 60;
-        seconds += parameter.value.getUTCSeconds();
-        milliseconds = (seconds * 1000) + parameter.value.getUTCMilliseconds();
+        days = Math.floor((_date.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
+        seconds = _date.getUTCHours() * 60 * 60;
+        seconds += _date.getUTCMinutes() * 60;
+        seconds += _date.getUTCSeconds();
+        milliseconds = (seconds * 1000) + _date.getUTCMilliseconds();
       } else {
-        dstDiff = -(parameter.value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
-        days = Math.floor((parameter.value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
-        seconds = parameter.value.getHours() * 60 * 60;
-        seconds += parameter.value.getMinutes() * 60;
-        seconds += parameter.value.getSeconds();
-        milliseconds = (seconds * 1000) + parameter.value.getMilliseconds();
+        dstDiff = -(_date.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
+        days = Math.floor((_date.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
+        seconds = _date.getHours() * 60 * 60;
+        seconds += _date.getMinutes() * 60;
+        seconds += _date.getSeconds();
+        milliseconds = (seconds * 1000) + _date.getMilliseconds();
       }
 
       threeHundredthsOfSecond = milliseconds / (3 + (1 / 3));
@@ -46,17 +47,5 @@ module.exports = {
       buffer.writeUInt8(0);
     }
   },
-
-  validate: function(value) {
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Date)) {
-      value = Date.parse(value);
-    }
-    if (isNaN(value)) {
-      return new TypeError('Invalid date.');
-    }
-    return value;
-  }
+  validate: DateTimeN.validate
 };

--- a/src/data-types/datetime2.js
+++ b/src/data-types/datetime2.js
@@ -1,5 +1,6 @@
-const YEAR_ONE = new Date(2000, 0, -730118);
-const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
+const DateTimeN = require('./datetimen');
+const YEAR_ONE = DateTimeN.YEAR_ONE;
+const UTC_YEAR_ONE = DateTimeN.UTC_YEAR_ONE;
 
 module.exports = {
   id: 0x2A,
@@ -77,26 +78,14 @@ module.exports = {
           buffer.writeUInt40LE(timestamp);
       }
       if (options.useUTC) {
-        buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
+        buffer.writeUInt24LE(Math.floor((time - UTC_YEAR_ONE) / 86400000));
       } else {
-        const dstDiff = -(parameter.value.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000;
-        buffer.writeUInt24LE(Math.floor((+parameter.value - YEAR_ONE + dstDiff) / 86400000));
+        const dstDiff = -(time.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000;
+        buffer.writeUInt24LE(Math.floor((time - YEAR_ONE + dstDiff) / 86400000));
       }
     } else {
       buffer.writeUInt8(0);
     }
   },
-
-  validate: function(value) {
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Date)) {
-      value = Date.parse(value);
-    }
-    if (isNaN(value)) {
-      return new TypeError('Invalid date.');
-    }
-    return value;
-  }
+  validate: DateTimeN.validate
 };

--- a/src/data-types/datetimen.js
+++ b/src/data-types/datetimen.js
@@ -13,7 +13,7 @@ module.exports = {
       return null;
     }
     // do Date.parse internally and duplicate existing date instances
-    let _date = new Date(value);
+    const _date = new Date(value);
     if (isNaN(_date)) {
       return new TypeError('Invalid date.');
     }

--- a/src/data-types/datetimen.js
+++ b/src/data-types/datetimen.js
@@ -2,5 +2,22 @@ module.exports = {
   id: 0x6F,
   type: 'DATETIMN',
   name: 'DateTimeN',
-  dataLengthLength: 1
+  dataLengthLength: 1,
+  EPOCH_DATE: new Date(1900, 0, 1),
+  UTC_EPOCH_DATE: new Date(Date.UTC(1900, 0, 1)),
+  YEAR_ONE: new Date(2000, 0, -730118),
+  UTC_YEAR_ONE: Date.UTC(2000, 0, -730118),
+  // TODO null is not a Date instance: why does it return null (with type coercion in comparison)?
+  validate: function(value) {
+    if (value == null) {
+      return null;
+    }
+    // do Date.parse internally and duplicate existing date instances
+    let _date = new Date(value);
+    if (isNaN(_date)) {
+      return new TypeError('Invalid date.');
+    }
+
+    return _date;
+  }
 };

--- a/src/data-types/datetimeoffset.js
+++ b/src/data-types/datetimeoffset.js
@@ -1,4 +1,5 @@
-const UTC_YEAR_ONE = Date.UTC(2000, 0, -730118);
+const DateTimeN = require('./datetimen');
+const UTC_YEAR_ONE = DateTimeN.UTC_YEAR_ONE;
 
 module.exports = {
   id: 0x2B,
@@ -39,7 +40,8 @@ module.exports = {
   },
   writeParameterData: function(buffer, parameter) {
     if (parameter.value != null) {
-      const time = new Date(+parameter.value);
+      const _date = new Date(+parameter.value);
+      const time = new Date(_date);
       time.setUTCFullYear(1970);
       time.setUTCMonth(0);
       time.setUTCDate(1);
@@ -48,7 +50,7 @@ module.exports = {
       timestamp += (parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0) * Math.pow(10, parameter.scale);
       timestamp = Math.round(timestamp);
 
-      const offset = -parameter.value.getTimezoneOffset();
+      const offset = -_date.getTimezoneOffset();
       switch (parameter.scale) {
         case 0:
         case 1:
@@ -67,22 +69,11 @@ module.exports = {
           buffer.writeUInt8(10);
           buffer.writeUInt40LE(timestamp);
       }
-      buffer.writeUInt24LE(Math.floor((+parameter.value - UTC_YEAR_ONE) / 86400000));
+      buffer.writeUInt24LE(Math.floor((_date - UTC_YEAR_ONE) / 86400000));
       buffer.writeInt16LE(offset);
     } else {
       buffer.writeUInt8(0);
     }
   },
-  validate: function(value) {
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Date)) {
-      value = Date.parse(value);
-    }
-    if (isNaN(value)) {
-      return new TypeError('Invalid date.');
-    }
-    return value;
-  }
+  validate: DateTimeN.validate
 };

--- a/src/data-types/smalldatetime.js
+++ b/src/data-types/smalldatetime.js
@@ -1,7 +1,6 @@
 const DateTimeN = require('./datetimen');
-
-const EPOCH_DATE = new Date(1900, 0, 1);
-const UTC_EPOCH_DATE = new Date(Date.UTC(1900, 0, 1));
+const EPOCH_DATE = DateTimeN.EPOCH_DATE;
+const UTC_EPOCH_DATE = DateTimeN.UTC_EPOCH_DATE;
 
 module.exports = {
   id: 0x3A,
@@ -20,13 +19,14 @@ module.exports = {
   writeParameterData: function(buffer, parameter, options) {
     if (parameter.value != null) {
       let days, dstDiff, minutes;
+      const _date = new Date(parameter.value);
       if (options.useUTC) {
-        days = Math.floor((parameter.value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
-        minutes = (parameter.value.getUTCHours() * 60) + parameter.value.getUTCMinutes();
+        days = Math.floor((_date.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
+        minutes = (_date.getUTCHours() * 60) + _date.getUTCMinutes();
       } else {
-        dstDiff = -(parameter.value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
-        days = Math.floor((parameter.value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
-        minutes = (parameter.value.getHours() * 60) + parameter.value.getMinutes();
+        dstDiff = -(_date.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
+        days = Math.floor((_date.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
+        minutes = (_date.getHours() * 60) + _date.getMinutes();
       }
 
       buffer.writeUInt8(4);
@@ -37,20 +37,5 @@ module.exports = {
       buffer.writeUInt8(0);
     }
   },
-
-  validate: function(value) {
-    if (value == null) {
-      return null;
-    }
-
-    if (!(value instanceof Date)) {
-      value = Date.parse(value);
-    }
-
-    if (isNaN(value)) {
-      return new TypeError('Invalid date.');
-    }
-
-    return value;
-  }
+  validate: DateTimeN.validate
 };

--- a/src/data-types/time.js
+++ b/src/data-types/time.js
@@ -1,3 +1,5 @@
+const DateTimeN = require('./datetimen');
+
 module.exports = {
   id: 0x29,
   type: 'TIMEN',
@@ -77,18 +79,5 @@ module.exports = {
       buffer.writeUInt8(0);
     }
   },
-
-  validate: function(value) {
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Date) {
-      return value;
-    }
-    value = Date.parse(value);
-    if (isNaN(value)) {
-      return new TypeError('Invalid time.');
-    }
-    return value;
-  }
+  validate: DateTimeN.validate
 };


### PR DESCRIPTION
Resolves issues related to [Date and time types](http://tediousjs.github.io/tedious/api-datatypes.html) like #339 #608 #675 (possibly others) where methods were called on `parameter.value` that is not of the correct type and lacks the expected methods, throwing errors like `parameter.value.<method-name> is not a function`.

This could use more tests to cover the problems mentioned in the issues.