### PR TITLE
Cancellation: emit `error` on bulkload row streams

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1620,7 +1620,9 @@ class Connection extends EventEmitter {
         // There's two ways to handle request cancelation:
         if (message.writable) {
           // - if the message is still writable, we'll set the ignore bit
+          //   and end the message.
           message.ignore = true;
+          message.end();
         } else {
           // - but if the message has been ended (and thus has been fully sent off),
           //   we need to send an `ATTENTION` message to the server

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -403,9 +403,6 @@ exports.testStreamingBulkLoadWithCancel = function(test) {
   const totalRows = 500000;
   const connection = this.connection;
 
-  connection.on('error', function(err) {
-    test.ifError(err);
-  });
   startCreateTable();
 
   function startCreateTable() {
@@ -433,7 +430,7 @@ exports.testStreamingBulkLoadWithCancel = function(test) {
       read() {
         process.nextTick(() => {
           while (rowCount < totalRows) {
-            if (rowCount === totalRows - 100) {
+            if (rowCount === 10000) {
               bulkLoad.cancel();
             }
 
@@ -451,7 +448,9 @@ exports.testStreamingBulkLoadWithCancel = function(test) {
     });
 
     pipeline(rowSource, rowStream, function(err) {
-      test.ifError(err);
+      test.ok(err);
+      test.strictEqual(err.message, 'Canceled.');
+      test.strictEqual(rowCount, 10000);
     });
   }
 


### PR DESCRIPTION
This fixes a small issue with streaming `BulkLoad`s and request cancellation.

When a streaming bulk load request is cancelled, the row stream would still allow data to be written into it. By emitting a `error` event and destroying the stream, we can ensure that no more data can be written. This will also ensure that other streams that pipe into the row stream will be unpiped and can be cleaned up (e.g. by using `stream.pipeline`, this would happen automatically).

This could lead to request cancellation timeouts, as the row stream would keep continuing writing data to the message stream after the message ignore bit was set and the request cancellation timer could trigger before the row stream was ended.