### PR TITLE
chore: upgrade to `big-number@1.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "big-number": "0.3.1",
+    "big-number": "1.0.0",
     "bl": "^1.2.2",
     "depd": "^1.1.2",
     "native-duplexpair": "^1.0.0",

--- a/src/ntlm-payload.js
+++ b/src/ntlm-payload.js
@@ -112,7 +112,7 @@ class NTLMResponsePayload {
   }
 
   createTimestamp(time: number) {
-    const tenthsOfAMicrosecond = new BigInteger(time).plus(11644473600).multiply(10000000);
+    const tenthsOfAMicrosecond = BigInteger(time).plus(11644473600).multiply(10000000);
     const hexArray = [];
 
     let pair = [];

--- a/src/ntlm-payload.js
+++ b/src/ntlm-payload.js
@@ -2,7 +2,7 @@
 
 const WritableTrackingBuffer = require('./tracking-buffer/writable-tracking-buffer');
 const crypto = require('crypto');
-const BigInteger = require('big-number').n;
+const BigInteger = require('big-number');
 
 const hex = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
 


### PR DESCRIPTION
Update big-number to fix some implementation bugs; public API doesn't seem to have changed.