### PR TITLE
fix: remove retries for instance-lookup

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -939,7 +939,7 @@ class Connection extends EventEmitter {
 
   socketError(error) {
     if (this.state === this.STATE.CONNECTING || this.state === this.STATE.SENT_TLSSSLNEGOTIATION) {
-      const message = `Failed to connect to ${this.config.server}:${this.config.options.port} - ${error.message}`;
+      const message = `Failed to connect to ${this.config.server}: ${this.config.options.port ? `:${this.config.options.port}` : `\\${this.config.options.instanceName}`} - ${error.message}`;
       this.debug.log(message);
       this.emit('connect', ConnectionError(message, 'ESOCKET'));
     } else {

--- a/src/instance-lookup.js
+++ b/src/instance-lookup.js
@@ -2,7 +2,6 @@ const Sender = require('./sender').Sender;
 
 const SQL_SERVER_BROWSER_PORT = 1434;
 const TIMEOUT = 2 * 1000;
-const RETRIES = 3;
 // There are three bytes at the start of the response, whose purpose is unknown.
 const MYSTERY_HEADER_LENGTH = 3;
 
@@ -31,49 +30,37 @@ class InstanceLookup {
       throw new TypeError('Invalid arguments: "timeout" must be a number');
     }
 
-    const retries = options.retries === undefined ? RETRIES : options.retries;
-    if (typeof retries !== 'number') {
-      throw new TypeError('Invalid arguments: "retries" must be a number');
-    }
-
     if (typeof callback !== 'function') {
       throw new TypeError('Invalid arguments: "callback" must be a function');
     }
 
-    let sender, timer, retriesLeft = retries;
+    let sender, timer;
 
     const onTimeout = () => {
       sender.cancel();
-      makeAttempt();
+      callback('Failed to get response from SQL Server Browser on ' + server);
     };
 
     const makeAttempt = () => {
-      if (retriesLeft > 0) {
-        retriesLeft--;
+      const request = Buffer.from([0x02]);
+      sender = this.createSender(options.server, SQL_SERVER_BROWSER_PORT, request);
+      sender.execute((err, message) => {
+        clearTimeout(timer);
+        if (err) {
+          callback('Failed to lookup instance on ' + server + ' - ' + err.message);
+          return;
+        } else {
+          message = message.toString('ascii', MYSTERY_HEADER_LENGTH);
+          const port = this.parseBrowserResponse(message, instanceName);
 
-        const request = Buffer.from([0x02]);
-        sender = this.createSender(options.server, SQL_SERVER_BROWSER_PORT, request);
-        sender.execute((err, message) => {
-          clearTimeout(timer);
-          if (err) {
-            callback('Failed to lookup instance on ' + server + ' - ' + err.message);
-            return;
+          if (port) {
+            callback(undefined, port);
           } else {
-            message = message.toString('ascii', MYSTERY_HEADER_LENGTH);
-            const port = this.parseBrowserResponse(message, instanceName);
-
-            if (port) {
-              callback(undefined, port);
-            } else {
-              callback('Port for ' + instanceName + ' not found in ' + options.server);
-            }
+            callback('Port for ' + instanceName + ' not found in ' + options.server);
           }
-        });
-
-        timer = setTimeout(onTimeout, timeout);
-      } else {
-        callback('Failed to get response from SQL Server Browser on ' + server);
-      }
+        }
+      });
+      timer = setTimeout(onTimeout, timeout);
     };
 
     makeAttempt();


### PR DESCRIPTION
Removed option.retries from instance-lookup.js, this option does not exist and it is never passed from connection.js.
Also, fixes #672 
