### PR TITLE
Speed up big-int parsing

### DIFF
--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -6,7 +6,6 @@ const guidParser = require('./guid-parser');
 const readPrecision = require('./metadata-parser').readPrecision;
 const readScale = require('./metadata-parser').readScale;
 const readCollation = require('./metadata-parser').readCollation;
-const convertLEBytesToString = require('./tracking-buffer/bigint').convertLEBytesToString;
 
 const NULL = (1 << 16) - 1;
 const MAX = (1 << 16) - 1;
@@ -87,9 +86,7 @@ function valueParse(parser, metaData, options, callback) {
       return parser.readInt16LE(callback);
 
     case 'BigInt':
-      return parser.readBuffer(8, (buffer) => {
-        callback(convertLEBytesToString(buffer));
-      });
+      return parser.readInt64LE(callback);
 
     case 'IntN':
       return readDataLength(parser, type, metaData, (dataLength) => {
@@ -103,9 +100,7 @@ function valueParse(parser, metaData, options, callback) {
           case 4:
             return parser.readInt32LE(callback);
           case 8:
-            return parser.readBuffer(8, (buffer) => {
-              callback(convertLEBytesToString(buffer));
-            });
+            return parser.readInt64LE(callback);
 
           default:
             return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for IntN'));

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -112,7 +112,7 @@ function execSqlOutput(done, type, value, expectedValue, connectionOptions) {
 
     if (value instanceof Date) {
       assert.strictEqual(returnValue.getTime(), expectedValue.getTime());
-    } else if (type === TYPES.BigInt) {
+    } else if (type === TYPES.BigInt && (expectedValue > Number.MAX_SAFE_INTEGER || expectedValue < Number.MIN_SAFE_INTEGER)) {
       assert.strictEqual(returnValue, expectedValue.toString());
     } else if (type === TYPES.UniqueIdentifier) {
       assert.deepEqual(returnValue, expectedValue);

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -51,7 +51,7 @@ describe('Row Token Parser', () => {
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 2);
-    assert.strictEqual('1', token.columns[0].value);
+    assert.strictEqual(1, token.columns[0].value);
     assert.strictEqual('9223372036854775807', token.columns[1].value);
   });
 
@@ -588,17 +588,17 @@ describe('Row Token Parser', () => {
 
     assert.strictEqual(token.columns.length, 12);
     assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual('0', token.columns[1].value);
-    assert.strictEqual('1', token.columns[2].value);
+    assert.strictEqual(0, token.columns[1].value);
+    assert.strictEqual(1, token.columns[2].value);
     assert.strictEqual('-1', token.columns[3].value);
-    assert.strictEqual('2', token.columns[4].value);
-    assert.strictEqual('-2', token.columns[5].value);
+    assert.strictEqual(2, token.columns[4].value);
+    assert.strictEqual(-2, token.columns[5].value);
     assert.strictEqual('9223372036854775807', token.columns[6].value);
     assert.strictEqual('-9223372036854775808', token.columns[7].value);
-    assert.strictEqual('10', token.columns[8].value);
-    assert.strictEqual('100', token.columns[9].value);
-    assert.strictEqual('1000', token.columns[10].value);
-    assert.strictEqual('10000', token.columns[11].value);
+    assert.strictEqual(10, token.columns[8].value);
+    assert.strictEqual(100, token.columns[9].value);
+    assert.strictEqual(1000, token.columns[10].value);
+    assert.strictEqual(10000, token.columns[11].value);
   });
 
   it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `false`', () => {


### PR DESCRIPTION
Resolves speed bottleneck when there are a lot of bigint data coming from SQL server.

It tries to parse it into Number, and only if it will overflow MAX_SAFE_INTEGER it goes to string parsing