### PR TITLE
Automatically tag new releases as `latest` after a week

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ node_js:
   - "11"
 
 stages:
-  - test
+  - name: test
+    if: (type = push) OR (type = pull_request)
   - name: azure
-    if: type = push
-  - lint
+    if: (type = push)
+  - name: lint
+    if: (type = push) OR (type = pull_request)
   - name: release
-    if: (branch = master) AND (type = push)
+    if: (type = push) AND (branch = master)
+  - name: tag-latest
+    if: (type = cron)
 
 services:
   - docker
@@ -104,3 +108,21 @@ jobs:
       before_install: skip
       before_script: skip
       script: npm run semantic-release
+
+    - stage: tag-latest
+      node_js: 8
+      before_install: skip
+      before_script: skip
+      script:
+        - |
+          read next latest <<< $(npm info tedious --json | jq -r '."dist-tags".next, ."dist-tags".latest')
+          if [ "$(printf '%s\n' "$latest" "$next" | sort -V | tail -n 1)" != "$latest" ]; then
+            date_format="%Y-%m-%dT%H:%M:%SZ"
+
+            publish_date=$(date -d $(npm info tedious --json | jq -r '.time["'"$next"'"]') +$date_format)
+            week_ago=$(date -d '-7 days' +$date_format)
+
+            if [[ "$publish_date" < "$week_ago" || "$publish_date" == "$week_ago" ]]; then
+              npm dist-tag add "tedious@$next" latest
+            fi
+          fi


### PR DESCRIPTION
This adds a new stage on Travis CI called `tag-latest`, that will automatically tag the current version from the `next` release channel as `latest`, if that version was published at least 7 days ago.

This stage will be triggered daily via a Travis CI cron job.