### PR TITLE
Simplify state handling internals

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1803,6 +1803,7 @@ Connection.prototype.STATE = {
           } else {
             this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
           }
+
           this.transitionTo(this.STATE.FINAL);
         }
       }
@@ -1840,45 +1841,18 @@ Connection.prototype.STATE = {
           this.debug.payload(function() {
             return payload.toString('  ');
           });
-
-          this.transitionTo(this.STATE.SENT_NTLM_RESPONSE);
         } else {
-          if (this.loginError) {
-            this.emit('connect', this.loginError);
+          if (this.loggedIn) {
+            this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
           } else {
-            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
-          }
+            if (this.loginError) {
+              this.emit('connect', this.loginError);
+            } else {
+              this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
+            }
 
-          this.transitionTo(this.STATE.FINAL);
-        }
-      }
-    }
-  },
-  SENT_NTLM_RESPONSE: {
-    name: 'SentNTLMResponse',
-    events: {
-      socketError: function() {
-        this.transitionTo(this.STATE.FINAL);
-      },
-      connectTimeout: function() {
-        this.transitionTo(this.STATE.FINAL);
-      },
-      data: function(data) {
-        this.sendDataToTokenStreamParser(data);
-      },
-      routingChange: function() {
-        this.transitionTo(this.STATE.REROUTING);
-      },
-      message: function() {
-        if (this.loggedIn) {
-          this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
-        } else {
-          if (this.loginError) {
-            this.emit('connect', this.loginError);
-          } else {
-            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
+            this.transitionTo(this.STATE.FINAL);
           }
-          this.transitionTo(this.STATE.FINAL);
         }
       }
     }


### PR DESCRIPTION
These changes are slightly reworking some internal details of how the logic for handling different states is organized.

There's a few specific things I tried to do here:

* Remove the number of `.dispatchEvent` calls and state specific event handler code. In all the places I changed, the indirection this introduced made the code harder to understand, and was absolutely not necessary.
* Remove `process.nextTick` calls that were not necessary. These required code to be changed to be async, even though these `process.nextTick` calls were not even required.
* Remove `SENT_NTLM_RESPONSE` state. There is no state like this described in the MS-TDS specification, instead this logic happens as part of `SENT_LOGIN7_WITH_NTLM`, so I merged those two together.