### PR TITLE
chore: fix npm configuration on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,8 @@ jobs:
 
     - stage: tag-latest
       node_js: 8
-      before_install: skip
+      before_install:
+        - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
       before_script: skip
       script:
         - |


### PR DESCRIPTION
I'm not really sure what changed, but it looks like `npm` does not actually know anything about the `NPM_TOKEN` environment variable. This seems to have broken automatic releases recently, but I couldn't find any documentation that this should have worked, ever. 🤷‍♂️