### PR TITLE
refactor: simplify connection encrypt option

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -515,7 +515,7 @@ class Connection extends EventEmitter {
         enableImplicitTransactions: false,
         enableNumericRoundabort: false,
         enableQuotedIdentifier: true,
-        encrypt: false,
+        encrypt: true,
         fallbackToDefaultDb: false,
         instanceName: undefined,
         isolationLevel: ISOLATION_LEVEL.READ_COMMITTED,
@@ -759,8 +759,6 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.encrypt = config.options.encrypt;
-      } else {
-        this.config.options.encrypt = true;
       }
 
       if (config.options.fallbackToDefaultDb !== undefined) {


### PR DESCRIPTION
This moves the default for `config.options.encrypt` up into the base
configuration object, simplifying the setup and making it clearer
that the default is `encrypt: true` (and a minute bit faster).

Behaviour remains identical after this restructure.

----

**Before submitting a PR :**
1. [x] Ensure your fork is created from `master` branch of [the repository](https://github.com/tediousjs/tedious).
2. [x] Run `npm install` in the root folder.
3. [x] After bug fix/code change, ensure all the existing tests and new tests (if any) pass (`npm run-script test-all`). During development, to run individual test use `node_modules/nodeunit test/<test_file.js> -t <test_name>`.
4. [x] Build the driver (`npm run build`).
5. [x] Run eslint and flow typechecker (`npm run lint`).
6. [x] Run commitlint (`node_modules/.bin/commitlint --from origin/master --to HEAD`). Refer [commit conventions](https://commitlint.js.org/#/concepts-commit-conventions) and [commit rules](https://commitlint.js.org/#/reference-rules).

**Thank you for Contributing!**
