### PR TITLE
Fix compatibility on Node.js 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 node_js:
   - "6"
   - "8"
-  - "9"
   - "10"
+  - "11"
 
 stages:
   - test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"
-    - nodejs_version: "9"
     - nodejs_version: "10"
+    - nodejs_version: "11"
 
 branches:
   only:

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -7,9 +7,6 @@ import type { Duplex } from 'stream';
 import type { TLSSocket } from 'tls';
 import type { Socket } from 'net';
 
-// $FlowFixMe
-const constants = require('constants');
-
 const tls = require('tls');
 const DuplexPair = require('native-duplexpair');
 const { EventEmitter} = require('events');
@@ -63,28 +60,13 @@ module.exports = class MessageIO extends EventEmitter {
     return this.outgoingMessageStream.packetSize;
   }
 
-  startTls(credentialsDetails: Object, hostname: string, trustServerCertificate: boolean) {
-    if (credentialsDetails.secureOptions === undefined) {
-      // If the caller has not specified their own `secureOptions`,
-      // we set `SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS` here.
-      // Older SQL Server instances running on older Windows versions have
-      // trouble with the BEAST workaround in OpenSSL.
-      // As BEAST is a browser specific exploit, we can just disable this option here.
-      credentialsDetails = Object.create(credentialsDetails, {
-        secureOptions: {
-          value: constants.SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
-        }
-      });
-    }
-
-    const credentials = tls.createSecureContext(credentialsDetails);
-
+  startTls(secureContext: Object, hostname: string, trustServerCertificate: boolean) {
     const duplexpair = new DuplexPair();
     const securePair = this.securePair = {
       cleartext: tls.connect({
         socket: duplexpair.socket1,
         servername: hostname,
-        secureContext: credentials,
+        secureContext: secureContext,
         rejectUnauthorized: !trustServerCertificate
       }),
       encrypted: duplexpair.socket2

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -334,13 +334,34 @@ exports.encrypt = function(test) {
   });
 };
 
+exports['potentially throws an error on invalid crypto credential details'] = function(test) {
+  var config = getConfig();
+  config.options.encrypt = true;
+
+  // On newer Node.js versions, this will throw an error when passed to `tls.createSecureContext`
+  config.options.cryptoCredentialsDetails = {
+    ciphers: '!ALL'
+  };
+
+  try {
+    const { createSecureContext } = require('tls');
+    createSecureContext(config.options.cryptoCredentialsDetails);
+  } catch (err) {
+    test.throws(() => {
+      new Connection(config);
+    });
+  }
+
+  test.done();
+};
+
 exports['fails if no cipher can be negotiated'] = function(test) {
   var config = getConfig();
   config.options.encrypt = true;
 
-  // Do not allow any cipher to be used
+  // Specify a cipher that should never be supported by SQL Server
   config.options.cryptoCredentialsDetails = {
-    ciphers: '!ALL'
+    ciphers: 'NULL'
   };
 
   var connection = new Connection(config);

--- a/test/unit/tedious-test.js
+++ b/test/unit/tedious-test.js
@@ -31,7 +31,7 @@ exports.connectionDoesNotModifyPassedConfig = function(test) {
       encrypt: false,
       port: 1234,
       cryptoCredentialsDetails: {
-        ciphers: 'RC4-MD5'
+        ciphers: 'DEFAULT'
       }
     }
   };


### PR DESCRIPTION
This removes Node.js 9.x (no longer supported) and adds Node.js 11.x to the list of Node.js versions tested on Appveyor and Travis.

It also fixes compatibility with one of the breaking changes introduced in Node.js 11.x around `tls.createSecureContext` and the handling of invalid options.