### PR TITLE
ci: run Travis lint stage on Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
 jobs:
   include:
     - stage: lint
-      node_js: 4
+      node_js: 6
       before_install: skip
       before_script: skip
       script:


### PR DESCRIPTION
This was missed in #739. 😅