### PR TITLE
fix: flow control in message-io.js

### DIFF
--- a/src/incoming-message-stream.js
+++ b/src/incoming-message-stream.js
@@ -26,6 +26,22 @@ class IncomingMessageStream extends Transform {
     this.bl = new BufferList();
   }
 
+  pause() {
+    super.pause();
+
+    if (this.currentMessage) {
+      this.currentMessage.pause();
+    }
+  }
+
+  resume() {
+    super.resume();
+
+    if (this.currentMessage) {
+      this.currentMessage.resume();
+    }
+  }
+
   processBufferedData(callback: () => void) {
     // The packet header is always 8 bytes of length.
     while (this.bl.length >= HEADER_LENGTH) {


### PR DESCRIPTION
Fix for #877

@arthurschreiber could you have a look at this? In Tedious 2.7.0 you changed the data flow architecture to a stream of streams. The inner stream must also be paused.