### PR TITLE
fix: make writing large TVP non-blocking operation

### DIFF
--- a/src/bulk-load.js
+++ b/src/bulk-load.js
@@ -379,7 +379,7 @@ class RowTransform extends Transform {
         scale: c.scale,
         precision: c.precision,
         value: row[i]
-      }, this.mainOptions);
+      }, this.mainOptions, () => {});
     }
 
     this.push(buf.data);

--- a/src/connection.js
+++ b/src/connection.js
@@ -1303,7 +1303,9 @@ class Connection extends EventEmitter {
 
   sendInitialSql() {
     const payload = new SqlBatchPayload(this.getInitialSql(), this.currentTransactionDescriptor(), this.config.options);
-    return this.messageIo.sendMessage(TYPE.SQL_BATCH, payload.data);
+    payload.getData((data) => {
+      return this.messageIo.sendMessage(TYPE.SQL_BATCH, data);
+    });
   }
 
   getInitialSql() {
@@ -1650,8 +1652,15 @@ class Connection extends EventEmitter {
           return;
         }
 
-        // There's two ways to handle request cancelation:
-        if (message.writable) {
+        // There's three ways to handle request cancelation:
+        if (this.state === this.STATE.BUILDING_CLIENT_REQUEST) {
+          // The request was cancelled before buffering finished
+          const sqlRequest = this.request;
+          this.request = undefined;
+          sqlRequest.callback(RequestError('Canceled.', 'ECANCEL'));
+          this.transitionTo(this.STATE.LOGGED_IN);
+
+        } else if (message.writable) {
           // - if the message is still writable, we'll set the ignore bit
           //   and end the message.
           message.ignore = true;
@@ -1679,22 +1688,41 @@ class Connection extends EventEmitter {
           request.rowToPacketTransform.end();
         }
         this.messageIo.outgoingMessageStream.write(message);
+        this.transitionTo(this.STATE.SENT_CLIENT_REQUEST);
+
+        if (request.paused) { // Request.pause() has been called before the request was started
+          this.pauseRequest(request);
+        }
       } else {
         this.createRequestTimer();
 
-        message = this.messageIo.sendMessage(packetType, payload.data, this.resetConnectionOnNextRequest);
+        // Transition to an intermediate state to ensure that no new requests
+        // are made on the connection while the buffer is being populated.
+        this.transitionTo(this.STATE.BUILDING_CLIENT_REQUEST);
 
-        this.resetConnectionOnNextRequest = false;
-        this.debug.payload(function() {
-          return payload.toString('  ');
+        payload.getData((data) => {
+          if (this.state !== this.STATE.BUILDING_CLIENT_REQUEST) {
+            // Something else has happened on the connection since starting to
+            // build the request. That state change should have invoked the
+            // request handler so there is nothing to do at this point.
+            return;
+          }
+
+          message = this.messageIo.sendMessage(packetType, data, this.resetConnectionOnNextRequest);
+
+          this.resetConnectionOnNextRequest = false;
+          this.debug.payload(function() {
+            return payload.toString('  ');
+          });
+
+          this.transitionTo(this.STATE.SENT_CLIENT_REQUEST);
+
+          if (request.paused) { // Request.pause() has been called before the request was started
+            this.pauseRequest(request);
+          }
         });
       }
 
-      this.transitionTo(this.STATE.SENT_CLIENT_REQUEST);
-
-      if (request.paused) { // Request.pause() has been called before the request was started
-        this.pauseRequest(request);
-      }
     }
   }
 
@@ -2052,6 +2080,18 @@ Connection.prototype.STATE = {
     events: {
       socketError: function() {
         this.transitionTo(this.STATE.FINAL);
+      }
+    }
+  },
+  BUILDING_CLIENT_REQUEST: {
+    name: 'BuildingClientRequest',
+    events: {
+      socketError: function(err) {
+        const sqlRequest = this.request;
+        this.request = undefined;
+        this.transitionTo(this.STATE.FINAL);
+
+        sqlRequest.callback(err);
       }
     }
   },

--- a/src/data-types/bigint.js
+++ b/src/data-types/bigint.js
@@ -14,7 +14,7 @@ module.exports = {
     buffer.writeUInt8(8);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       const val = typeof parameter.value !== 'number' ? parameter.value : parseInt(parameter.value);
       buffer.writeUInt8(8);
@@ -22,6 +22,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/binary.js
+++ b/src/data-types/binary.js
@@ -34,13 +34,14 @@ module.exports = {
     buffer.writeUInt16LE(parameter.length);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt16LE(parameter.length);
       buffer.writeBuffer(parameter.value.slice(0, Math.min(parameter.length, this.maximumLength)));
     } else {
       buffer.writeUInt16LE(NULL);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/bit.js
+++ b/src/data-types/bit.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(1);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (typeof parameter.value === 'undefined' || parameter.value === null) {
       buffer.writeUInt8(0);
     } else {
       buffer.writeUInt8(1);
       buffer.writeUInt8(parameter.value ? 1 : 0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/char.js
+++ b/src/data-types/char.js
@@ -47,12 +47,13 @@ module.exports = {
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUsVarbyte(parameter.value, 'ascii');
     } else {
       buffer.writeUInt16LE(NULL);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/date.js
+++ b/src/data-types/date.js
@@ -16,7 +16,7 @@ module.exports = {
     buffer.writeUInt8(this.id);
   },
 
-  writeParameterData: function(buffer, parameter, options) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(3);
       if (options.useUTC) {
@@ -28,6 +28,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/datetime.js
+++ b/src/data-types/datetime.js
@@ -17,7 +17,7 @@ module.exports = {
     buffer.writeUInt8(8);
   },
 
-  writeParameterData: function(buffer, parameter, options) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       let days, dstDiff, milliseconds, seconds, threeHundredthsOfSecond;
       if (options.useUTC) {
@@ -45,6 +45,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/datetime2.js
+++ b/src/data-types/datetime2.js
@@ -43,7 +43,7 @@ module.exports = {
     buffer.writeUInt8(parameter.scale);
   },
 
-  writeParameterData: function(buffer, parameter, options) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       const time = new Date(+parameter.value);
 
@@ -85,6 +85,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/datetimeoffset.js
+++ b/src/data-types/datetimeoffset.js
@@ -37,7 +37,7 @@ module.exports = {
     buffer.writeUInt8(this.id);
     buffer.writeUInt8(parameter.scale);
   },
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       const time = new Date(+parameter.value);
       time.setUTCFullYear(1970);
@@ -72,6 +72,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
   validate: function(value) {
     if (value == null) {

--- a/src/data-types/decimal.js
+++ b/src/data-types/decimal.js
@@ -44,7 +44,7 @@ module.exports = {
     buffer.writeUInt8(parameter.scale);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       const sign = parameter.value < 0 ? 0 : 1;
       const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale)));
@@ -71,6 +71,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/float.js
+++ b/src/data-types/float.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(8);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(8);
       buffer.writeDoubleLE(parseFloat(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/image.js
+++ b/src/data-types/image.js
@@ -23,13 +23,14 @@ module.exports = {
     buffer.writeInt32LE(parameter.length);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeInt32LE(parameter.length);
       buffer.writeBuffer(parameter.value);
     } else {
       buffer.writeInt32LE(parameter.length);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/int.js
+++ b/src/data-types/int.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(4);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(4);
       buffer.writeInt32LE(parseInt(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/money.js
+++ b/src/data-types/money.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(8);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(8);
       buffer.writeMoney(parameter.value * 10000);
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/nchar.js
+++ b/src/data-types/nchar.js
@@ -47,12 +47,13 @@ module.exports = {
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUsVarbyte(parameter.value, 'ucs2');
     } else {
       buffer.writeUInt16LE(NULL);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/numeric.js
+++ b/src/data-types/numeric.js
@@ -44,7 +44,7 @@ module.exports = {
     buffer.writeUInt8(parameter.scale);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       const sign = parameter.value < 0 ? 0 : 1;
       const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale)));
@@ -71,6 +71,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/nvarchar.js
+++ b/src/data-types/nvarchar.js
@@ -52,7 +52,7 @@ module.exports = {
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       if (parameter.length <= this.maximumLength) {
         buffer.writeUsVarbyte(parameter.value, 'ucs2');
@@ -65,6 +65,7 @@ module.exports = {
       buffer.writeUInt32LE(0xFFFFFFFF);
       buffer.writeUInt32LE(0xFFFFFFFF);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/real.js
+++ b/src/data-types/real.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(4);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(4);
       buffer.writeFloatLE(parseFloat(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/smalldatetime.js
+++ b/src/data-types/smalldatetime.js
@@ -17,7 +17,7 @@ module.exports = {
     buffer.writeUInt8(4);
   },
 
-  writeParameterData: function(buffer, parameter, options) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       let days, dstDiff, minutes;
       if (options.useUTC) {
@@ -36,6 +36,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/smallint.js
+++ b/src/data-types/smallint.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(2);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(2);
       buffer.writeInt16LE(parseInt(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/smallmoney.js
+++ b/src/data-types/smallmoney.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(4);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(4);
       buffer.writeInt32LE(parameter.value * 10000);
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/text.js
+++ b/src/data-types/text.js
@@ -24,7 +24,7 @@ module.exports = {
     buffer.writeInt32LE(parameter.length);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
     if (parameter.value != null) {
       buffer.writeInt32LE(parameter.length);
@@ -32,6 +32,7 @@ module.exports = {
     } else {
       buffer.writeInt32LE(parameter.length);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/time.js
+++ b/src/data-types/time.js
@@ -40,7 +40,7 @@ module.exports = {
     buffer.writeUInt8(parameter.scale);
   },
 
-  writeParameterData: function(buffer, parameter, options) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       const time = new Date(+parameter.value);
 
@@ -76,6 +76,7 @@ module.exports = {
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/tinyint.js
+++ b/src/data-types/tinyint.js
@@ -14,13 +14,14 @@ module.exports = {
     buffer.writeUInt8(1);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(1);
       buffer.writeUInt8(parseInt(parameter.value));
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/uniqueidentifier.js
+++ b/src/data-types/uniqueidentifier.js
@@ -19,13 +19,14 @@ module.exports = {
     buffer.writeUInt8(0x10);
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       buffer.writeUInt8(0x10);
       buffer.writeBuffer(Buffer.from(guidParser.guidToArray(parameter.value)));
     } else {
       buffer.writeUInt8(0);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/varbinary.js
+++ b/src/data-types/varbinary.js
@@ -46,7 +46,7 @@ module.exports = {
     }
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       if (parameter.length <= this.maximumLength) {
         buffer.writeUsVarbyte(parameter.value);
@@ -59,6 +59,7 @@ module.exports = {
       buffer.writeUInt32LE(0xFFFFFFFF);
       buffer.writeUInt32LE(0xFFFFFFFF);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/data-types/varchar.js
+++ b/src/data-types/varchar.js
@@ -52,7 +52,7 @@ module.exports = {
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
   },
 
-  writeParameterData: function(buffer, parameter) {
+  writeParameterData: function(buffer, parameter, options, cb) {
     if (parameter.value != null) {
       if (parameter.length <= this.maximumLength) {
         buffer.writeUsVarbyte(parameter.value, 'ascii');
@@ -65,6 +65,7 @@ module.exports = {
       buffer.writeUInt32LE(0xFFFFFFFF);
       buffer.writeUInt32LE(0xFFFFFFFF);
     }
+    cb();
   },
 
   validate: function(value) {

--- a/src/sqlbatch-payload.js
+++ b/src/sqlbatch-payload.js
@@ -8,18 +8,23 @@ const writeAllHeaders = require('./all-headers').writeToTrackingBuffer;
  */
 class SqlBatchPayload {
   sqlText: string;
-  data: Buffer;
+  txnDescriptor: Buffer;
+  options: { tdsVersion: string };
 
   constructor(sqlText: string, txnDescriptor: Buffer, options: { tdsVersion: string }) {
     this.sqlText = sqlText;
+    this.txnDescriptor = txnDescriptor;
+    this.options = options;
+  }
 
+  getData(cb: (data: Buffer) => void) {
     const buffer = new WritableTrackingBuffer(100 + 2 * this.sqlText.length, 'ucs2');
-    if (options.tdsVersion >= '7_2') {
+    if (this.options.tdsVersion >= '7_2') {
       const outstandingRequestCount = 1;
-      writeAllHeaders(buffer, txnDescriptor, outstandingRequestCount);
+      writeAllHeaders(buffer, this.txnDescriptor, outstandingRequestCount);
     }
     buffer.writeString(this.sqlText, 'ucs2');
-    this.data = buffer.data;
+    cb(buffer.data);
   }
 
   toString(indent: string = '') {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -46,7 +46,7 @@ class Transaction {
     buffer.writeString(this.name, 'ucs2');
 
     return {
-      data: buffer.data,
+      getData: (cb) => { cb(buffer.data); },
       toString: () => {
         return 'Begin Transaction: name=' + this.name + ', isolationLevel=' + isolationLevelByValue[this.isolationLevel];
       }
@@ -63,6 +63,7 @@ class Transaction {
     buffer.writeUInt8(0);
 
     return {
+      getData: (cb) => { cb(buffer.data); },
       data: buffer.data,
       toString: () => {
         return 'Commit Transaction: name=' + this.name;
@@ -80,7 +81,7 @@ class Transaction {
     buffer.writeUInt8(0);
 
     return {
-      data: buffer.data,
+      getData: (cb) => { cb(buffer.data); },
       toString: () => {
         return 'Rollback Transaction: name=' + this.name;
       }
@@ -95,7 +96,7 @@ class Transaction {
     buffer.writeString(this.name, 'ucs2');
 
     return {
-      data: buffer.data,
+      getData: (cb) => { cb(buffer.data); },
       toString: () => {
         return 'Save Transaction: name=' + this.name;
       }

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -13,7 +13,7 @@ exports.smallDateTimeDaylightSaving = function(test) {
     var buffer = new WritableTrackingBuffer(8);
     var parameter = { value: testSet[0] };
     var expectedNoOfDays = testSet[1];
-    type.writeParameterData(buffer, parameter, { useUTC: false });
+    type.writeParameterData(buffer, parameter, { useUTC: false }, () => {});
     test.strictEqual(buffer.buffer.readUInt16LE(1), expectedNoOfDays);
   }
   test.done();
@@ -30,7 +30,7 @@ exports.dateTimeDaylightSaving = function(test) {
     var buffer = new WritableTrackingBuffer(16);
     var parameter = { value: testSet[0] };
     var expectedNoOfDays = testSet[1];
-    type.writeParameterData(buffer, parameter, { useUTC: false });
+    type.writeParameterData(buffer, parameter, { useUTC: false }, () => {});
     test.strictEqual(buffer.buffer.readInt32LE(1), expectedNoOfDays);
   }
   test.done();
@@ -45,7 +45,7 @@ exports.dateTime2DaylightSaving = function(test) {
     [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('06000000183a0b', 'hex')]
   ]) {
     var buffer = new WritableTrackingBuffer(16);
-    type.writeParameterData(buffer, { value: value, scale: 0 }, { useUTC: false });
+    type.writeParameterData(buffer, { value: value, scale: 0 }, { useUTC: false }, () => {});
     test.deepEqual(buffer.data, expectedBuffer);
   }
   test.done();
@@ -60,7 +60,7 @@ exports.dateDaylightSaving = function(test) {
     [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('03183a0b', 'hex')]
   ]) {
     var buffer = new WritableTrackingBuffer(16);
-    type.writeParameterData(buffer, { value: value }, { useUTC: false });
+    type.writeParameterData(buffer, { value: value }, { useUTC: false }, () => {});
 
     test.deepEqual(buffer.data, expectedBuffer);
   }
@@ -79,7 +79,7 @@ exports.nanoSecondRounding = function(test) {
     parameter.value.nanosecondDelta = nanosecondDelta;
 
     const buffer = new WritableTrackingBuffer(16);
-    type.writeParameterData(buffer, parameter, { useUTC: false });
+    type.writeParameterData(buffer, parameter, { useUTC: false }, () => {});
 
     test.deepEqual(buffer.data, expectedBuffer);
   }


### PR DESCRIPTION
Addresses #475 by adding setImmediate callbacks to allow work waiting on the event loop to process after each parameter and each row of a TVP parameter is written to the internal buffer.