### PR TITLE
refactor: switch to a `Message` stream based architecture

### DIFF
--- a/src/incoming-message-stream.js
+++ b/src/incoming-message-stream.js
@@ -1,0 +1,86 @@
+// @flow
+
+const BufferList = require('bl');
+const { Transform } = require('readable-stream');
+
+const Message = require('./message');
+const { Packet, HEADER_LENGTH } = require('./packet');
+
+import type Debug from './debug';
+
+/**
+  IncomingMessageStream
+  Transform received TDS data into individual IncomingMessage streams.
+*/
+class IncomingMessageStream extends Transform {
+  debug: Debug;
+  bl: BufferList;
+  currentMessage: Message | typeof undefined;
+
+  constructor(debug: Debug) {
+    super({ readableObjectMode: true });
+
+    this.debug = debug;
+
+    this.currentMessage = undefined;
+    this.bl = new BufferList();
+  }
+
+  processBufferedData(callback: () => void) {
+    // The packet header is always 8 bytes of length.
+    while (this.bl.length >= HEADER_LENGTH) {
+      // Get the full packet length
+      const length = this.bl.readUInt16BE(2);
+
+      if (this.bl.length >= length) {
+        const data = this.bl.slice(0, length);
+        this.bl.consume(length);
+
+        // TODO: Get rid of creating `Packet` instances here.
+        const packet = new Packet(data);
+        this.debug.packet('Received', packet);
+        this.debug.data(packet);
+
+        let message = this.currentMessage;
+        if (message === undefined) {
+          message = new Message({ type: packet.type(), resetConnection: false });
+          this.push(message);
+        }
+
+        if (packet.isLast()) {
+          this.currentMessage = undefined;
+          // Wait until the current message was fully processed before we
+          // continue processing any remaining messages.
+          message.once('end', () => {
+            this.processBufferedData(callback);
+          });
+          message.end(packet.data());
+          return;
+        } else {
+          this.currentMessage = message;
+          // If too much data is buffering up in the
+          // current message, wait for it to drain.
+          if (!message.write(packet.data())) {
+            message.once('drain', () => {
+              this.processBufferedData(callback);
+            });
+            return;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+
+    // Not enough data to read the next packet. Stop here and wait for
+    // the next call to `_transform`.
+    callback();
+  }
+
+  _transform(chunk: Buffer, encoding: void, callback: () => void) {
+    this.bl.append(chunk);
+    this.processBufferedData(callback);
+  }
+}
+
+module.exports = IncomingMessageStream;

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -2,85 +2,40 @@ const tls = require('tls');
 const crypto = require('crypto');
 const DuplexPair = require('native-duplexpair');
 const EventEmitter = require('events').EventEmitter;
-const Transform = require('readable-stream').Transform;
 
-const Packet = require('./packet').Packet;
 const TYPE = require('./packet').TYPE;
-const packetHeaderLength = require('./packet').HEADER_LENGTH;
 
-class ReadablePacketStream extends Transform {
-  constructor() {
-    super({ objectMode: true });
-
-    this.buffer = new Buffer(0);
-    this.position = 0;
-  }
-
-  _transform(chunk, encoding, callback) {
-    if (this.position === this.buffer.length) {
-      // If we have fully consumed the previous buffer,
-      // we can just replace it with the new chunk
-      this.buffer = chunk;
-    } else {
-      // If we haven't fully consumed the previous buffer,
-      // we simply concatenate the leftovers and the new chunk.
-      this.buffer = Buffer.concat([
-        this.buffer.slice(this.position), chunk
-      ], (this.buffer.length - this.position) + chunk.length);
-    }
-
-    this.position = 0;
-
-    // The packet header is always 8 bytes of length.
-    while (this.buffer.length >= this.position + packetHeaderLength) {
-      // Get the full packet length
-      const length = this.buffer.readUInt16BE(this.position + 2);
-
-      if (this.buffer.length >= this.position + length) {
-        const data = this.buffer.slice(this.position, this.position + length);
-        this.position += length;
-        this.push(new Packet(data));
-      } else {
-        // Not enough data to provide the next packet. Stop here and wait for
-        // the next call to `_transform`.
-        break;
-      }
-    }
-
-    callback();
-  }
-}
+const Message = require('./message');
+const IncomingMessageStream = require('./incoming-message-stream');
+const OutgoingMessageStream = require('./outgoing-message-stream');
 
 module.exports = class MessageIO extends EventEmitter {
-  constructor(socket, _packetSize, debug) {
+  constructor(socket, packetSize, debug) {
     super();
 
     this.socket = socket;
-    this._packetSize = _packetSize;
     this.debug = debug;
 
     this.tlsNegotiationComplete = false;
 
-    this.packetStream = new ReadablePacketStream();
-    this.packetStream.on('data', (packet) => {
-      this.logPacket('Received', packet);
-      this.emit('data', packet.data());
-      if (packet.isLast()) {
-        this.emit('message');
-      }
+    this.incomingMessageStream = new IncomingMessageStream(this.debug);
+    this.incomingMessageStream.on('data', (message) => {
+      message.on('data', (chunk) => { this.emit('data', chunk); });
+      message.on('end', () => { this.emit('message'); });
     });
 
-    this.socket.pipe(this.packetStream);
-    this.packetDataSize = this._packetSize - packetHeaderLength;
+    this.outgoingMessageStream = new OutgoingMessageStream(this.debug, { packetSize: packetSize });
+
+    this.socket.pipe(this.incomingMessageStream);
+    this.outgoingMessageStream.pipe(this.socket);
   }
 
   packetSize(packetSize) {
     if (arguments.length > 0) {
-      this.debug.log('Packet size changed from ' + this._packetSize + ' to ' + packetSize);
-      this._packetSize = packetSize;
-      this.packetDataSize = this._packetSize - packetHeaderLength;
+      this.debug.log('Packet size changed from ' + this.outgoingMessageStream.packetSize + ' to ' + packetSize);
+      this.outgoingMessageStream.packetSize = packetSize;
     }
-    return this._packetSize;
+    return this.outgoingMessageStream.packetSize;
   }
 
   startTls(credentialsDetails, hostname, trustServerCertificate) {
@@ -115,16 +70,22 @@ module.exports = class MessageIO extends EventEmitter {
     });
 
     securePair.encrypted.on('data', (data) => {
-      this.sendMessage(TYPE.PRELOGIN, data);
+      this.sendMessage(TYPE.PRELOGIN, data, false);
     });
   }
 
   encryptAllFutureTraffic() {
-    this.socket.unpipe(this.packetStream);
     this.securePair.encrypted.removeAllListeners('data');
+
+    this.outgoingMessageStream.unpipe(this.socket);
+    this.socket.unpipe(this.incomingMessageStream);
+
     this.socket.pipe(this.securePair.encrypted);
     this.securePair.encrypted.pipe(this.socket);
-    this.securePair.cleartext.pipe(this.packetStream);
+
+    this.securePair.cleartext.pipe(this.incomingMessageStream);
+    this.outgoingMessageStream.pipe(this.securePair.cleartext);
+
     this.tlsNegotiationComplete = true;
   }
 
@@ -135,56 +96,18 @@ module.exports = class MessageIO extends EventEmitter {
   // TODO listen for 'drain' event when socket.write returns false.
   // TODO implement incomplete request cancelation (2.2.1.6)
   sendMessage(packetType, data, resetConnection) {
-    let numberOfPackets;
-    if (data) {
-      numberOfPackets = (Math.floor((data.length - 1) / this.packetDataSize)) + 1;
-    } else {
-      numberOfPackets = 1;
-      data = new Buffer(0);
-    }
-
-    for (let packetNumber = 0; packetNumber < numberOfPackets; packetNumber++) {
-      const payloadStart = packetNumber * this.packetDataSize;
-
-      let payloadEnd;
-      if (packetNumber < numberOfPackets - 1) {
-        payloadEnd = payloadStart + this.packetDataSize;
-      } else {
-        payloadEnd = data.length;
-      }
-
-      const packetPayload = data.slice(payloadStart, payloadEnd);
-
-      const packet = new Packet(packetType);
-      packet.last(packetNumber === numberOfPackets - 1);
-      packet.resetConnection(resetConnection);
-      packet.packetId(packetNumber + 1);
-      packet.addData(packetPayload);
-      this.sendPacket(packet);
-    }
-  }
-
-  sendPacket(packet) {
-    this.logPacket('Sent', packet);
-    if (this.securePair && this.tlsNegotiationComplete) {
-      this.securePair.cleartext.write(packet.buffer);
-    } else {
-      this.socket.write(packet.buffer);
-    }
-  }
-
-  logPacket(direction, packet) {
-    this.debug.packet(direction, packet);
-    this.debug.data(packet);
+    const message = new Message({ type: packetType, resetConnection: resetConnection });
+    message.end(data);
+    this.outgoingMessageStream.write(message);
   }
 
   // Temporarily suspends the flow of incoming packets.
   pause() {
-    this.packetStream.pause();
+    this.incomingMessageStream.pause();
   }
 
   // Resumes the flow of incoming packets.
   resume() {
-    this.packetStream.resume();
+    this.incomingMessageStream.resume();
   }
 };

--- a/src/message.js
+++ b/src/message.js
@@ -1,0 +1,17 @@
+// @flow
+
+const { PassThrough } = require('readable-stream');
+
+class Message extends PassThrough {
+  type: number;
+  resetConnection: boolean;
+
+  constructor({ type, resetConnection = false } : { type: number, resetConnection?: boolean }) {
+    super();
+
+    this.type = type;
+    this.resetConnection = resetConnection;
+  }
+}
+
+module.exports = Message;

--- a/src/outgoing-message-stream.js
+++ b/src/outgoing-message-stream.js
@@ -1,0 +1,88 @@
+// @flow
+
+const BufferList = require('bl');
+const { Duplex } = require('readable-stream');
+
+const { Packet, HEADER_LENGTH } = require('./packet');
+
+import type Debug from './debug';
+import type Message from './message';
+
+class OutgoingMessageStream extends Duplex {
+  packetSize: number;
+  debug: Debug;
+  bl: BufferList;
+
+  constructor(debug: Debug, { packetSize } : { packetSize: number }) {
+    super({ writableObjectMode: true });
+
+    this.packetSize = packetSize;
+    this.debug = debug;
+    this.bl = new BufferList();
+
+    // When the writable side is ended, push `null`
+    // to also end the readable side.
+    this.on('finish', () => {
+      this.push(null);
+    });
+  }
+
+  _write(message: Message, encoding: void, callback: (?Error) => void) {
+    const length = this.packetSize - HEADER_LENGTH;
+    let packetNumber = 0;
+
+    this.currentMessage = message;
+    this.currentMessage.on('data', (data) => {
+      this.bl.append(data);
+
+      while (this.bl.length > length) {
+        const data = this.bl.slice(0, length);
+        this.bl.consume(length);
+
+        // TODO: Get rid of creating `Packet` instances here.
+        const packet = new Packet(message.type);
+        packet.packetId(packetNumber += 1);
+        packet.resetConnection(message.resetConnection);
+        packet.addData(data);
+
+        this.debug.packet('Sent', packet);
+        this.debug.data(packet);
+
+        if (this.push(packet.buffer) === false) {
+          this.currentMessage.pause();
+        }
+      }
+    });
+
+    this.currentMessage.on('end', () => {
+      const data = this.bl.slice();
+      this.bl.consume(data.length);
+
+      // TODO: Get rid of creating `Packet` instances here.
+      const packet = new Packet(message.type);
+      packet.packetId(packetNumber += 1);
+      packet.resetConnection(message.resetConnection);
+      packet.last(true);
+      packet.addData(data);
+
+      this.debug.packet('Sent', packet);
+      this.debug.data(packet);
+
+      this.push(packet.buffer);
+
+      this.currentMessage = undefined;
+
+      callback();
+    });
+  }
+
+  _read(size: number) {
+    // If we do have a message, resume it and get data flowing.
+    // Otherwise, there is nothing to do.
+    if (this.currentMessage) {
+      this.currentMessage.resume();
+    }
+  }
+}
+
+module.exports = OutgoingMessageStream;

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -111,7 +111,7 @@ exports.testPausingRequestPausesTransforms = function(test) {
       request.pause();
 
       setTimeout(() => {
-        test.ok(this.connection.messageIo.packetStream.isPaused());
+        test.ok(this.connection.messageIo.incomingMessageStream.isPaused());
         test.ok(this.connection.tokenStreamParser.parser.isPaused());
 
         request.resume();

--- a/test/unit/incoming-message-stream-test.js
+++ b/test/unit/incoming-message-stream-test.js
@@ -1,0 +1,109 @@
+const BufferList = require('bl');
+const { assert } = require('chai');
+
+const IncomingMessageStream = require('../../src/incoming-message-stream');
+const Message = require('../../src/message');
+const Debug = require('../../src/debug');
+
+describe('IncomingMessageStream', function() {
+  it('extract messages from packet data', function(done) {
+    const packetData = new Buffer('test1234');
+    const packetHeader = new Buffer(8);
+
+    let offset = 0;
+    offset = packetHeader.writeUInt8(0x11, offset);
+    offset = packetHeader.writeUInt8(0x01, offset);
+    offset = packetHeader.writeUInt16BE(8 + packetData.length, offset);
+    offset = packetHeader.writeUInt16BE(0x0000, offset);
+    offset = packetHeader.writeUInt8(1, offset);
+    packetHeader.writeUInt8(0x00, offset);
+
+    const packet = Buffer.concat([packetHeader, packetData]);
+
+    const incoming = new IncomingMessageStream(new Debug());
+
+    incoming.on('data', function(message) {
+      assert.instanceOf(message, Message);
+      assert.strictEqual(message.type, 0x11);
+      assert.strictEqual(message.resetConnection, false);
+
+      const result = new BufferList(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.deepEqual(res, packetData);
+
+        done();
+      });
+
+      message.pipe(result);
+    });
+
+    incoming.end(packet);
+  });
+
+  it('streams packet data into the message as packets come in', function(done) {
+    const packetData = new Buffer('test1234');
+    const packetHeader = new Buffer(8);
+
+    let offset = 0;
+    offset = packetHeader.writeUInt8(0x11, offset);
+    offset = packetHeader.writeUInt8(0x00, offset);
+    offset = packetHeader.writeUInt16BE(8 + packetData.length, offset);
+    offset = packetHeader.writeUInt16BE(0x0000, offset);
+    offset = packetHeader.writeUInt8(1, offset);
+    packetHeader.writeUInt8(0x00, offset);
+
+    const firstPacket = Buffer.concat([packetHeader, packetData]);
+
+    offset = 0;
+    offset = packetHeader.writeUInt8(0x11, offset);
+    offset = packetHeader.writeUInt8(0x01, offset);
+    offset = packetHeader.writeUInt16BE(8 + packetData.length, offset);
+    offset = packetHeader.writeUInt16BE(0x0000, offset);
+    offset = packetHeader.writeUInt8(1, offset);
+    packetHeader.writeUInt8(0x00, offset);
+
+    const secondPacket = Buffer.concat([packetHeader, packetData]);
+
+    const incoming = new IncomingMessageStream(new Debug());
+
+    const result = new BufferList(function(err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.deepEqual(res, Buffer.concat([ packetData, packetData ]));
+
+      done();
+    });
+
+    let messageEnded = false;
+    incoming.on('data', function(message) {
+      assert.instanceOf(message, Message);
+
+      message.on('end', function() {
+        messageEnded = true;
+      });
+
+      message.pipe(result);
+    });
+
+    incoming.write(firstPacket, function() {
+      const writtenData = result.slice();
+
+      assert.strictEqual(writtenData.length, 8);
+      assert.deepEqual(writtenData, packetData);
+
+      incoming.write(secondPacket, function() {
+        const writtenData = result.slice();
+
+        assert.strictEqual(writtenData.length, 16);
+        assert.deepEqual(writtenData, Buffer.concat([ packetData, packetData ]));
+
+        assert.strictEqual(messageEnded, true);
+      });
+    });
+  });
+});

--- a/test/unit/message-test.js
+++ b/test/unit/message-test.js
@@ -1,0 +1,20 @@
+const { assert } = require('chai');
+
+const Message = require('../../src/message');
+
+describe('Message', function() {
+  it('has a type', function() {
+    const message = new Message({ type: 0x11, resetConnection: false });
+    assert.strictEqual(message.type, 0x11);
+  });
+
+  it('can signal a connection reset', function() {
+    let message;
+
+    message = new Message({ type: 0x11, resetConnection: false });
+    assert.strictEqual(message.resetConnection, false);
+
+    message = new Message({ type: 0x11, resetConnection: true });
+    assert.strictEqual(message.resetConnection, true);
+  });
+});

--- a/test/unit/outgoing-message-stream-test.js
+++ b/test/unit/outgoing-message-stream-test.js
@@ -1,0 +1,120 @@
+const BufferList = require('bl');
+const { assert } = require('chai');
+
+const OutgoingMessageStream = require('../../src/outgoing-message-stream');
+const Message = require('../../src/message');
+const Debug = require('../../src/debug');
+
+describe('OutgoingMessageStream', function() {
+  it('wraps the given message contents into a packet', function(done) {
+    const contents = new Buffer('test1234');
+
+    const message = new Message({ type: 0x11 });
+    message.end(contents);
+
+    const outgoing = new OutgoingMessageStream(new Debug(), { packetSize: 1024 * 4 });
+    const result = new BufferList(function(err, buf) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(buf.length, 16);
+
+      assert.strictEqual(buf.readUInt8(0), 0x11);
+      assert.strictEqual(buf.readUInt8(1), 0x01);
+      assert.strictEqual(buf.readUInt16BE(2), 8 + contents.length);
+      assert.strictEqual(buf.readUInt16BE(4), 0x0000);
+      assert.strictEqual(buf.readUInt8(6), 1);
+      assert.strictEqual(buf.readUInt8(7), 0);
+
+      assert.deepEqual(buf.slice(8), contents);
+
+      done();
+    });
+
+    outgoing.write(message);
+
+    outgoing.pipe(result);
+    outgoing.end();
+  });
+
+  it('splits messages that exceed the packetSize - packetHeaderSize into multiple packets', function(done) {
+    const contents = new Buffer('test1234');
+
+    const message = new Message({ type: 0x11 });
+    message.end(contents);
+
+    const outgoing = new OutgoingMessageStream(new Debug(), { packetSize: 8 + 4 });
+
+    const result = new BufferList(function(err, buf) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(buf.length, 24);
+
+      assert.strictEqual(buf.readUInt8(0), 0x11);
+      assert.strictEqual(buf.readUInt8(1), 0x00);
+      assert.strictEqual(buf.readUInt16BE(2), 8 + 4);
+      assert.strictEqual(buf.readUInt16BE(4), 0x0000);
+      assert.strictEqual(buf.readUInt8(6), 1);
+      assert.strictEqual(buf.readUInt8(7), 0);
+      assert.deepEqual(buf.slice(8, 12), contents.slice(0, 4));
+
+      assert.strictEqual(buf.readUInt8(12), 0x11);
+      assert.strictEqual(buf.readUInt8(13), 0x01);
+      assert.strictEqual(buf.readUInt16BE(14), 8 + 4);
+      assert.strictEqual(buf.readUInt16BE(16), 0x0000);
+      assert.strictEqual(buf.readUInt8(18), 2);
+      assert.strictEqual(buf.readUInt8(19), 0);
+      assert.deepEqual(buf.slice(20, 24), contents.slice(4, 8));
+
+      done();
+    });
+
+    outgoing.pipe(result);
+    outgoing.end(message);
+  });
+
+  it('supports writing multiple different messages', function(done) {
+    const contents = new Buffer('test1234');
+
+    const messages = [
+      new Message({ type: 0x11 }),
+      new Message({ type: 0x12 })
+    ];
+
+    const outgoing = new OutgoingMessageStream(new Debug(), { packetSize: 1024 * 4 });
+    const result = new BufferList(function(err, buf) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(buf.length, 32);
+      assert.strictEqual(buf.readUInt8(0), 0x11);
+      assert.strictEqual(buf.readUInt8(1), 0x01);
+      assert.strictEqual(buf.readUInt16BE(2), 8 + contents.length);
+      assert.strictEqual(buf.readUInt16BE(4), 0x0000);
+      assert.strictEqual(buf.readUInt8(6), 1);
+      assert.strictEqual(buf.readUInt8(7), 0);
+      assert.deepEqual(buf.slice(8, 16), contents);
+
+      assert.strictEqual(buf.readUInt8(16), 0x12);
+      assert.strictEqual(buf.readUInt8(17), 0x01);
+      assert.strictEqual(buf.readUInt16BE(18), 8 + contents.length);
+      assert.strictEqual(buf.readUInt16BE(20), 0x0000);
+      assert.strictEqual(buf.readUInt8(22), 1);
+      assert.strictEqual(buf.readUInt8(23), 0);
+      assert.deepEqual(buf.slice(24, 32), contents);
+
+      done();
+    });
+
+    outgoing.pipe(result);
+    messages.forEach(function(message) {
+      message.end(contents);
+      outgoing.write(message);
+    });
+    outgoing.end();
+  });
+});


### PR DESCRIPTION
For as long as `tedious` has existed, it's internals have been very unsupportive of stream based processing. The two main disadvantages of this are higher memory usage (because data is buffered) and lower performance (data is only sent after everything was buffered).

Previous changes in `tedious`'s internals moved us a bit closer to having internals be based on Node.js stream primitives, but we're still not there yet. 😅

This change here represents another big step in this direction. It introduces a new message based stream architecture and consists of three pieces:

* `Message`: A simple `PassThrough` stream that just forwards whatever is written into it, without modification.
* `IncomingMessageStream`: A `Transform` stream that takes in a raw TDS packet stream, creates `Message` instances and extracts and forwards the packet data into these messages.
* `OutgoingMessageStream`: A `Duplex` stream that takes in `Message` instances, reads their data and wraps it into raw TDS packets.

This basically makes both `IncomingMessageStream` and `OutgoingMessageStream` a "stream of streams". 😬All these streams correctly implement and respect backpressure (e.g. when the underlying socket gets saturated).

The changes are currently restricted to the `MessageIO` layer, so we don't reap any of the stream benefits just yet, but it lets us gradually move in the right direction.

This is partially based on the work #528.