### PR TITLE
fix: `end` events on the socket outside the `FINAL` state are errors

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -952,7 +952,11 @@ class Connection extends EventEmitter {
 
   socketEnd() {
     this.debug.log('socket ended');
-    this.transitionTo(this.STATE.FINAL);
+    if (this.state !== this.STATE.FINAL) {
+      const error = new Error('socket hang up');
+      error.code = 'ECONNRESET';
+      this.socketError(error);
+    }
   }
 
   socketClose() {


### PR DESCRIPTION
If we receive an `end` event outside the `FINAL` state, the remote side hung up on us, and this should be treated like an error.

/cc @landondavidson