### PR TITLE
Fix NTLM authentication

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ before_test:
 
   - mkdir C:\Users\appveyor\.tedious
   - ps: >-
-      Set-Content -Value '{
+      Set-Content -Value $('{
         "config": {
           "server": "localhost",
           "userName": "sa",
@@ -41,8 +41,18 @@ before_test:
           "options": {
             "database": "master"
           }
+        },
+
+        "ntlm": {
+          "server": "localhost",
+          "userName": "' + $env:username + '",
+          "password": "' + [Microsoft.Win32.Registry]::GetValue("HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon", "DefaultPassword", '') + '",
+          "domain": "' + $env:computername + '",
+          "options": {
+            "database": "master"
+          }
         }
-      }' -Path C:\Users\appveyor\.tedious\test-connection.json
+      }') -Path C:\Users\appveyor\.tedious\test-connection.json
 
 
 test_script:

--- a/src/connection.js
+++ b/src/connection.js
@@ -1927,6 +1927,8 @@ Connection.prototype.STATE = {
           this.debug.payload(function() {
             return payload.toString('  ');
           });
+
+          this.ntlmpacket = undefined;
         } else {
           if (this.loggedIn) {
             this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);


### PR DESCRIPTION
This fixes an issue with NTLM authentication that was introduced with a recent refactoring, as reported in https://github.com/tediousjs/tedious/issues/856.

It also extends the AppVeyor configuration to enable NTLM authentication tests, so regressions will be caught much earlier in the future. 🙇 

This fixes https://github.com/tediousjs/tedious/issues/856