### PR TITLE
fix: improve handling of TLS errors

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -931,7 +931,7 @@ class Connection extends EventEmitter {
   }
 
   socketError(error) {
-    if (this.state === this.STATE.CONNECTING) {
+    if (this.state === this.STATE.CONNECTING || this.state === this.STATE.SENT_TLSSSLNEGOTIATION) {
       const message = `Failed to connect to ${this.config.server}:${this.config.options.port} - ${error.message}`;
       this.debug.log(message);
       this.emit('connect', ConnectionError(message, 'ESOCKET'));

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -113,6 +113,12 @@ module.exports = class MessageIO extends EventEmitter {
       this.sendMessage(TYPE.PRELOGIN, data);
     });
 
+    // If an error happens in the TLS layer, there is nothing we can do about it.
+    // Forward the error to the socket so the connection gets properly cleaned up.
+    this.securePair.cleartext.on('error', (err) => {
+      this.socket.destroy(err);
+    });
+
     // On Node >= 0.12, the encrypted stream automatically starts spewing out
     // data once we attach a `data` listener. But on Node <= 0.10.x, this is not
     // the case. We need to kick the cleartext stream once to get the

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -322,6 +322,26 @@ exports.encrypt = function(test) {
   });
 };
 
+exports['fails if no cipher can be negotiated'] = function(test) {
+  var config = getConfig();
+  config.options.encrypt = true;
+
+  // Do not allow any cipher to be used
+  config.options.cryptoCredentialsDetails = {
+    ciphers: '!ALL'
+  };
+
+  var connection = new Connection(config);
+  connection.on('connect', function(err) {
+    test.ok(err);
+    test.strictEqual(err.code, 'ESOCKET');
+  });
+
+  connection.on('end', function() {
+    test.done();
+  });
+};
+
 exports['does not emit error after connect timeout'] = function(test) {
   const config = getConfig();
   config.options.connectTimeout = 1;


### PR DESCRIPTION
This fixes an issue in the TLS negotiation code of `tedious` that has been around for quite some time. 😞I also think this is one of the issues that has been plagueing people that wanted to use `tedious` in combination with encrypted connections (as is required e.g. when connecting to Azure).

Errors happening in the TLS layer were basically not handled at all. Usually, unhandled `error` events cause an uncaught exception in node.js (and bring down the whole process), but it looks like that this is not happening on `SecurePair`/`TLSSocket` instances. 🤷‍♂️ In our cases, these unhandled errors caused the connection to just go into some weird blocking state and become unusable. This most likely also caused issues with connection pool libraries. 🤔 

Anyway, by listening to `error` events and forwarding them to the underlying network socket instance, errors in the TLS layer get bubbled up and handled correctly - the connection gets closed with an error.

A very simple test case that shows this behaviour is to connect to an SQL Server instance, but block any cipher from being used.