### PR TITLE
fix: connection failure using Managed Service Identity (MSI) token due to the wrong connection type 

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -125,7 +125,7 @@ class Connection extends EventEmitter {
         }
 
         authentication = {
-          type: 'azure-active-directory-password',
+          type: 'azure-active-directory-access-token',
           options: {
             token: options.token
           }
@@ -1892,7 +1892,7 @@ Connection.prototype.STATE = {
       },
       featureExtAck: function(token) {
         const { authentication } = this.config;
-        if (authentication.type === 'azure-active-directory-password') {
+        if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-access-token') {
           if (token.fedAuth === undefined) {
             this.loginError = ConnectionError('Did not receive Active Directory authentication acknowledgement');
             this.loggedIn = false;

--- a/test/unit/connection-config-validation.js
+++ b/test/unit/connection-config-validation.js
@@ -1,5 +1,5 @@
 const Connection = require('../../src/tedious').Connection;
-var assert = require('chai').assert
+var assert = require('chai').assert;
 
 function ensureConnectionIsClosed(connection, callback) {
   if (connection.closed) {
@@ -20,15 +20,15 @@ describe('Connection configuration validation', function() {
     config.options = { encrypt: false };
     config.server = 'localhost';
     done();
-  })
+  });
 
-  it('default transient retry interval',() =>  {
+  it('default transient retry interval', () => {
     const connection = new Connection(config);
     assert.strictEqual(connection.config.options.connectionRetryInterval, 500);
     ensureConnectionIsClosed(connection, () => {});
   });
 
-  it('good transient retry interval',() => {
+  it('good transient retry interval', () => {
     const goodRetryInterval = 75;
     config.options.connectionRetryInterval = goodRetryInterval;
     const connection = new Connection(config);
@@ -36,7 +36,7 @@ describe('Connection configuration validation', function() {
     ensureConnectionIsClosed(connection, () => {});
   });
 
-  it('bad transient retry interval',() =>  {
+  it('bad transient retry interval', () => {
     const zeroRetryInterval = 0;
     config.options.connectionRetryInterval = zeroRetryInterval;
     assert.throws(() => {
@@ -50,13 +50,13 @@ describe('Connection configuration validation', function() {
     });
   });
 
-  it('default max transient retries',() =>  {
+  it('default max transient retries', () => {
     const connection = new Connection(config);
     assert.strictEqual(connection.config.options.maxRetriesOnTransientErrors, 3);
     ensureConnectionIsClosed(connection, () => {});
   });
 
-  it('good max transient retries',() =>  {
+  it('good max transient retries', () => {
     const zeroMaxRetries = 0;
     config.options.maxRetriesOnTransientErrors = zeroMaxRetries;
     const firstConnection = new Connection(config);
@@ -72,7 +72,7 @@ describe('Connection configuration validation', function() {
     });
   });
 
-  it('bad max transient retries',() =>  {
+  it('bad max transient retries', () => {
     const negativeMaxRetries = -5;
     config.options.maxRetriesOnTransientErrors = negativeMaxRetries;
     assert.throws(() => {
@@ -80,7 +80,7 @@ describe('Connection configuration validation', function() {
     });
   });
 
-  it('bad azure ad authentication method',() =>  {
+  it('bad azure ad authentication method', () => {
     const authenticationMethod = 'abc';
     config.authentication = authenticationMethod;
     assert.throws(() => {
@@ -88,13 +88,12 @@ describe('Connection configuration validation', function() {
     });
   });
 
-  it('bad tds version for with azure ad',() =>  {
+  it('bad tds version for with azure ad', () => {
     const authenticationMethod = 'activedirectorypassword';
     config.authentication = authenticationMethod;
     config.options.tdsVersion = '7_2';
     assert.throws(() => {
       new Connection(config);
     });
-  })
-
-})
+  });
+});

--- a/test/unit/connection-config-validation.js
+++ b/test/unit/connection-config-validation.js
@@ -1,4 +1,5 @@
 const Connection = require('../../src/tedious').Connection;
+var assert = require('chai').assert
 
 function ensureConnectionIsClosed(connection, callback) {
   if (connection.closed) {
@@ -10,96 +11,90 @@ function ensureConnectionIsClosed(connection, callback) {
   connection.close();
 }
 
-exports['Connection configuration validation'] = {
-  'setUp': function(done) {
-    this.config = {};
-    this.config.options = { encrypt: false };
-    this.config.server = 'localhost';
+describe('Connection configuration validation', function() {
+
+  var config;
+
+  beforeEach(function(done) {
+    config = {};
+    config.options = { encrypt: false };
+    config.server = 'localhost';
     done();
-  },
+  })
 
-  'default transient retry interval': function(test) {
-    const connection = new Connection(this.config);
-    test.strictEqual(connection.config.options.connectionRetryInterval, 500);
-    ensureConnectionIsClosed(connection, () => { test.done(); });
-  },
+  it('default transient retry interval',() =>  {
+    const connection = new Connection(config);
+    assert.strictEqual(connection.config.options.connectionRetryInterval, 500);
+    ensureConnectionIsClosed(connection, () => {});
+  });
 
-  'good transient retry interval': function(test) {
+  it('good transient retry interval',() => {
     const goodRetryInterval = 75;
-    this.config.options.connectionRetryInterval = goodRetryInterval;
-    const connection = new Connection(this.config);
-    test.strictEqual(connection.config.options.connectionRetryInterval, goodRetryInterval);
-    ensureConnectionIsClosed(connection, () => { test.done(); });
-  },
+    config.options.connectionRetryInterval = goodRetryInterval;
+    const connection = new Connection(config);
+    assert.strictEqual(connection.config.options.connectionRetryInterval, goodRetryInterval);
+    ensureConnectionIsClosed(connection, () => {});
+  });
 
-  'bad transient retry interval': function(test) {
+  it('bad transient retry interval',() =>  {
     const zeroRetryInterval = 0;
-    this.config.options.connectionRetryInterval = zeroRetryInterval;
-    test.throws(() => {
-      new Connection(this.config);
+    config.options.connectionRetryInterval = zeroRetryInterval;
+    assert.throws(() => {
+      new Connection(config);
     });
 
     const negativeRetryInterval = -25;
-    this.config.options.connectionRetryInterval = negativeRetryInterval;
-    test.throws(() => {
-      new Connection(this.config);
+    config.options.connectionRetryInterval = negativeRetryInterval;
+    assert.throws(() => {
+      new Connection(config);
     });
+  });
 
-    test.done();
-  },
+  it('default max transient retries',() =>  {
+    const connection = new Connection(config);
+    assert.strictEqual(connection.config.options.maxRetriesOnTransientErrors, 3);
+    ensureConnectionIsClosed(connection, () => {});
+  });
 
-  'default max transient retries': function(test) {
-    const connection = new Connection(this.config);
-    test.strictEqual(connection.config.options.maxRetriesOnTransientErrors, 3);
-    ensureConnectionIsClosed(connection, () => { test.done(); });
-  },
-
-  'good max transient retries': function(test) {
+  it('good max transient retries',() =>  {
     const zeroMaxRetries = 0;
-    this.config.options.maxRetriesOnTransientErrors = zeroMaxRetries;
-    const firstConnection = new Connection(this.config);
-    test.strictEqual(firstConnection.config.options.maxRetriesOnTransientErrors, zeroMaxRetries);
+    config.options.maxRetriesOnTransientErrors = zeroMaxRetries;
+    const firstConnection = new Connection(config);
+    assert.strictEqual(firstConnection.config.options.maxRetriesOnTransientErrors, zeroMaxRetries);
 
     const nonZeroMaxRetries = 5;
-    this.config.options.maxRetriesOnTransientErrors = nonZeroMaxRetries;
-    const secondConnection = new Connection(this.config);
-    test.strictEqual(secondConnection.config.options.maxRetriesOnTransientErrors, nonZeroMaxRetries);
+    config.options.maxRetriesOnTransientErrors = nonZeroMaxRetries;
+    const secondConnection = new Connection(config);
+    assert.strictEqual(secondConnection.config.options.maxRetriesOnTransientErrors, nonZeroMaxRetries);
 
     ensureConnectionIsClosed(firstConnection, () => {
-      ensureConnectionIsClosed(secondConnection, () => {
-        test.done();
-      });
+      ensureConnectionIsClosed(secondConnection, () => {});
     });
-  },
+  });
 
-  'bad max transient retries': function(test) {
+  it('bad max transient retries',() =>  {
     const negativeMaxRetries = -5;
-    this.config.options.maxRetriesOnTransientErrors = negativeMaxRetries;
-    test.throws(() => {
-      new Connection(this.config);
+    config.options.maxRetriesOnTransientErrors = negativeMaxRetries;
+    assert.throws(() => {
+      new Connection(config);
     });
+  });
 
-    test.done();
-  },
-
-  'bad azure ad authentication method': function(test) {
+  it('bad azure ad authentication method',() =>  {
     const authenticationMethod = 'abc';
-    this.config.authentication = authenticationMethod;
-    test.throws(() => {
-      new Connection(this.config);
+    config.authentication = authenticationMethod;
+    assert.throws(() => {
+      new Connection(config);
     });
+  });
 
-    test.done();
-  },
-
-  'bad tds version for with azure ad': function(test) {
+  it('bad tds version for with azure ad',() =>  {
     const authenticationMethod = 'activedirectorypassword';
-    this.config.authentication = authenticationMethod;
-    this.config.options.tdsVersion = '7_2';
-    test.throws(() => {
-      new Connection(this.config);
+    config.authentication = authenticationMethod;
+    config.options.tdsVersion = '7_2';
+    assert.throws(() => {
+      new Connection(config);
     });
+  })
 
-    test.done();
-  }
-};
+})

--- a/test/unit/tedious-test.js
+++ b/test/unit/tedious-test.js
@@ -1,52 +1,48 @@
 const Connection = require('../../src/tedious').Connection;
 const ISOLATION_LEVEL = require('../../src/tedious').ISOLATION_LEVEL;
 const TYPES = require('../../src/tedious').TYPES;
+var assert = require('chai').assert
 
-exports.types = function(test) {
-  test.ok(TYPES);
-  test.ok(TYPES.VarChar);
+describe('tedious-test', function() {
 
-  test.done();
-};
+  it('types' ,()=> {
+    assert.ok(TYPES);
+    assert.ok(TYPES.VarChar);
+  });
 
-exports.isolationLevel = function(test) {
-  test.ok(ISOLATION_LEVEL);
-  test.ok(ISOLATION_LEVEL.READ_UNCOMMITTED);
+  it('isolationLevel' ,()=> {
+    assert.ok(ISOLATION_LEVEL);
+    assert.ok(ISOLATION_LEVEL.READ_UNCOMMITTED);
+  });
 
-  test.done();
-};
+  it('connection' ,()=> {
+    assert.ok(Connection);
+  });
 
-exports.connection = function(test) {
-  test.ok(Connection);
-
-  test.done();
-};
-
-exports.connectionDoesNotModifyPassedConfig = function(test) {
-  var config = {
-    server: 'localhost',
-    userName: 'sa',
-    password: 'sapwd',
-    options: {
-      encrypt: false,
-      port: 1234,
-      cryptoCredentialsDetails: {
-        ciphers: 'DEFAULT'
+  it('connectionDoesNotModifyPassedConfig' ,()=> {
+    var config = {
+      server: 'localhost',
+      userName: 'sa',
+      password: 'sapwd',
+      options: {
+        encrypt: false,
+        port: 1234,
+        cryptoCredentialsDetails: {
+          ciphers: 'DEFAULT'
+        }
       }
-    }
-  };
+    };
 
-  var connection = new Connection(config);
+    var connection = new Connection(config);
 
-  test.notStrictEqual(connection.config, config);
-  test.notStrictEqual(connection.config.options, config.options);
+    assert.notStrictEqual(connection.config, config);
+    assert.notStrictEqual(connection.config.options, config.options);
 
-  // Test that we did not do a deep copy of the cryptoCredentialsDetails,
-  // as we never modify that value inside tedious.
-  test.strictEqual(
-    connection.config.options.cryptoCredentialsDetails,
-    config.options.cryptoCredentialsDetails
-  );
-
-  test.done();
-};
+    // Test that we did not do a deep copy of the cryptoCredentialsDetails,
+    // as we never modify that value inside tedious.
+    assert.strictEqual(
+      connection.config.options.cryptoCredentialsDetails,
+      config.options.cryptoCredentialsDetails
+    );
+  });
+})

--- a/test/unit/tedious-test.js
+++ b/test/unit/tedious-test.js
@@ -1,25 +1,25 @@
 const Connection = require('../../src/tedious').Connection;
 const ISOLATION_LEVEL = require('../../src/tedious').ISOLATION_LEVEL;
 const TYPES = require('../../src/tedious').TYPES;
-var assert = require('chai').assert
+var assert = require('chai').assert;
 
 describe('tedious-test', function() {
 
-  it('types' ,()=> {
+  it('types', () => {
     assert.ok(TYPES);
     assert.ok(TYPES.VarChar);
   });
 
-  it('isolationLevel' ,()=> {
+  it('isolationLevel', () => {
     assert.ok(ISOLATION_LEVEL);
     assert.ok(ISOLATION_LEVEL.READ_UNCOMMITTED);
   });
 
-  it('connection' ,()=> {
+  it('connection', () => {
     assert.ok(Connection);
   });
 
-  it('connectionDoesNotModifyPassedConfig' ,()=> {
+  it('connectionDoesNotModifyPassedConfig', () => {
     var config = {
       server: 'localhost',
       userName: 'sa',
@@ -45,4 +45,4 @@ describe('tedious-test', function() {
       config.options.cryptoCredentialsDetails
     );
   });
-})
+});

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -1,5 +1,6 @@
 var TYPE = require('../../src/data-type').typeByName;
 var assert = require('chai').assert
+
 describe('Validations', function() {
   it('Bit', () => {
     var value = TYPE.Bit.validate(null);

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -1,401 +1,354 @@
 var TYPE = require('../../src/data-type').typeByName;
+var assert = require('chai').assert
+describe('Validations', function() {
+  it('Bit', () => {
+    var value = TYPE.Bit.validate(null);
+    assert.strictEqual(value, null);
 
-exports.Bit = function(test) {
-  var value = TYPE.Bit.validate(null);
-  test.strictEqual(value, null);
+    var value = TYPE.Bit.validate(true);
+    assert.strictEqual(value, true);
 
-  value = TYPE.Bit.validate(true);
-  test.strictEqual(value, true);
+    var value = TYPE.Bit.validate('asdf');
+    assert.strictEqual(value, true);
 
-  value = TYPE.Bit.validate('asdf');
-  test.strictEqual(value, true);
+    var value = TYPE.Bit.validate('');
+    assert.strictEqual(value, false);
 
-  value = TYPE.Bit.validate('');
-  test.strictEqual(value, false);
+    var value = TYPE.Bit.validate(55);
+    assert.strictEqual(value, true);
 
-  value = TYPE.Bit.validate(55);
-  test.strictEqual(value, true);
+    var value = TYPE.Bit.validate(0);
+    assert.strictEqual(value, false);
 
-  value = TYPE.Bit.validate(0);
-  test.strictEqual(value, false);
+  });
 
-  test.done();
-};
+  it('TinyInt', () =>  {
+    var value = TYPE.TinyInt.validate(null);
+    assert.strictEqual(value, null);
 
-exports.TinyInt = function(test) {
-  var value = TYPE.TinyInt.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.TinyInt.validate(15);
+    assert.strictEqual(value, 15);
 
-  value = TYPE.TinyInt.validate(15);
-  test.strictEqual(value, 15);
+    value = TYPE.TinyInt.validate('15');
+    assert.strictEqual(value, 15);
 
-  value = TYPE.TinyInt.validate('15');
-  test.strictEqual(value, 15);
+    value = TYPE.TinyInt.validate(256);
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.TinyInt.validate(256);
-  test.ok(value instanceof TypeError);
+  it('SmallInt', () =>  {
+    var value = TYPE.SmallInt.validate(null);
+    assert.strictEqual(value, null);
 
-  test.done();
-};
+    value = TYPE.SmallInt.validate(-32768);
+    assert.strictEqual(value, -32768);
 
-exports.SmallInt = function(test) {
-  var value = TYPE.SmallInt.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.SmallInt.validate(-32769);
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.SmallInt.validate(-32768);
-  test.strictEqual(value, -32768);
+  it('Int', () =>  {
+    var value = TYPE.Int.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.SmallInt.validate(-32769);
-  test.ok(value instanceof TypeError);
+    value = TYPE.Int.validate(2147483647);
+    assert.strictEqual(value, 2147483647);
 
-  test.done();
-};
+    value = TYPE.Int.validate(2147483648);
+    assert.ok(value instanceof TypeError);
+  });
 
-exports.Int = function(test) {
-  var value = TYPE.Int.validate(null);
-  test.strictEqual(value, null);
+  it('BigInt', () =>  {
+    var value = TYPE.BigInt.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Int.validate(2147483647);
-  test.strictEqual(value, 2147483647);
+    value = TYPE.BigInt.validate(2147483647);
+    assert.strictEqual(value, 2147483647);
 
-  value = TYPE.Int.validate(2147483648);
-  test.ok(value instanceof TypeError);
+    value = TYPE.BigInt.validate(-9007199254740991);
+    assert.strictEqual(value, -9007199254740991);
 
-  test.done();
-};
+    value = TYPE.BigInt.validate(9007199254740991);
+    assert.strictEqual(value, 9007199254740991);
 
-exports.BigInt = function(test) {
-  var value = TYPE.BigInt.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.BigInt.validate(-9007199254740992);
+    assert.ok(value instanceof TypeError);
 
-  value = TYPE.BigInt.validate(2147483647);
-  test.strictEqual(value, 2147483647);
+    value = TYPE.BigInt.validate(9007199254740992);
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.BigInt.validate(-9007199254740991);
-  test.strictEqual(value, -9007199254740991);
+  it('SmallDateTime', () => {
+    var value = TYPE.SmallDateTime.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.BigInt.validate(9007199254740991);
-  test.strictEqual(value, 9007199254740991);
+    var date = new Date();
+    value = TYPE.SmallDateTime.validate(date);
+    assert.strictEqual(+value, +date);
 
-  value = TYPE.BigInt.validate(-9007199254740992);
-  test.ok(value instanceof TypeError);
+    value = TYPE.SmallDateTime.validate('2015-02-12T16:43:13.632Z');
+    assert.strictEqual(+value, 1423759393632);
 
-  value = TYPE.BigInt.validate(9007199254740992);
-  test.ok(value instanceof TypeError);
+    value = TYPE.SmallDateTime.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  test.done();
-};
+  it('DateTime', () => {
+    var value = TYPE.DateTime.validate(null);
+    assert.strictEqual(value, null);
 
-exports.SmallDateTime = function(test) {
-  var value = TYPE.SmallDateTime.validate(null);
-  test.strictEqual(value, null);
+    var date = new Date();
+    value = TYPE.DateTime.validate(date);
+    assert.strictEqual(+value, +date);
 
-  var date = new Date();
-  value = TYPE.SmallDateTime.validate(date);
-  test.strictEqual(+value, +date);
+    value = TYPE.DateTime.validate('2015-02-12T16:43:13.632Z');
+    assert.strictEqual(+value, 1423759393632);
 
-  value = TYPE.SmallDateTime.validate('2015-02-12T16:43:13.632Z');
-  test.strictEqual(+value, 1423759393632);
+    value = TYPE.DateTime.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.SmallDateTime.validate('xxx');
-  test.ok(value instanceof TypeError);
+  it('DateTime2', () => {
+    var value = TYPE.DateTime2.validate(null);
+    assert.strictEqual(value, null);
 
-  test.done();
-};
+    var date = new Date();
+    value = TYPE.DateTime2.validate(date);
+    assert.strictEqual(+value, +date);
 
-exports.DateTime = function(test) {
-  var value = TYPE.DateTime.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.DateTime2.validate('2015-02-12T16:43:13.632Z');
+    assert.strictEqual(+value, 1423759393632);
 
-  var date = new Date();
-  value = TYPE.DateTime.validate(date);
-  test.strictEqual(+value, +date);
+    value = TYPE.DateTime2.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.DateTime.validate('2015-02-12T16:43:13.632Z');
-  test.strictEqual(+value, 1423759393632);
+  it('Time', () => {
+    var value = TYPE.Time.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.DateTime.validate('xxx');
-  test.ok(value instanceof TypeError);
+    var date = new Date();
+    value = TYPE.Time.validate(date);
+    assert.strictEqual(+value, +date);
 
-  test.done();
-};
+    value = TYPE.Time.validate('2015-02-12T16:43:13.632Z');
+    assert.strictEqual(+value, 1423759393632);
 
-exports.DateTime2 = function(test) {
-  var value = TYPE.DateTime2.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Time.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  var date = new Date();
-  value = TYPE.DateTime2.validate(date);
-  test.strictEqual(+value, +date);
+  it('DateTimeOffset', () => {
+    var value = TYPE.DateTimeOffset.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.DateTime2.validate('2015-02-12T16:43:13.632Z');
-  test.strictEqual(+value, 1423759393632);
+    var date = new Date();
+    value = TYPE.DateTimeOffset.validate(date);
+    assert.strictEqual(+value, +date);
 
-  value = TYPE.DateTime2.validate('xxx');
-  test.ok(value instanceof TypeError);
+    value = TYPE.DateTimeOffset.validate('2015-02-12T16:43:13.632Z');
+    assert.strictEqual(+value, 1423759393632);
 
-  test.done();
-};
+    value = TYPE.DateTimeOffset.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-exports.Time = function(test) {
-  var value = TYPE.Time.validate(null);
-  test.strictEqual(value, null);
+  it('Real', () => {
+    var value = TYPE.Real.validate(null);
+    assert.strictEqual(value, null);
 
-  var date = new Date();
-  value = TYPE.Time.validate(date);
-  test.strictEqual(+value, +date);
+    value = TYPE.Real.validate(1516.61556);
+    assert.strictEqual(value, 1516.61556);
 
-  value = TYPE.Time.validate('2015-02-12T16:43:13.632Z');
-  test.strictEqual(+value, 1423759393632);
+    value = TYPE.Real.validate('1516.61556');
+    assert.strictEqual(value, 1516.61556);
 
-  value = TYPE.Time.validate('xxx');
-  test.ok(value instanceof TypeError);
+    value = TYPE.Real.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  test.done();
-};
+  it('Float', () => {
+    var value = TYPE.Float.validate(null);
+    assert.strictEqual(value, null);
 
-exports.DateTimeOffset = function(test) {
-  var value = TYPE.DateTimeOffset.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Float.validate(1516.61556);
+    assert.strictEqual(value, 1516.61556);
 
-  var date = new Date();
-  value = TYPE.DateTimeOffset.validate(date);
-  test.strictEqual(+value, +date);
+    value = TYPE.Float.validate('1516.61556');
+    assert.strictEqual(value, 1516.61556);
 
-  value = TYPE.DateTimeOffset.validate('2015-02-12T16:43:13.632Z');
-  test.strictEqual(+value, 1423759393632);
+    value = TYPE.Float.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.DateTimeOffset.validate('xxx');
-  test.ok(value instanceof TypeError);
+  it('Decimal', () => {
+    var value = TYPE.Decimal.validate(null);
+    assert.strictEqual(value, null);
 
-  test.done();
-};
+    value = TYPE.Decimal.validate(1516.61556);
+    assert.strictEqual(value, 1516.61556);
 
-exports.Real = function(test) {
-  var value = TYPE.Real.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Decimal.validate('1516.61556');
+    assert.strictEqual(value, 1516.61556);
 
-  value = TYPE.Real.validate(1516.61556);
-  test.strictEqual(value, 1516.61556);
+    value = TYPE.Decimal.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.Real.validate('1516.61556');
-  test.strictEqual(value, 1516.61556);
+  it('Numeric', () => {
+    var value = TYPE.Numeric.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Real.validate('xxx');
-  test.ok(value instanceof TypeError);
+    value = TYPE.Numeric.validate(1516.61556);
+    assert.strictEqual(value, 1516.61556);
 
-  test.done();
-};
+    value = TYPE.Numeric.validate('1516.61556');
+    assert.strictEqual(value, 1516.61556);
 
-exports.Float = function(test) {
-  var value = TYPE.Float.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Numeric.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.Float.validate(1516.61556);
-  test.strictEqual(value, 1516.61556);
+  it('Money', () => {
+    var value = TYPE.Money.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Float.validate('1516.61556');
-  test.strictEqual(value, 1516.61556);
+    value = TYPE.Money.validate(1516.61556);
+    assert.strictEqual(value, 1516.61556);
 
-  value = TYPE.Float.validate('xxx');
-  test.ok(value instanceof TypeError);
+    value = TYPE.Money.validate('1516.61556');
+    assert.strictEqual(value, 1516.61556);
 
-  test.done();
-};
+    value = TYPE.Money.validate('xxx');
+    assert.ok(value instanceof TypeError);
+  });
 
-exports.Decimal = function(test) {
-  var value = TYPE.Decimal.validate(null);
-  test.strictEqual(value, null);
+  it('SmallMoney', () => {
+    var value = TYPE.SmallMoney.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Decimal.validate(1516.61556);
-  test.strictEqual(value, 1516.61556);
+    value = TYPE.SmallMoney.validate(214748.3647);
+    assert.strictEqual(value, 214748.3647);
 
-  value = TYPE.Decimal.validate('1516.61556');
-  test.strictEqual(value, 1516.61556);
+    value = TYPE.SmallMoney.validate(214748.3648);
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.Decimal.validate('xxx');
-  test.ok(value instanceof TypeError);
+  it('Image', () => {
+    var value = TYPE.Image.validate(null);
+    assert.strictEqual(value, null);
 
-  test.done();
-};
+    var buffer = Buffer.from([0x00, 0x01]);
+    value = TYPE.Image.validate(buffer);
+    assert.strictEqual(value, buffer);
 
-exports.Numeric = function(test) {
-  var value = TYPE.Numeric.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Image.validate({});
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.Numeric.validate(1516.61556);
-  test.strictEqual(value, 1516.61556);
+  it('Binary', () => {
+    var value = TYPE.Binary.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Numeric.validate('1516.61556');
-  test.strictEqual(value, 1516.61556);
+    var buffer = Buffer.from([0x00, 0x01]);
+    value = TYPE.Binary.validate(buffer);
+    assert.strictEqual(value, buffer);
 
-  value = TYPE.Numeric.validate('xxx');
-  test.ok(value instanceof TypeError);
+    value = TYPE.Binary.validate({});
+    assert.ok(value instanceof TypeError);
+  });
 
-  test.done();
-};
+  it('VarBinary', () => {
+    var value = TYPE.VarBinary.validate(null);
+    assert.strictEqual(value, null);
 
-exports.Money = function(test) {
-  var value = TYPE.Money.validate(null);
-  test.strictEqual(value, null);
+    var buffer = Buffer.from([0x00, 0x01]);
+    value = TYPE.VarBinary.validate(buffer);
+    assert.strictEqual(value, buffer);
 
-  value = TYPE.Money.validate(1516.61556);
-  test.strictEqual(value, 1516.61556);
+    value = TYPE.VarBinary.validate({});
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.Money.validate('1516.61556');
-  test.strictEqual(value, 1516.61556);
+  it('Text', () => {
+    var value = TYPE.Text.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Money.validate('xxx');
-  test.ok(value instanceof TypeError);
+    value = TYPE.Text.validate('asdf');
+    assert.strictEqual(value, 'asdf');
 
-  test.done();
-};
+    value = TYPE.Text.validate(Buffer.from('asdf', 'utf8'));
+    assert.strictEqual(value, 'asdf');
 
-exports.SmallMoney = function(test) {
-  var value = TYPE.SmallMoney.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Text.validate({ toString: null });
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.SmallMoney.validate(214748.3647);
-  test.strictEqual(value, 214748.3647);
+  it('VarChar', () => {
+    var value = TYPE.VarChar.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.SmallMoney.validate(214748.3648);
-  test.ok(value instanceof TypeError);
+    value = TYPE.VarChar.validate('asdf');
+    assert.strictEqual(value, 'asdf');
 
-  test.done();
-};
+    value = TYPE.VarChar.validate(Buffer.from('asdf', 'utf8'));
+    assert.strictEqual(value, 'asdf');
 
-exports.Image = function(test) {
-  var value = TYPE.Image.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.VarChar.validate({ toString: null });
+    assert.ok(value instanceof TypeError);
+  });
 
-  var buffer = Buffer.from([0x00, 0x01]);
-  value = TYPE.Image.validate(buffer);
-  test.strictEqual(value, buffer);
+  it('NVarChar', () => {
+    var value = TYPE.NVarChar.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Image.validate({});
-  test.ok(value instanceof TypeError);
+    value = TYPE.NVarChar.validate('asdf');
+    assert.strictEqual(value, 'asdf');
 
-  test.done();
-};
+    value = TYPE.NVarChar.validate(Buffer.from('asdf', 'utf8'));
+    assert.strictEqual(value, 'asdf');
 
-exports.Binary = function(test) {
-  var value = TYPE.Binary.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.NVarChar.validate({ toString: null });
+    assert.ok(value instanceof TypeError);
+  });
 
-  var buffer = Buffer.from([0x00, 0x01]);
-  value = TYPE.Binary.validate(buffer);
-  test.strictEqual(value, buffer);
+  it('Char', () => {
+    var value = TYPE.Char.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Binary.validate({});
-  test.ok(value instanceof TypeError);
+    value = TYPE.Char.validate('asdf');
+    assert.strictEqual(value, 'asdf');
 
-  test.done();
-};
+    value = TYPE.Char.validate(Buffer.from('asdf', 'utf8'));
+    assert.strictEqual(value, 'asdf');
 
-exports.VarBinary = function(test) {
-  var value = TYPE.VarBinary.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.Char.validate({ toString: null });
+    assert.ok(value instanceof TypeError);
+  });
 
-  var buffer = Buffer.from([0x00, 0x01]);
-  value = TYPE.VarBinary.validate(buffer);
-  test.strictEqual(value, buffer);
+  it('NChar', () => {
+    var value = TYPE.NChar.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.VarBinary.validate({});
-  test.ok(value instanceof TypeError);
+    value = TYPE.NChar.validate('asdf');
+    assert.strictEqual(value, 'asdf');
 
-  test.done();
-};
+    value = TYPE.NChar.validate(Buffer.from('asdf', 'utf8'));
+    assert.strictEqual(value, 'asdf');
 
-exports.Text = function(test) {
-  var value = TYPE.Text.validate(null);
-  test.strictEqual(value, null);
+    value = TYPE.NChar.validate({ toString: null });
+    assert.ok(value instanceof TypeError);
+  });
 
-  value = TYPE.Text.validate('asdf');
-  test.strictEqual(value, 'asdf');
+  it('TVP', () => {
+    var value = TYPE.TVP.validate(null);
+    assert.strictEqual(value, null);
 
-  value = TYPE.Text.validate(Buffer.from('asdf', 'utf8'));
-  test.strictEqual(value, 'asdf');
+    var table = { columns: [], rows: [] };
+    value = TYPE.TVP.validate(table);
+    assert.strictEqual(value, table);
 
-  value = TYPE.Text.validate({ toString: null });
-  test.ok(value instanceof TypeError);
-
-  test.done();
-};
-
-exports.VarChar = function(test) {
-  var value = TYPE.VarChar.validate(null);
-  test.strictEqual(value, null);
-
-  value = TYPE.VarChar.validate('asdf');
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.VarChar.validate(Buffer.from('asdf', 'utf8'));
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.VarChar.validate({ toString: null });
-  test.ok(value instanceof TypeError);
-
-  test.done();
-};
-
-exports.NVarChar = function(test) {
-  var value = TYPE.NVarChar.validate(null);
-  test.strictEqual(value, null);
-
-  value = TYPE.NVarChar.validate('asdf');
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.NVarChar.validate(Buffer.from('asdf', 'utf8'));
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.NVarChar.validate({ toString: null });
-  test.ok(value instanceof TypeError);
-
-  test.done();
-};
-
-exports.Char = function(test) {
-  var value = TYPE.Char.validate(null);
-  test.strictEqual(value, null);
-
-  value = TYPE.Char.validate('asdf');
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.Char.validate(Buffer.from('asdf', 'utf8'));
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.Char.validate({ toString: null });
-  test.ok(value instanceof TypeError);
-
-  test.done();
-};
-
-exports.NChar = function(test) {
-  var value = TYPE.NChar.validate(null);
-  test.strictEqual(value, null);
-
-  value = TYPE.NChar.validate('asdf');
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.NChar.validate(Buffer.from('asdf', 'utf8'));
-  test.strictEqual(value, 'asdf');
-
-  value = TYPE.NChar.validate({ toString: null });
-  test.ok(value instanceof TypeError);
-
-  test.done();
-};
-
-exports.TVP = function(test) {
-  var value = TYPE.TVP.validate(null);
-  test.strictEqual(value, null);
-
-  var table = { columns: [], rows: [] };
-  value = TYPE.TVP.validate(table);
-  test.strictEqual(value, table);
-
-  value = TYPE.TVP.validate({});
-  test.ok(value instanceof TypeError);
-
-  test.done();
-};
+    value = TYPE.TVP.validate({});
+    assert.ok(value instanceof TypeError);
+  });
+})

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -1,29 +1,29 @@
 var TYPE = require('../../src/data-type').typeByName;
-var assert = require('chai').assert
+var assert = require('chai').assert;
 
 describe('Validations', function() {
   it('Bit', () => {
     var value = TYPE.Bit.validate(null);
     assert.strictEqual(value, null);
 
-    var value = TYPE.Bit.validate(true);
+    value = TYPE.Bit.validate(true);
     assert.strictEqual(value, true);
 
-    var value = TYPE.Bit.validate('asdf');
+    value = TYPE.Bit.validate('asdf');
     assert.strictEqual(value, true);
 
-    var value = TYPE.Bit.validate('');
+    value = TYPE.Bit.validate('');
     assert.strictEqual(value, false);
 
-    var value = TYPE.Bit.validate(55);
+    value = TYPE.Bit.validate(55);
     assert.strictEqual(value, true);
 
-    var value = TYPE.Bit.validate(0);
+    value = TYPE.Bit.validate(0);
     assert.strictEqual(value, false);
 
   });
 
-  it('TinyInt', () =>  {
+  it('TinyInt', () => {
     var value = TYPE.TinyInt.validate(null);
     assert.strictEqual(value, null);
 
@@ -37,7 +37,7 @@ describe('Validations', function() {
     assert.ok(value instanceof TypeError);
   });
 
-  it('SmallInt', () =>  {
+  it('SmallInt', () => {
     var value = TYPE.SmallInt.validate(null);
     assert.strictEqual(value, null);
 
@@ -48,7 +48,7 @@ describe('Validations', function() {
     assert.ok(value instanceof TypeError);
   });
 
-  it('Int', () =>  {
+  it('Int', () => {
     var value = TYPE.Int.validate(null);
     assert.strictEqual(value, null);
 
@@ -59,7 +59,7 @@ describe('Validations', function() {
     assert.ok(value instanceof TypeError);
   });
 
-  it('BigInt', () =>  {
+  it('BigInt', () => {
     var value = TYPE.BigInt.validate(null);
     assert.strictEqual(value, null);
 
@@ -352,4 +352,4 @@ describe('Validations', function() {
     value = TYPE.TVP.validate({});
     assert.ok(value instanceof TypeError);
   });
-})
+});


### PR DESCRIPTION
Using Managed Service Identity (MSI) token forming connection will cause an error. It is caused by a logic flaw within the connection.js. This PR is fixing this specific error. 