### PR TITLE
fix: datetime max millisecond issue

### DIFF
--- a/src/data-types/datetime.ts
+++ b/src/data-types/datetime.ts
@@ -39,6 +39,12 @@ const DateTime: DataType = {
       threeHundredthsOfSecond = milliseconds / (3 + (1 / 3));
       threeHundredthsOfSecond = Math.round(threeHundredthsOfSecond);
 
+      // 25920000 equals one day
+      if (threeHundredthsOfSecond === 25920000) {
+        days += 1;
+        threeHundredthsOfSecond = 0;
+      }
+
       buffer.writeUInt8(8);
       buffer.writeInt32LE(days);
 

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -608,9 +608,16 @@ describe('Parameterised Statements Test', function() {
     );
   });
 
-  // This test fails on the version of SQL Server in AppVeyor.
-  // exports.dateTimePrecision_9_day_flip = (test) ->
-  //  execSql(test, TYPES.DateTime, new Date('January 1, 1998 23:59:59.999'), null, null, new Date('January 2, 1998 00:00:00.000'))
+  it('should test date time precision_9 hr flip', function(done) {
+    execSql(
+      done,
+      TYPES.DateTime,
+      new Date('January 1, 1998 23:59:59.999'),
+      null,
+      null,
+      new Date('January 2, 1998 00:00:00.000')
+    );
+  });
 
   it('should test date time 2', function(done) {
     execSql(


### PR DESCRIPTION
Datetime round millisecond in nearest .xx3, .xx7, .xx0, when the ms is rounded to 000 in case of 23:59:59:999, day should be incremented. the issue manifest itself in useUTC true or false

Fixes: #755 