### PR TITLE
Fix compatibility with Node.js 12.4 and newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "6"
   - "8"
   - "10"
-  - "11"
+  - "12"
 
 cache:
   npm: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
-    - nodejs_version: "11"
+    - nodejs_version: "12"
 
 branches:
   only:

--- a/src/message-io.js
+++ b/src/message-io.js
@@ -57,6 +57,11 @@ module.exports = class MessageIO extends EventEmitter {
       this.debug.log('Packet size changed from ' + this.outgoingMessageStream.packetSize + ' to ' + packetSize);
       this.outgoingMessageStream.packetSize = packetSize;
     }
+
+    if (this.securePair) {
+      this.securePair.cleartext.setMaxSendFragment(this.outgoingMessageStream.packetSize);
+    }
+
     return this.outgoingMessageStream.packetSize;
   }
 
@@ -97,6 +102,7 @@ module.exports = class MessageIO extends EventEmitter {
   }
 
   encryptAllFutureTraffic() {
+    this.securePair.cleartext.setMaxSendFragment(this.outgoingMessageStream.packetSize);
     this.securePair.encrypted.removeAllListeners('data');
 
     this.outgoingMessageStream.unpipe(this.socket);


### PR DESCRIPTION
SQL Server expects individual TLS segments to never contain more data than the negotiated TDS packet size. If this is not the case, SQL Server will simply drop the connection without warning.

Since Node.js 12.4, `TLSSocket`s try to fit as much data as possible into a TLS fragment. Because the default TLS fragment size is `16384` bytes, and this does not necessarily match the negotiated TDS packet size, users of Node.js 12.4 and newer would encounter sudden connection drops (e.g. when sending large queries).

By keeping the TLS fragment size and the negoitated TDS packet size in sync, we can make sure SQL Server does not drop the connection.

Fixes: https://github.com/tediousjs/tedious/issues/923