### PR TITLE
fix: connection failure using Managed Service Identity (MSI) token due to the wrong authentication type

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -125,7 +125,7 @@ class Connection extends EventEmitter {
         }
 
         authentication = {
-          type: 'azure-active-directory-password',
+          type: 'azure-active-directory-access-token',
           options: {
             token: options.token
           }
@@ -1892,7 +1892,7 @@ Connection.prototype.STATE = {
       },
       featureExtAck: function(token) {
         const { authentication } = this.config;
-        if (authentication.type === 'azure-active-directory-password') {
+        if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-access-token') {
           if (token.fedAuth === undefined) {
             this.loginError = ConnectionError('Did not receive Active Directory authentication acknowledgement');
             this.loggedIn = false;


### PR DESCRIPTION
Using Managed Service Identity (MSI) token forming connection will cause an error. It is caused by a logic flaw within the connection.js. This PR is fixing this specific error.