### PR TITLE
Clean up some value parsing code

### DIFF
--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -17,29 +17,21 @@ const UNKNOWN_PLP_LEN = Buffer.from([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0
 const DEFAULT_ENCODING = 'utf8';
 
 function readTextPointerNull(parser, type, callback) {
-  if (type.hasTextPointerAndTimestamp) {
-    parser.readUInt8((textPointerLength) => {
-      if (textPointerLength !== 0) {
-        // Appear to be dummy values, so consume and discard them.
-        parser.readBuffer(textPointerLength, () => {
-          parser.readBuffer(8, () => {
-            callback(undefined);
-          });
+  parser.readUInt8((textPointerLength) => {
+    if (textPointerLength !== 0) {
+      // Appear to be dummy values, so consume and discard them.
+      parser.readBuffer(textPointerLength, () => {
+        parser.readBuffer(8, () => {
+          callback(false);
         });
-      } else {
-        callback(true);
-      }
-    });
-  } else {
-    callback(undefined);
-  }
+      });
+    } else {
+      callback(true);
+    }
+  });
 }
 
-function readDataLength(parser, type, metaData, textPointerNull, callback) {
-  if (textPointerNull) {
-    return callback(0);
-  }
-
+function readDataLength(parser, type, metaData, callback) {
   if (metaData.isVariantValue) {
     return callback(metaData.dataLength);
   }
@@ -81,282 +73,324 @@ module.exports = valueParse;
 function valueParse(parser, metaData, options, callback) {
   const type = metaData.type;
 
-  readTextPointerNull(parser, type, (textPointerNull) => {
-    readDataLength(parser, type, metaData, textPointerNull, (dataLength) => {
-      switch (type.name) {
-        case 'Null':
-          return callback(null);
+  switch (type.name) {
+    case 'Null':
+      return callback(null);
 
-        case 'TinyInt':
-          return parser.readUInt8(callback);
+    case 'TinyInt':
+      return parser.readUInt8(callback);
 
-        case 'Int':
-          return parser.readInt32LE(callback);
+    case 'Int':
+      return parser.readInt32LE(callback);
 
-        case 'SmallInt':
-          return parser.readInt16LE(callback);
+    case 'SmallInt':
+      return parser.readInt16LE(callback);
 
-        case 'BigInt':
-          return parser.readBuffer(8, (buffer) => {
-            callback(convertLEBytesToString(buffer));
-          });
+    case 'BigInt':
+      return parser.readBuffer(8, (buffer) => {
+        callback(convertLEBytesToString(buffer));
+      });
 
-        case 'IntN':
-          switch (dataLength) {
-            case 0:
-              return callback(null);
-            case 1:
-              return parser.readUInt8(callback);
-            case 2:
-              return parser.readInt16LE(callback);
-            case 4:
-              return parser.readInt32LE(callback);
-            case 8:
-              return parser.readBuffer(8, (buffer) => {
-                callback(convertLEBytesToString(buffer));
-              });
-
-            default:
-              return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for IntN'));
-          }
-
-        case 'Real':
-          return parser.readFloatLE(callback);
-
-        case 'Float':
-          return parser.readDoubleLE(callback);
-
-        case 'FloatN':
-          switch (dataLength) {
-            case 0:
-              return callback(null);
-            case 4:
-              return parser.readFloatLE(callback);
-            case 8:
-              return parser.readDoubleLE(callback);
-
-            default:
-              return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for FloatN'));
-          }
-
-        case 'Money':
-        case 'SmallMoney':
-        case 'MoneyN':
-          switch (dataLength) {
-            case 0:
-              return callback(null);
-            case 4:
-              return parser.readInt32LE((value) => {
-                callback(value / MONEY_DIVISOR);
-              });
-            case 8:
-              return parser.readInt32LE((high) => {
-                parser.readUInt32LE((low) => {
-                  callback((low + (0x100000000 * high)) / MONEY_DIVISOR);
-                });
-              });
-
-            default:
-              return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for MoneyN'));
-          }
-
-        case 'Bit':
-          return parser.readUInt8((value) => {
-            callback(!!value);
-          });
-
-        case 'BitN':
-          switch (dataLength) {
-            case 0:
-              return callback(null);
-            case 1:
-              return parser.readUInt8((value) => {
-                callback(!!value);
-              });
-            default:
-              return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for BitN'));
-          }
-
-        case 'VarChar':
-        case 'Char':
-          const codepage = metaData.collation.codepage;
-          if (metaData.dataLength === MAX) {
-            return readMaxChars(parser, codepage, callback);
-          } else {
-            return readChars(parser, dataLength, codepage, NULL, callback);
-          }
-
-        case 'NVarChar':
-        case 'NChar':
-          if (metaData.dataLength === MAX) {
-            return readMaxNChars(parser, callback);
-          } else {
-            return readNChars(parser, dataLength, NULL, callback);
-          }
-
-        case 'VarBinary':
-        case 'Binary':
-          if (metaData.dataLength === MAX) {
-            return readMaxBinary(parser, callback);
-          } else {
-            return readBinary(parser, dataLength, NULL, callback);
-          }
-
-        case 'Text':
-          if (textPointerNull) {
+    case 'IntN':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        switch (dataLength) {
+          case 0:
             return callback(null);
-          } else {
-            return readChars(parser, dataLength, metaData.collation.codepage, PLP_NULL, callback);
-          }
+          case 1:
+            return parser.readUInt8(callback);
+          case 2:
+            return parser.readInt16LE(callback);
+          case 4:
+            return parser.readInt32LE(callback);
+          case 8:
+            return parser.readBuffer(8, (buffer) => {
+              callback(convertLEBytesToString(buffer));
+            });
 
-        case 'NText':
-          if (textPointerNull) {
+          default:
+            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for IntN'));
+        }
+      });
+
+    case 'Real':
+      return parser.readFloatLE(callback);
+
+    case 'Float':
+      return parser.readDoubleLE(callback);
+
+    case 'FloatN':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        switch (dataLength) {
+          case 0:
             return callback(null);
-          } else {
-            return readNChars(parser, dataLength, PLP_NULL, callback);
-          }
+          case 4:
+            return parser.readFloatLE(callback);
+          case 8:
+            return parser.readDoubleLE(callback);
 
-        case 'Image':
-          if (textPointerNull) {
+          default:
+            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for FloatN'));
+        }
+      });
+
+    case 'Money':
+    case 'SmallMoney':
+    case 'MoneyN':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        switch (dataLength) {
+          case 0:
             return callback(null);
-          } else {
-            return readBinary(parser, dataLength, PLP_NULL, callback);
-          }
-
-        case 'Xml':
-          return readMaxNChars(parser, callback);
-
-        case 'SmallDateTime':
-          return readSmallDateTime(parser, options.useUTC, callback);
-
-        case 'DateTime':
-          return readDateTime(parser, options.useUTC, callback);
-
-        case 'DateTimeN':
-          switch (dataLength) {
-            case 0:
-              return callback(null);
-            case 4:
-              return readSmallDateTime(parser, options.useUTC, callback);
-            case 8:
-              return readDateTime(parser, options.useUTC, callback);
-            default:
-              return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for DateTimeN'));
-          }
-
-        case 'Time':
-          if (dataLength === 0) {
-            return callback(null);
-          } else {
-            return readTime(parser, dataLength, metaData.scale, options.useUTC, callback);
-          }
-
-        case 'Date':
-          if (dataLength === 0) {
-            return callback(null);
-          } else {
-            return readDate(parser, options.useUTC, callback);
-          }
-
-        case 'DateTime2':
-          if (dataLength === 0) {
-            return callback(null);
-          } else {
-            return readDateTime2(parser, dataLength, metaData.scale, options.useUTC, callback);
-          }
-
-        case 'DateTimeOffset':
-          if (dataLength === 0) {
-            return callback(null);
-          } else {
-            return readDateTimeOffset(parser, dataLength, metaData.scale, callback);
-          }
-
-        case 'NumericN':
-        case 'DecimalN':
-          if (dataLength === 0) {
-            return callback(null);
-          } else {
-            return parser.readUInt8((sign) => {
-              sign = sign === 1 ? 1 : -1;
-
-              let readValue;
-              switch (dataLength - 1) {
-                case 4:
-                  readValue = parser.readUInt32LE;
-                  break;
-                case 8:
-                  readValue = parser.readUNumeric64LE;
-                  break;
-                case 12:
-                  readValue = parser.readUNumeric96LE;
-                  break;
-                case 16:
-                  readValue = parser.readUNumeric128LE;
-                  break;
-                default:
-                  return parser.emit('error', new Error(sprintf('Unsupported numeric size %d', dataLength - 1)));
-              }
-
-              readValue.call(parser, (value) => {
-                callback((value * sign) / Math.pow(10, metaData.scale));
+          case 4:
+            return parser.readInt32LE((value) => {
+              callback(value / MONEY_DIVISOR);
+            });
+          case 8:
+            return parser.readInt32LE((high) => {
+              parser.readUInt32LE((low) => {
+                callback((low + (0x100000000 * high)) / MONEY_DIVISOR);
               });
             });
-          }
 
-        case 'UniqueIdentifier':
-          switch (dataLength) {
-            case 0:
-              return callback(null);
-            case 0x10:
-              return parser.readBuffer(0x10, (data) => {
-                callback(options.lowerCaseGuids ? guidParser.arrayToLowerCaseGuid(data) : guidParser.arrayToUpperCaseGuid(data));
-              });
+          default:
+            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for MoneyN'));
+        }
+      });
 
-            default:
-              return parser.emit('error', new Error(sprintf('Unsupported guid size %d', dataLength - 1)));
-          }
+    case 'Bit':
+      return parser.readUInt8((value) => {
+        callback(!!value);
+      });
 
-        case 'UDT':
-          return readMaxBinary(parser, callback);
-
-        case 'Variant':
-          if (dataLength === 0) {
+    case 'BitN':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        switch (dataLength) {
+          case 0:
             return callback(null);
-          }
-
-          const valueMetaData = metaData.valueMetaData = {};
-          Object.defineProperty(valueMetaData, 'isVariantValue', { value: true });
-          return parser.readUInt8((baseType) => {
-            return parser.readUInt8((propBytes) => {
-              valueMetaData.dataLength = dataLength - propBytes - 2;
-              valueMetaData.type = TYPE[baseType];
-              return readPrecision(parser, valueMetaData.type, (precision) => {
-                valueMetaData.precision = precision;
-                return readScale(parser, valueMetaData.type, (scale) => {
-                  valueMetaData.scale = scale;
-                  return readCollation(parser, valueMetaData.type, (collation) => {
-                    valueMetaData.collation = collation;
-                    if (baseType === 0xA5 || baseType === 0xAD || baseType === 0xA7 || baseType === 0xAF || baseType === 0xE7 || baseType === 0xEF) {
-                      return readDataLength(parser, valueMetaData.type, {}, null, (maxDataLength) => {
-                        // skip the 2-byte max length sent for BIGVARCHRTYPE, BIGCHARTYPE, NVARCHARTYPE, NCHARTYPE, BIGVARBINTYPE and BIGBINARYTYPE types
-                        // and parse based on the length of actual data
-                        return valueParse(parser, valueMetaData, options, callback);
-                      });
-                    } else {
-                      return valueParse(parser, valueMetaData, options, callback);
-                    }
-                  });
-                });
-              });
+          case 1:
+            return parser.readUInt8((value) => {
+              callback(!!value);
             });
-          });
+          default:
+            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for BitN'));
+        }
+      });
 
-        default:
-          return parser.emit('error', new Error(sprintf('Unrecognised type %s', type.name)));
+    case 'VarChar':
+    case 'Char':
+      const codepage = metaData.collation.codepage;
+      if (metaData.dataLength === MAX) {
+        return readMaxChars(parser, codepage, callback);
+      } else {
+        return readDataLength(parser, type, metaData, (dataLength) => {
+          readChars(parser, dataLength, codepage, NULL, callback);
+        });
       }
-    });
-  });
+
+    case 'NVarChar':
+    case 'NChar':
+      if (metaData.dataLength === MAX) {
+        return readMaxNChars(parser, callback);
+      } else {
+        return readDataLength(parser, type, metaData, (dataLength) => {
+          readNChars(parser, dataLength, NULL, callback);
+        });
+      }
+
+    case 'VarBinary':
+    case 'Binary':
+      if (metaData.dataLength === MAX) {
+        return readMaxBinary(parser, callback);
+      } else {
+        return readDataLength(parser, type, metaData, (dataLength) => {
+          readBinary(parser, dataLength, NULL, callback);
+        });
+      }
+
+    case 'Text':
+      return readTextPointerNull(parser, type, (textPointerNull) => {
+        if (textPointerNull) {
+          return callback(null);
+        }
+
+        readDataLength(parser, type, metaData, (dataLength) => {
+          readChars(parser, dataLength, metaData.collation.codepage, PLP_NULL, callback);
+        });
+      });
+
+    case 'NText':
+      return readTextPointerNull(parser, type, (textPointerNull) => {
+        if (textPointerNull) {
+          return callback(null);
+        }
+
+        readDataLength(parser, type, metaData, (dataLength) => {
+          readNChars(parser, dataLength, PLP_NULL, callback);
+        });
+      });
+
+    case 'Image':
+      return readTextPointerNull(parser, type, (textPointerNull) => {
+        if (textPointerNull) {
+          return callback(null);
+        }
+
+        readDataLength(parser, type, metaData, (dataLength) => {
+          readBinary(parser, dataLength, PLP_NULL, callback);
+        });
+      });
+
+    case 'Xml':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        readMaxNChars(parser, callback);
+      });
+
+    case 'SmallDateTime':
+      return readSmallDateTime(parser, options.useUTC, callback);
+
+    case 'DateTime':
+      return readDateTime(parser, options.useUTC, callback);
+
+    case 'DateTimeN':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        switch (dataLength) {
+          case 0:
+            return callback(null);
+          case 4:
+            return readSmallDateTime(parser, options.useUTC, callback);
+          case 8:
+            return readDateTime(parser, options.useUTC, callback);
+          default:
+            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for DateTimeN'));
+        }
+      });
+
+    case 'Time':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        if (dataLength === 0) {
+          return callback(null);
+        } else {
+          return readTime(parser, dataLength, metaData.scale, options.useUTC, callback);
+        }
+      });
+
+    case 'Date':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        if (dataLength === 0) {
+          return callback(null);
+        } else {
+          return readDate(parser, options.useUTC, callback);
+        }
+      });
+
+    case 'DateTime2':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        if (dataLength === 0) {
+          return callback(null);
+        } else {
+          return readDateTime2(parser, dataLength, metaData.scale, options.useUTC, callback);
+        }
+      });
+
+    case 'DateTimeOffset':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        if (dataLength === 0) {
+          return callback(null);
+        } else {
+          return readDateTimeOffset(parser, dataLength, metaData.scale, callback);
+        }
+      });
+
+    case 'NumericN':
+    case 'DecimalN':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        if (dataLength === 0) {
+          return callback(null);
+        } else {
+          return parser.readUInt8((sign) => {
+            sign = sign === 1 ? 1 : -1;
+
+            let readValue;
+            switch (dataLength - 1) {
+              case 4:
+                readValue = parser.readUInt32LE;
+                break;
+              case 8:
+                readValue = parser.readUNumeric64LE;
+                break;
+              case 12:
+                readValue = parser.readUNumeric96LE;
+                break;
+              case 16:
+                readValue = parser.readUNumeric128LE;
+                break;
+              default:
+                return parser.emit('error', new Error(sprintf('Unsupported numeric size %d', dataLength - 1)));
+            }
+
+            readValue.call(parser, (value) => {
+              callback((value * sign) / Math.pow(10, metaData.scale));
+            });
+          });
+        }
+      });
+
+    case 'UniqueIdentifier':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        switch (dataLength) {
+          case 0:
+            return callback(null);
+          case 0x10:
+            return parser.readBuffer(0x10, (data) => {
+              callback(options.lowerCaseGuids ? guidParser.arrayToLowerCaseGuid(data) : guidParser.arrayToUpperCaseGuid(data));
+            });
+
+          default:
+            return parser.emit('error', new Error(sprintf('Unsupported guid size %d', dataLength - 1)));
+        }
+      });
+
+    case 'UDT':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        readMaxBinary(parser, callback);
+      });
+
+    case 'Variant':
+      return readDataLength(parser, type, metaData, (dataLength) => {
+        if (dataLength === 0) {
+          return callback(null);
+        }
+
+        const valueMetaData = metaData.valueMetaData = {};
+        Object.defineProperty(valueMetaData, 'isVariantValue', { value: true });
+        return parser.readUInt8((baseType) => {
+          return parser.readUInt8((propBytes) => {
+            valueMetaData.dataLength = dataLength - propBytes - 2;
+            valueMetaData.type = TYPE[baseType];
+            return readPrecision(parser, valueMetaData.type, (precision) => {
+              valueMetaData.precision = precision;
+              return readScale(parser, valueMetaData.type, (scale) => {
+                valueMetaData.scale = scale;
+                return readCollation(parser, valueMetaData.type, (collation) => {
+                  valueMetaData.collation = collation;
+                  if (baseType === 0xA5 || baseType === 0xAD || baseType === 0xA7 || baseType === 0xAF || baseType === 0xE7 || baseType === 0xEF) {
+                    return readDataLength(parser, valueMetaData.type, {}, (maxDataLength) => {
+                      // skip the 2-byte max length sent for BIGVARCHRTYPE, BIGCHARTYPE, NVARCHARTYPE, NCHARTYPE, BIGVARBINTYPE and BIGBINARYTYPE types
+                      // and parse based on the length of actual data
+                      return valueParse(parser, valueMetaData, options, callback);
+                    });
+                  } else {
+                    return valueParse(parser, valueMetaData, options, callback);
+                  }
+                });
+              });
+            });
+          });
+        });
+      });
+
+    default:
+      return parser.emit('error', new Error(sprintf('Unrecognised type %s', type.name)));
+  }
 }
 
 function readBinary(parser, dataLength, nullValue, callback) {


### PR DESCRIPTION
This slightly cleans up the value parsing code's use of `readTextPointerNull` and `readDataLength`.

`readTextPointerNull` is now only called for `Image`, `Text` and `NText` data type.

`readDataLength` is now only called for variable length data types.