### PR TITLE
feat: deprecate type null

### DIFF
--- a/src/data-type.js
+++ b/src/data-type.js
@@ -83,7 +83,6 @@ module.exports.TYPE = {
 };
 
 const typeByName = module.exports.typeByName = {
-  Null,
   TinyInt,
   Bit,
   SmallInt,
@@ -117,6 +116,7 @@ const typeByName = module.exports.typeByName = {
   Variant,
 
   // These are all internal and should not be used directly.
+  Null,
   IntN,
   BitN,
   FloatN,
@@ -143,6 +143,6 @@ const typeByName = module.exports.typeByName = {
   deprecate.property(typeByName, alias, 'The `' + alias + '` data type alias is deprecated, please use `' + name + '` instead.');
 });
 
-['IntN', 'BitN', 'FloatN', 'MoneyN', 'DateTimeN', 'DecimalN', 'NumericN'].forEach(function(name) {
+['IntN', 'BitN', 'FloatN', 'MoneyN', 'DateTimeN', 'DecimalN', 'NumericN', 'Null'].forEach(function(name) {
   deprecate.property(typeByName, name, 'The `' + name + '` data type is internal and will be removed.');
 });

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -14,23 +14,6 @@ var options = {
   tdsVersion: '7_2'
 };
 
-module.exports.dbnull = function(test) {
-  var colMetaData = [{ type: dataTypeByName.Null }];
-
-  var buffer = new WritableTrackingBuffer(0, 'ucs2');
-  buffer.writeUInt8(0xd1);
-
-  var parser = new Parser({ token() {} }, colMetaData, options);
-  parser.write(buffer.data);
-  var token = parser.read();
-
-  test.strictEqual(token.columns.length, 1);
-  test.strictEqual(token.columns[0].value, null);
-  test.strictEqual(token.columns[0].metadata, colMetaData[0]);
-
-  test.done();
-};
-
 module.exports.int = function(test) {
   var colMetaData = [{ type: dataTypeByName.Int }];
   var value = 3;


### PR DESCRIPTION
Fixes #321 
>Since NULL is not a SQL Server data type, the sp_executesql query formed with null as type will run into syntax error (in Server side).
>
>plus, from TDS spec,
>
>    NULLTYPE can be sent to SQL Server (for example, in RPCRequest), but SQL Server never emits NULLTYPE data.

