### PR TITLE
Stop OpenSSL from inserting empty fragments

### DIFF
--- a/src/message-io.js
+++ b/src/message-io.js
@@ -7,8 +7,10 @@ import type { Duplex } from 'stream';
 import type { TLSSocket } from 'tls';
 import type { Socket } from 'net';
 
+// $FlowFixMe
+const constants = require('constants');
+
 const tls = require('tls');
-const crypto = require('crypto');
 const DuplexPair = require('native-duplexpair');
 const { EventEmitter} = require('events');
 
@@ -62,7 +64,20 @@ module.exports = class MessageIO extends EventEmitter {
   }
 
   startTls(credentialsDetails: Object, hostname: string, trustServerCertificate: boolean) {
-    const credentials = tls.createSecureContext ? tls.createSecureContext(credentialsDetails) : crypto.createCredentials(credentialsDetails);
+    if (credentialsDetails.secureOptions === undefined) {
+      // If the caller has not specified their own `secureOptions`,
+      // we set `SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS` here.
+      // Older SQL Server instances running on older Windows versions have
+      // trouble with the BEAST workaround in OpenSSL.
+      // As BEAST is a browser specific exploit, we can just disable this option here.
+      credentialsDetails = Object.create(credentialsDetails, {
+        secureOptions: {
+          value: constants.SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
+        }
+      });
+    }
+
+    const credentials = tls.createSecureContext(credentialsDetails);
 
     const duplexpair = new DuplexPair();
     const securePair = this.securePair = {


### PR DESCRIPTION
SQLServer versions running on older Windows versions that have a buggy 
SSL/TLS implementation don't play well with the BEAST countermeasure 
implemented by OpenSSL, and cause the connection process to hang during 
the SSL/TLS handshake.

Due to the nature of the BEAST attack (it's specific to web browsers), 
we can safely disable the counter measures to fix the connection 
process, without jeopardizing security. 🎉 