### PR TITLE
Added an enter event to the logged in state, allowing to reuse connections

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2468,6 +2468,9 @@ Connection.prototype.STATE = {
   },
   LOGGED_IN: {
     name: 'LoggedIn',
+    enter: function() {
+        this.emit('ready');
+    },
     events: {
       socketError: function() {
         this.transitionTo(this.STATE.FINAL);


### PR DESCRIPTION
Hi,

This small change allows reusing connections once they enter the LOGGED_IN state, whether they have only just been connected or have finished a previous query.

Otherwise, the only way I can see to do that is with timers and checking if any connections have returned to "LOGGED_IN".

Thanks - Lawrence
