### PR TITLE
Rework request cancellation

### DIFF
--- a/src/bulk-load.js
+++ b/src/bulk-load.js
@@ -324,12 +324,20 @@ class BulkLoad extends EventEmitter {
     // to call `message.end` to finish the request.
     this.rowToPacketTransform.once('error', (err) => {
       this.error = err;
-      this.canceled = true;
-      this.emit('cancel');
+      this.cancel();
       message.end();
     });
 
     return message;
+  }
+
+  cancel() {
+    if (this.canceled) {
+      return;
+    }
+
+    this.canceled = true;
+    this.emit('cancel');
   }
 }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -1029,7 +1029,7 @@ class Connection extends EventEmitter {
 
   requestTimeout() {
     this.requestTimer = undefined;
-    this.cancel();
+    this.request.cancel();
     const timeout = (this.request.timeout !== undefined) ? this.request.timeout : this.config.options.requestTimeout;
     const message = 'Timeout: Request failed to complete in ' + timeout + 'ms';
     this.request.error = RequestError(message, 'ETIMEOUT');
@@ -1486,8 +1486,7 @@ class Connection extends EventEmitter {
     });
 
     bulkLoad.once('cancel', () => {
-      request.canceled = true;
-      request.emit('cancel');
+      request.cancel();
     });
 
     this.execSqlBatch(request);
@@ -1736,8 +1735,7 @@ class Connection extends EventEmitter {
       return false;
     }
 
-    this.request.canceled = true;
-    this.request.emit('cancel');
+    this.request.cancel();
     return true;
   }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -2111,7 +2111,10 @@ Connection.prototype.STATE = {
       this.attentionReceived = false;
     },
     events: {
-      socketError: function() {
+      socketError: function(err) {
+        const sqlRequest = this.request;
+        this.request = undefined;
+        sqlRequest.callback(err);
         this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -121,6 +121,7 @@ module.exports = class MessageIO extends EventEmitter {
     const message = new Message({ type: packetType, resetConnection: resetConnection });
     message.end(data);
     this.outgoingMessageStream.write(message);
+    return message;
   }
 
   // Temporarily suspends the flow of incoming packets.

--- a/src/message.js
+++ b/src/message.js
@@ -5,12 +5,14 @@ const { PassThrough } = require('readable-stream');
 class Message extends PassThrough {
   type: number;
   resetConnection: boolean;
+  ignore: boolean;
 
   constructor({ type, resetConnection = false } : { type: number, resetConnection?: boolean }) {
     super();
 
     this.type = type;
     this.resetConnection = resetConnection;
+    this.ignore = false;
   }
 }
 

--- a/src/outgoing-message-stream.js
+++ b/src/outgoing-message-stream.js
@@ -33,6 +33,10 @@ class OutgoingMessageStream extends Duplex {
 
     this.currentMessage = message;
     this.currentMessage.on('data', (data) => {
+      if (this.currentMessage.ignore) {
+        return;
+      }
+
       this.bl.append(data);
 
       while (this.bl.length > length) {
@@ -63,6 +67,7 @@ class OutgoingMessageStream extends Duplex {
       packet.packetId(packetNumber += 1);
       packet.resetConnection(message.resetConnection);
       packet.last(true);
+      packet.ignore(message.ignore);
       packet.addData(data);
 
       this.debug.packet('Sent', packet);

--- a/src/packet.js
+++ b/src/packet.js
@@ -76,7 +76,7 @@ class Packet {
     return this.buffer.readUInt16BE(OFFSET.Length);
   }
 
-  resetConnection(reset?: boolean) {
+  resetConnection(reset: boolean) {
     let status = this.buffer.readUInt8(OFFSET.Status);
     if (reset) {
       status |= STATUS.RESETCONNECTION;
@@ -97,6 +97,16 @@ class Packet {
       this.buffer.writeUInt8(status, OFFSET.Status);
     }
     return this.isLast();
+  }
+
+  ignore(last: boolean) {
+    let status = this.buffer.readUInt8(OFFSET.Status);
+    if (last) {
+      status |= STATUS.IGNORE;
+    } else {
+      status &= 0xFF - STATUS.IGNORE;
+    }
+    this.buffer.writeUInt8(status, OFFSET.Status);
   }
 
   isLast() {

--- a/src/request.js
+++ b/src/request.js
@@ -209,6 +209,15 @@ class Request extends EventEmitter {
     }
   }
 
+  cancel() {
+    if (this.canceled) {
+      return;
+    }
+
+    this.canceled = true;
+    this.emit('cancel');
+  }
+
   setTimeout(timeout: number | typeof undefined) {
     this.timeout = timeout;
   }

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -271,7 +271,7 @@ exports['bulkLoad - cancel after request send does nothing'] = function(test) {
     test.ifError(err);
     bulkLoad.addRow({ id: 1234 });
     connection.execBulkLoad(bulkLoad);
-    connection.cancel();
+    bulkLoad.cancel();
   });
 
   const request_verifyBulkLoad = new Request('SELECT [id] FROM #tmpTestTable5', function(err, rowCount) {
@@ -295,7 +295,7 @@ exports['bulkLoad - cancel after request completed'] = function(test) {
   const bulkLoad = connection.newBulkLoad('#tmpTestTable5', {keepNulls: true}, function(err, rowCount) {
     test.ifError(err);
 
-    connection.cancel();
+    bulkLoad.cancel();
 
     connection.execSqlBatch(request_verifyBulkLoad);
   });
@@ -434,7 +434,7 @@ exports.testStreamingBulkLoadWithCancel = function(test) {
         process.nextTick(() => {
           while (rowCount < totalRows) {
             if (rowCount === totalRows - 100) {
-              connection.cancel();
+              bulkLoad.cancel();
             }
 
             const i = rowCount++;

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const Readable = require('readable-stream').Readable;
+const { pipeline, Readable } = require('readable-stream');
 const Connection = require('../../src/connection');
 const Request = require('../../src/request');
 const TYPES = require('../../src/data-type').typeByName;
@@ -253,6 +253,79 @@ exports['bulkLoad - verify null value'] = function(test) {
   connection.execSqlBatch(request);
 };
 
+exports['bulkLoad - cancel after request send does nothing'] = function(test) {
+  const connection = this.connection;
+
+  const bulkLoad = connection.newBulkLoad('#tmpTestTable5', { keepNulls: true }, function(err, rowCount) {
+    test.ok(err);
+    test.strictEqual(err.message, 'Canceled.');
+
+    connection.execSqlBatch(request_verifyBulkLoad);
+  });
+
+  bulkLoad.addColumn('id', TYPES.Int, {
+    nullable: true
+  });
+
+  const request = new Request('CREATE TABLE #tmpTestTable5 ([id] int NULL DEFAULT 253565)', function(err) {
+    test.ifError(err);
+    bulkLoad.addRow({ id: 1234 });
+    connection.execBulkLoad(bulkLoad);
+    connection.cancel();
+  });
+
+  const request_verifyBulkLoad = new Request('SELECT [id] FROM #tmpTestTable5', function(err, rowCount) {
+    test.ifError(err);
+
+    test.strictEqual(rowCount, 0);
+
+    test.done();
+  });
+
+  request_verifyBulkLoad.on('row', function(columns) {
+    test.deepEqual(columns[0].value, null);
+  });
+
+  connection.execSqlBatch(request);
+};
+
+exports['bulkLoad - cancel after request completed'] = function(test) {
+  const connection = this.connection;
+
+  const bulkLoad = connection.newBulkLoad('#tmpTestTable5', {keepNulls: true}, function(err, rowCount) {
+    test.ifError(err);
+
+    connection.cancel();
+
+    connection.execSqlBatch(request_verifyBulkLoad);
+  });
+
+  bulkLoad.addColumn('id', TYPES.Int, {
+    nullable: true
+  });
+
+  const request = new Request('CREATE TABLE #tmpTestTable5 ([id] int NULL DEFAULT 253565)', function(err) {
+    test.ifError(err);
+    bulkLoad.addRow({ id: 1234 });
+    connection.execBulkLoad(bulkLoad);
+  });
+
+  const request_verifyBulkLoad = new Request('SELECT [id] FROM #tmpTestTable5', function(err, rowCount) {
+    test.ifError(err);
+
+    test.strictEqual(rowCount, 1);
+
+    test.done();
+  });
+
+  request_verifyBulkLoad.on('row', function(columns) {
+    test.strictEqual(columns[0].value, 1234);
+  });
+
+  connection.execSqlBatch(request);
+};
+
+
 exports.testStreamingBulkLoad = function(test) {
   const totalRows = 500000;
   const connection = this.connection;
@@ -279,7 +352,25 @@ exports.testStreamingBulkLoad = function(test) {
     bulkLoad.addColumn('i', TYPES.Int, {nullable: false});
     const rowStream = bulkLoad.getRowStream();
     connection.execBulkLoad(bulkLoad);
-    const rowSource = new RowSource(totalRows);
+
+    let rowCount = 0;
+    const rowSource = new Readable({
+      objectMode: true,
+
+      read() {
+        while (rowCount < totalRows) {
+          const i = rowCount++;
+          const row = [i];
+
+          if (!this.push(row)) {
+            return;
+          }
+        }
+
+        this.push(null);
+      }
+    });
+
     rowSource.pipe(rowStream);
   }
 
@@ -295,7 +386,7 @@ exports.testStreamingBulkLoad = function(test) {
         'from ' + tableName + ' a ' +
           'inner join ' + tableName + ' b on a.i = b.i - 1';
     const request = new Request(sql, completeVerifyTableContent);
-    request.on('data', (row) => {
+    request.on('row', (row) => {
       test.equals(row[0].value, totalRows - 1);
     });
     connection.execSqlBatch(request);
@@ -306,24 +397,88 @@ exports.testStreamingBulkLoad = function(test) {
     test.equal(rowCount, 1);
     test.done();
   }
+};
 
-  class RowSource extends Readable {
-    constructor(totalRows) {
-      super({
-        objectMode: true
-      });
-      this.totalRows = totalRows;
-      this.rowCount = 0;
-    }
-    _read() {
-      while (this.rowCount < this.totalRows) {
-        const i = this.rowCount++;
-        const row = [i];
-        if (!this.push(row)) {
-          return;
-        }
+exports.testStreamingBulkLoadWithCancel = function(test) {
+  const totalRows = 500000;
+  const connection = this.connection;
+
+  connection.on('error', function(err) {
+    test.ifError(err);
+  });
+  startCreateTable();
+
+  function startCreateTable() {
+    const sql = 'create table #stream_test (i int not null primary key)';
+    const request = new Request(sql, completeCreateTable);
+    connection.execSqlBatch(request);
+  }
+
+  function completeCreateTable(err) {
+    test.ifError(err);
+    startBulkLoad();
+  }
+
+  function startBulkLoad() {
+    const bulkLoad = connection.newBulkLoad('#stream_test', completeBulkLoad);
+    bulkLoad.addColumn('i', TYPES.Int, { nullable: false });
+
+    const rowStream = bulkLoad.getRowStream();
+    connection.execBulkLoad(bulkLoad);
+
+    let rowCount = 0;
+    const rowSource = new Readable({
+      objectMode: true,
+
+      read() {
+        process.nextTick(() => {
+          while (rowCount < totalRows) {
+            if (rowCount === totalRows - 100) {
+              connection.cancel();
+            }
+
+            const i = rowCount++;
+            const row = [i];
+
+            if (!this.push(row)) {
+              return;
+            }
+          }
+
+          this.push(null);
+        });
       }
-      this.push(null);
-    }
+    });
+
+    pipeline(rowSource, rowStream, function(err) {
+      test.ifError(err);
+    });
+  }
+
+  function completeBulkLoad(err, rowCount) {
+    test.ok(err);
+    test.strictEqual(err.message, 'Canceled.');
+
+    test.equal(rowCount, 0);
+    startVerifyTableContent();
+  }
+
+  function startVerifyTableContent() {
+    const sql = `
+      select count(*)
+      from #stream_test a
+      inner join #stream_test b on a.i = b.i - 1
+    `;
+    const request = new Request(sql, completeVerifyTableContent);
+    request.on('row', (row) => {
+      test.equals(row[0].value, 0);
+    });
+    connection.execSqlBatch(request);
+  }
+
+  function completeVerifyTableContent(err, rowCount) {
+    test.ifError(err);
+    test.equal(rowCount, 1);
+    test.done();
   }
 };

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -1047,7 +1047,7 @@ exports.cancelRequest = function(test) {
 };
 
 exports.requestTimeout = function(test) {
-  test.expect(8);
+  test.expect(1);
 
   var config = getConfig();
   config.options.requestTimeout = 1000;
@@ -1066,22 +1066,19 @@ exports.requestTimeout = function(test) {
   });
 
   request.on('doneProc', function(rowCount, more) {
-    test.ok(!rowCount);
-    test.strictEqual(more, false);
+    test.ok(false);
   });
 
   request.on('done', function(rowCount, more, rows) {
-    test.ok(!rowCount);
-    test.strictEqual(more, false);
+    test.ok(false);
   });
 
   request.on('columnMetadata', function(columnsMetadata) {
-    test.strictEqual(columnsMetadata.length, 1);
+    test.ok(false);
   });
 
   request.on('row', function(columns) {
-    test.strictEqual(columns.length, 1);
-    test.strictEqual(columns[0].value, 1);
+    test.ok(false);
   });
 
   var connection = new Connection(config);

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -993,7 +993,7 @@ exports.resetConnection = function(test) {
 };
 
 exports.cancelRequest = function(test) {
-  test.expect(8);
+  test.expect(1);
 
   var config = getConfig();
 
@@ -1011,22 +1011,19 @@ exports.cancelRequest = function(test) {
   });
 
   request.on('doneProc', function(rowCount, more) {
-    test.ok(!rowCount);
-    test.strictEqual(more, false);
+    test.ok(false);
   });
 
   request.on('done', function(rowCount, more, rows) {
-    test.ok(!rowCount);
-    test.strictEqual(more, false);
+    test.ok(false);
   });
 
   request.on('columnMetadata', function(columnsMetadata) {
-    test.strictEqual(columnsMetadata.length, 1);
+    test.ok(false);
   });
 
   request.on('row', function(columns) {
-    test.strictEqual(columns.length, 1);
-    test.strictEqual(columns[0].value, 1);
+    test.ok(false);
   });
 
   var connection = new Connection(config);

--- a/test/unit/bulk-load-test.js
+++ b/test/unit/bulk-load-test.js
@@ -1,0 +1,39 @@
+const { assert } = require('chai');
+
+const BulkLoad = require('../../src/bulk-load');
+
+describe('BulkLoad', function() {
+  it('starts out as not being canceled', function() {
+    const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+    assert.strictEqual(request.canceled, false);
+  });
+
+  describe('#cancel', function() {
+    it('marks the request as canceled', function() {
+      const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+      request.cancel();
+      assert.strictEqual(request.canceled, true);
+    });
+
+    it('emits a `cancel` event', function() {
+      const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+
+      let eventEmitted = false;
+      request.on('cancel', () => { eventEmitted = true; });
+      request.cancel();
+
+      assert.strictEqual(eventEmitted, true);
+    });
+
+    it('only emits the `cancel` event on the first call', function() {
+      const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+      request.cancel();
+
+      let eventEmitted = false;
+      request.on('cancel', () => { eventEmitted = true; });
+      request.cancel();
+
+      assert.strictEqual(eventEmitted, false);
+    });
+  });
+});

--- a/test/unit/request-test.js
+++ b/test/unit/request-test.js
@@ -1,0 +1,39 @@
+const { assert } = require('chai');
+
+const Request = require('../../src/request');
+
+describe('Request', function() {
+  it('starts out as not being canceled', function() {
+    const request = new Request('SELECT 1');
+    assert.strictEqual(request.canceled, false);
+  });
+
+  describe('#cancel', function() {
+    it('marks the request as canceled', function() {
+      const request = new Request();
+      request.cancel();
+      assert.strictEqual(request.canceled, true);
+    });
+
+    it('emits a `cancel` event', function() {
+      const request = new Request();
+
+      let eventEmitted = false;
+      request.on('cancel', () => { eventEmitted = true; });
+      request.cancel();
+
+      assert.strictEqual(eventEmitted, true);
+    });
+
+    it('only emits the `cancel` event on the first call', function() {
+      const request = new Request();
+      request.cancel();
+
+      let eventEmitted = false;
+      request.on('cancel', () => { eventEmitted = true; });
+      request.cancel();
+
+      assert.strictEqual(eventEmitted, false);
+    });
+  });
+});


### PR DESCRIPTION
This is an attempt to rework how request cancellation works, to make it more generic (it now works with regular requests and both streaming as well as non-streaming bulk loads) and more conformant to the MS-TDS spec.

This also adds a new `.cancel` method on the `Request` and `BulkLoad` classes, and deprecates the `cancel` method on the `Connection` class itself.

The changes in 8c9ce1d warrant a major version bump, as they change the behaviour of requests that are canceled after they were sent to the server. Instead of continuing to forward various events from the token stream parser to the canceled request, all this information will be "discarded", as described in [`3.2.5.8 Sent Attention State`](https://msdn.microsoft.com/en-us/library/dd340677.aspx) of the MS-TDS specification:

> If the response is structurally valid and it does not acknowledge the Attention as described in section 2.2.1.7, then the TDS client MUST discard any data contained in the response and remain in the "Sent Attention" state.
> 
> If the response is structurally valid and it acknowledges the Attention as described in section 2.2.1.7, then the TDS client MUST discard any data contained in the response, indicate the completion of the query to the upper layer together with the cause of the Attention (either an upper-layer cancellation as described in section 3.2.4 or query timeout as described in section 3.2.2), and enter the "Logged In" state.

Fixes: https://github.com/tediousjs/tedious/issues/545
Fixes: https://github.com/tediousjs/tedious/issues/534
Fixes: https://github.com/tediousjs/tedious/pull/566