### PR TITLE
FIX No longer rely on removed data-type props

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,6 +4,6 @@
 3. After bug fix/code change, ensure all the existing tests and new tests (if any) pass (`npm run-script test-all`). During development, to run individual test use `node_modules/nodeunit test/<test_file.js> -t <test_name>`.
 4. Build the driver (`npm run build`).
 5. Run eslint and flow typechecker (`npm run lint`).
-6. Run commitlint (`node_modules/.bin/commitlint --from origin/master --to HEAD`). Refer [commit conventions](http://marionebl.github.io/commitlint/#/concepts-commit-conventions) and [commit rules](http://marionebl.github.io/commitlint/#/reference-rules).
+6. Run commitlint (`node_modules/.bin/commitlint --from origin/master --to HEAD`). Refer [commit conventions](https://commitlint.js.org/#/concepts-commit-conventions) and [commit rules](https://commitlint.js.org/#/reference-rules).
 
 **Thank you for Contributing!**

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -7,7 +7,7 @@ import { TYPE as TOKEN_TYPE } from './token/token';
 import Message from './message';
 import { TYPE as PACKET_TYPE } from './packet';
 
-import { Parameter } from './data-type';
+import { DataType, Parameter } from './data-type';
 import { RequestError } from './errors';
 
 const FLAGS = {
@@ -131,7 +131,7 @@ class BulkLoad extends EventEmitter {
     this.bulkOptions = { checkConstraints, fireTriggers, keepNulls, lockTable };
   }
 
-  addColumn(name: string, type: any, { output = false, length, precision, scale, objName = name, nullable = true }: ColumnOptions) {
+  addColumn(name: string, type: DataType, { output = false, length, precision, scale, objName = name, nullable = true }: ColumnOptions) {
     if (this.firstRowWritten) {
       throw new Error('Columns cannot be added to bulk insert after the first row has been written.');
     }
@@ -157,16 +157,12 @@ class BulkLoad extends EventEmitter {
       }
     }
 
-    if (type.hasPrecision) {
-      if (column.precision == null && type.resolvePrecision) {
-        column.precision = type.resolvePrecision(column);
-      }
+    if (type.resolvePrecision && column.precision == null) {
+      column.precision = type.resolvePrecision(column);
     }
 
-    if (type.hasScale) {
-      if (column.scale == null && type.resolveScale) {
-        column.scale = type.resolveScale(column);
-      }
+    if (type.resolveScale && column.scale == null) {
+      column.scale = type.resolveScale(column);
     }
 
     this.columns.push(column);


### PR DESCRIPTION
Fixes #998 

This is a slightly different approach to fixing the problem than reinstating the `hasScale` flag (and other removed flags) from the `DataType` type; instead we infer the need to use `resolvePrecision` and `resolveScale` from the fact they are present.

This fixes a bug with `BulkLoad` where the error `Received an invalid column length from the bcp client for colid x` is thrown when scales are nor resolved for certain columns.