### PR TITLE
Disable Azure Active Directory Password build job on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,29 +91,6 @@ jobs:
       before_script: skip
       script: npx nyc --reporter=lcov npm run test-integration && npx codecov
 
-    - stage: azure
-      node_js: 8
-      before_install:
-      - mkdir ~/.tedious
-      - >
-        echo '{
-          "config": {
-            "server": "'${AZURE_SERVER}'",
-            "authentication": {
-              "type": "azure-active-directory-password",
-              "options": {
-                "userName": "'${AZURE_AD_USER}'",
-                "password": "'${AZURE_AD_PASS}'"
-              }
-            },
-            "options": {
-              "database": "test"
-            }
-          }
-        }' > ~/.tedious/test-connection.json
-      before_script: skip
-      script: npx nyc --reporter=lcov npm run test-integration && npx codecov
-
     - stage: release
       node_js: 8
       before_install: skip


### PR DESCRIPTION
This disables the Azure Active Directory Password build job on Travis CI until we can fix the configuration and bring it back.