### PR TITLE
convert values using `Number` instead of `parseInt`

### DIFF
--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -1,4 +1,4 @@
-import { DataType, ParameterData } from '../data-type';
+import { DataType } from '../data-type';
 import IntN from './intn';
 
 const BigInt: DataType = {
@@ -15,13 +15,10 @@ const BigInt: DataType = {
     buffer.writeUInt8(8);
   },
 
-  writeParameterData: function(buffer, parameter: ParameterData<null | unknown>, _options, cb) {
-    const value = parameter.value;
-
-    if (value != null) {
-      const val = typeof value !== 'number' ? parseInt(value as string) : value;
+  writeParameterData: function(buffer, parameter, _options, cb) {
+    if (parameter.value != null) {
       buffer.writeUInt8(8);
-      buffer.writeInt64LE(val);
+      buffer.writeInt64LE(Number(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
@@ -33,18 +30,19 @@ const BigInt: DataType = {
     if (value == null) {
       return null;
     }
-    if (isNaN(value as number)) {
+
+    if (typeof value !== 'number') {
+      value = Number(value);
+    }
+
+    if (isNaN(value)) {
       return new TypeError('Invalid number.');
     }
-    if (value as number < -9007199254740991 || value as number > 9007199254740991) {
-      // Number.MIN_SAFE_INTEGER = -9007199254740991
-      // Number.MAX_SAFE_INTEGER = 9007199254740991
-      // 9007199254740991 = (2**53) - 1
-      // Can't use Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER directly though
-      // as these constants are not available in node 0.10.
-      return new TypeError('Value must be between -9007199254740991 and 9007199254740991, inclusive.' +
-        ' For bigger numbers, use VarChar type.');
+
+    if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
+      return new TypeError(`Value must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}, inclusive.  For smaller or bigger numbers, use VarChar type.`);
     }
+
     return value;
   }
 };

--- a/src/data-types/int.ts
+++ b/src/data-types/int.ts
@@ -15,13 +15,14 @@ const Int: DataType = {
     buffer.writeUInt8(4);
   },
 
-  writeParameterData: function(buffer, parameter, options, cb) {
+  writeParameterData: function(buffer, parameter, _options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(4);
-      buffer.writeInt32LE(parseInt(parameter.value));
+      buffer.writeInt32LE(Number(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+
     cb();
   },
 
@@ -29,14 +30,20 @@ const Int: DataType = {
     if (value == null) {
       return null;
     }
-    value = parseInt(value);
+
+    if (typeof value !== 'number') {
+      value = Number(value);
+    }
+
     if (isNaN(value)) {
       return new TypeError('Invalid number.');
     }
+
     if (value < -2147483648 || value > 2147483647) {
-      return new TypeError('Value must be between -2147483648 and 2147483647.');
+      return new TypeError('Value must be between -2147483648 and 2147483647, inclusive.');
     }
-    return value;
+
+    return value | 0;
   }
 };
 

--- a/src/data-types/smallint.ts
+++ b/src/data-types/smallint.ts
@@ -15,13 +15,14 @@ const SmallInt: DataType = {
     buffer.writeUInt8(2);
   },
 
-  writeParameterData: function(buffer, parameter, options, cb) {
+  writeParameterData: function(buffer, parameter, _options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(2);
-      buffer.writeInt16LE(parseInt(parameter.value));
+      buffer.writeInt16LE(Number(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+
     cb();
   },
 
@@ -29,14 +30,20 @@ const SmallInt: DataType = {
     if (value == null) {
       return null;
     }
-    value = parseInt(value);
+
+    if (typeof value !== 'number') {
+      value = Number(value);
+    }
+
     if (isNaN(value)) {
       return new TypeError('Invalid number.');
     }
+
     if (value < -32768 || value > 32767) {
-      return new TypeError('Value must be between -32768 and 32767.');
+      return new TypeError('Value must be between -32768 and 32767, inclusive.');
     }
-    return value;
+
+    return value | 0;
   }
 };
 

--- a/src/data-types/tinyint.ts
+++ b/src/data-types/tinyint.ts
@@ -15,13 +15,14 @@ const TinyInt: DataType = {
     buffer.writeUInt8(1);
   },
 
-  writeParameterData: function(buffer, parameter, options, cb) {
+  writeParameterData: function(buffer, parameter, _options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(1);
-      buffer.writeUInt8(parseInt(parameter.value));
+      buffer.writeUInt8(Number(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+
     cb();
   },
 
@@ -29,14 +30,20 @@ const TinyInt: DataType = {
     if (value == null) {
       return null;
     }
-    value = parseInt(value);
+
+    if (typeof value !== 'number') {
+      value = Number(value);
+    }
+
     if (isNaN(value)) {
       return new TypeError('Invalid number.');
     }
+
     if (value < 0 || value > 255) {
-      return new TypeError('Value must be between 0 and 255.');
+      return new TypeError('Value must be between 0 and 255, inclusive.');
     }
-    return value;
+
+    return value | 0;
   }
 };
 

--- a/test/unit/int-data-type.js
+++ b/test/unit/int-data-type.js
@@ -1,0 +1,64 @@
+const { assert } = require('chai');
+const { typeByName: { Int, SmallInt, TinyInt } } = require('../../src/data-type');
+const WritableTrackingBuffer = require('../../src/tracking-buffer/writable-tracking-buffer');
+
+describe('integer-data-types', function() {
+  describe('int data type test', function() {
+    const params = [
+      { param: { value: 8.9 }, expected: 8 },
+      { param: { value: 0.000000000001 }, expected: 0 },
+      { param: { value: 8.5 }, expected: 8 }
+    ];
+
+    params.forEach(function(item) {
+      it('test valid parameter values', function(done) {
+        const buffer = new WritableTrackingBuffer(4 + 1);
+
+        Int.writeParameterData(buffer, item.param, {}, () => {
+          assert.equal(buffer.buffer.readInt32LE(1), item.expected);
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('small int data type test', function() {
+    const params = [
+      { param: { value: 8.9 }, expected: 8 },
+      { param: { value: 0.000000000001 }, expected: 0 },
+      { param: { value: 8.5 }, expected: 8 }
+    ];
+
+    params.forEach(function(item) {
+      it('test valid parameter values', function(done) {
+        const buffer = new WritableTrackingBuffer(4 + 1);
+
+        SmallInt.writeParameterData(buffer, item.param, {}, () => {
+          assert.equal(buffer.buffer.readInt32LE(1), item.expected);
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('tiny int data type test', function() {
+    const params = [
+      { param: { value: 8.9 }, expected: 8 },
+      { param: { value: 0.000000000001 }, expected: 0 },
+      { param: { value: 8.5 }, expected: 8 }
+    ];
+
+    params.forEach(function(item) {
+      it('test valid parameter values', function(done) {
+        const buffer = new WritableTrackingBuffer(4 + 1);
+        TinyInt.writeParameterData(buffer, item.param, {}, () => {
+          assert.equal(buffer.buffer.readInt32LE(1), item.expected);
+
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Using `parseInt` in parsing string to numbers would have different result for the same value, using `Math.round` would fix the issue (#814)

``` js
function sendReq(){
    const request = new Request("select @v1, @v2;", (err) =>{
        console.log(err);
    });
    request.on('row', cols =>{
        console.log(cols.map(x => x.value));
    });
    request.addParameter('v1', TYPES.TinyInt, 0.000000000000001);  // results in 1
    request.addParameter('v2', TYPES.TinyInt, "0.00000000000001"); // results in 0
    conn.execSql(request);
}
```
this PR fixes the commitlint issues in #823