### PR TITLE
Run linting CI step on Node.js 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 jobs:
   include:
     - stage: lint
-      node_js: 6
+      node_js: 8
       before_install: skip
       before_script: skip
       script:


### PR DESCRIPTION
`commitlint` seems to no longer support Node.js < 8.x, so let's just run the whole linting CI step on a version that is supported.