### PR TITLE
docs: update options.encrypt default to true

### DIFF
--- a/api-connection.html
+++ b/api-connection.html
@@ -349,7 +349,7 @@ var connection = new Connection(config);
       <dd>
         A boolean determining whether or not the connection will be encrypted. Set to <code>true</code> if you're on
         Windows Azure.
-        (default: <code>false</code>).
+        (default: <code>true</code>).
       </dd>
 
       <dt>


### PR DESCRIPTION
As of this commit (https://github.com/tediousjs/tedious/commit/70ffe4a) the default is to encrypt by default, so update the documentation accordingly
