### PR TITLE
Emit cancel event AFTER setting the error

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1114,10 +1114,10 @@ class Connection extends EventEmitter {
   requestTimeout() {
     this.requestTimer = undefined;
     const request = this.request;
-    request.cancel();
     const timeout = (request.timeout !== undefined) ? request.timeout : this.config.options.requestTimeout;
     const message = 'Timeout: Request failed to complete in ' + timeout + 'ms';
     request.error = RequestError(message, 'ETIMEOUT');
+	request.cancel();
   }
 
   retryTimeout() {

--- a/src/connection.js
+++ b/src/connection.js
@@ -1117,7 +1117,7 @@ class Connection extends EventEmitter {
     const timeout = (request.timeout !== undefined) ? request.timeout : this.config.options.requestTimeout;
     const message = 'Timeout: Request failed to complete in ' + timeout + 'ms';
     request.error = RequestError(message, 'ETIMEOUT');
-	request.cancel();
+    request.cancel();
   }
 
   retryTimeout() {


### PR DESCRIPTION
Without this PR, the only way for the cancel event listener to access the timeout error would be

```
request.on('cancel', (...args) => {
	setTimeout(() => {
		console.log('error', request.error);
	}, 1000);
});
```

With this pull request is applied, the undesirable timeout is no longer needed:
```
request.on('cancel', (...args) => {
	console.log('error', request.error);
});
```