### PR TITLE
adds handling when socket closes and still in the process of connecting

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -952,11 +952,13 @@ class Connection extends EventEmitter {
 
   socketEnd() {
     this.debug.log('socket ended');
+    this.checkForAConnectState();
     this.transitionTo(this.STATE.FINAL);
   }
 
   socketClose() {
     this.debug.log('connection to ' + this.config.server + ':' + this.config.options.port + ' closed');
+    this.checkForAConnectState();
     if (this.state === this.STATE.REROUTING) {
       this.debug.log('Rerouting to ' + this.routingData.server + ':' + this.routingData.port);
       this.dispatchEvent('reconnect');
@@ -968,6 +970,12 @@ class Connection extends EventEmitter {
       this.dispatchEvent('retry');
     } else {
       this.transitionTo(this.STATE.FINAL);
+    }
+  }
+
+  checkForAConnectState() {
+    if (this.state === this.STATE.SENT_TLSSSLNEGOTIATION) {
+      this.emit('connect', ConnectionError('failed to successfully negotiate tls', 'ESOCKET'));
     }
   }
 


### PR DESCRIPTION
This is a fix for the issue: https://github.com/tediousjs/tedious/issues/590. The issue seems to happen intermittently and we determined that the socket would inexplicably close when in state SENT_TLSSSLNEGOTIATION. We only see this when using an Azure Database.

Not sure which branch I should be pulling into. Please let me know if there is anything I can do to move this along. This is a major issue for us and possibly others.