### PR TITLE
Fix typo in getting started snippet

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -25,6 +25,7 @@ title: Getting started
       options: {  
         userName: "test",
         password: "test",
+      }
     }
   };
 


### PR DESCRIPTION
Small fix in a snippet on the Getting Started page. Thanks for maintain such a great project!