### PR TITLE
Disable caching on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
   - "10"
   - "11"
 
+cache:
+  npm: false
+
 stages:
   - name: test
     if: (type = push) OR (type = pull_request)


### PR DESCRIPTION
Starting July 2019, npm caching on Travis is enabled by default, but unfortunately breaks the build on Node.js 6.x.