### PR TITLE
Fix `IncomingMessageStream` packet processing when paused

### DIFF
--- a/src/incoming-message-stream.js
+++ b/src/incoming-message-stream.js
@@ -59,7 +59,7 @@ class IncomingMessageStream extends Transform {
 
         let message = this.currentMessage;
         if (message === undefined) {
-          message = new Message({ type: packet.type(), resetConnection: false });
+          this.currentMessage = message = new Message({ type: packet.type(), resetConnection: false });
           this.push(message);
         }
 
@@ -73,7 +73,6 @@ class IncomingMessageStream extends Transform {
           message.end(packet.data());
           return;
         } else {
-          this.currentMessage = message;
           // If too much data is buffering up in the
           // current message, wait for it to drain.
           if (!message.write(packet.data())) {

--- a/test/unit/incoming-message-stream-test.js
+++ b/test/unit/incoming-message-stream-test.js
@@ -106,4 +106,73 @@ describe('IncomingMessageStream', function() {
       });
     });
   });
+
+  it('correctly handles the last package coming in after the stream was paused', function(done) {
+    const packetData = Buffer.from('test1234');
+    const packetHeader = Buffer.alloc(8);
+
+    let offset = 0;
+    offset = packetHeader.writeUInt8(0x11, offset);
+    offset = packetHeader.writeUInt8(0x00, offset);
+    offset = packetHeader.writeUInt16BE(8 + packetData.length, offset);
+    offset = packetHeader.writeUInt16BE(0x0000, offset);
+    offset = packetHeader.writeUInt8(1, offset);
+    packetHeader.writeUInt8(0x00, offset);
+
+    const firstPacket = Buffer.concat([packetHeader, packetData]);
+
+    offset = 0;
+    offset = packetHeader.writeUInt8(0x11, offset);
+    offset = packetHeader.writeUInt8(0x01, offset);
+    offset = packetHeader.writeUInt16BE(8 + packetData.length, offset);
+    offset = packetHeader.writeUInt16BE(0x0000, offset);
+    offset = packetHeader.writeUInt8(1, offset);
+    packetHeader.writeUInt8(0x00, offset);
+
+    const secondPacket = Buffer.concat([packetHeader, packetData]);
+
+    const incoming = new IncomingMessageStream(new Debug());
+
+    const result = new BufferList(function(err, res) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.deepEqual(res, Buffer.concat([ packetData, packetData ]));
+
+      done();
+    });
+
+    let messageEnded = false;
+    incoming.on('data', function(message) {
+      assert.instanceOf(message, Message);
+
+      message.on('end', function() {
+        messageEnded = true;
+      });
+
+      message.pipe(result);
+    });
+
+    incoming.write(firstPacket, function() {
+      const writtenData = result.slice();
+
+      assert.strictEqual(writtenData.length, 8);
+      assert.deepEqual(writtenData, packetData);
+
+      incoming.pause();
+
+      incoming.write(secondPacket, function() {
+        const writtenData = result.slice();
+
+        assert.strictEqual(writtenData.length, 16);
+        assert.deepEqual(writtenData, Buffer.concat([ packetData, packetData ]));
+
+        assert.strictEqual(messageEnded, true);
+      });
+
+      assert.isFalse(messageEnded);
+      incoming.resume();
+    });
+  });
 });


### PR DESCRIPTION
The `IncomingMessageStream` handled the last packet of an incoming message incorrectly, when the stream was paused right before the that message was received. This could cause the `tedious` connection to become stuck in an undefined state and become unusable for further processing.

Fixes #899.