### PR TITLE
FIX Allow socketError under state LOGGED_IN_SENDING_INITIAL_SQL

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1723,6 +1723,9 @@ Connection.prototype.STATE = {
       this.sendInitialSql();
     },
     events: {
+      socketError: function socketError() {
+        this.transitionTo(this.STATE.FINAL);
+      },
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
       },


### PR DESCRIPTION
Further to https://github.com/tediousjs/tedious/pull/769 the change to correctly handle errors socket errors outside the final state.

The above PR failed to ensure that `socketError` events are allowed on the LOGGED_IN_SENDING_INITIAL_SQL state (a non-final state).

As such the following error can occur:

```
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: No event 'socketError' in state 'LoggedInSendingInitialSql'
    at Connection.dispatchEvent (./knex/node_modules/tedious/lib/connection.js:1014:28)
    at Connection.socketError (./knex/node_modules/tedious/lib/connection.js:1030:12)
    at Connection.socketEnd (./knex/node_modules/tedious/lib/connection.js:1047:14)
    at Socket.<anonymous> (./knex/node_modules/tedious/lib/connection.js:884:18)
    at Socket.emit (events.js:187:15)
    at endReadableNT (_stream_readable.js:1081:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
Emitted 'error' event at:
    at Connection.tedious.on.err (./knex/node_modules/mssql/lib/tedious.js:252:14)
    at Connection.emit (events.js:182:13)
    at Connection.dispatchEvent (./knex/node_modules/tedious/lib/connection.js:1014:14)
    at Connection.socketError (./knex/node_modules/tedious/lib/connection.js:1030:12)
    [... lines matching original stack trace ...]
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

This fixes the problem by allowing a `socketError` event to occur during this state