### PR TITLE
fix: transition states before calling request callbacks

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -650,7 +650,9 @@ class Connection extends EventEmitter {
       if (cleanupTypeEnum === this.cleanupTypeEnum.REDIRECT) {
         this.emit('rerouting');
       } else if (cleanupTypeEnum !== this.cleanupTypeEnum.RETRY) {
-        this.emit('end');
+        process.nextTick(() => {
+          this.emit('end');
+        });
       }
       if (this.request) {
         const err = RequestError('Connection closed before request completed.', 'ECLOSE');
@@ -2038,8 +2040,9 @@ Connection.prototype.STATE = {
       socketError: function(err) {
         const sqlRequest = this.request;
         this.request = undefined;
-        sqlRequest.callback(err);
         this.transitionTo(this.STATE.FINAL);
+
+        sqlRequest.callback(err);
       },
       data: function(data) {
         this.clearRequestTimer(); // request timer is stopped on first data package
@@ -2076,8 +2079,10 @@ Connection.prototype.STATE = {
       socketError: function(err) {
         const sqlRequest = this.request;
         this.request = undefined;
-        sqlRequest.callback(err);
+
         this.transitionTo(this.STATE.FINAL);
+
+        sqlRequest.callback(err);
       },
       data: function(data) {
         this.sendDataToTokenStreamParser(data);

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -664,7 +664,7 @@ exports.execBadSql = function(test) {
 };
 
 exports.closeConnectionRequestPending = function(test) {
-  test.expect(1);
+  test.expect(3);
 
   var config = getConfig();
 


### PR DESCRIPTION
When a socket error happens while a request is executed, the request's callback should be executed _after_ switching to the `FINAL` state.

This ensures we are consistent with the "happy path", where the connection is switched to the `LOGGED_IN` state before executing request callbacks. It'll also ensure that trying to send another request in the callback will fail with a `Requests can only be made in the LoggedIn state, not the Final state` message instead of `Requests can only be made in the LoggedIn state, not the SentClientRequest state`.