### PR TITLE
Change `enableArithAbort` default to `true`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -512,7 +512,7 @@ class Connection extends EventEmitter {
         enableAnsiNullDefault: true,
         enableAnsiPadding: true,
         enableAnsiWarnings: true,
-        enableArithAbort: false,
+        enableArithAbort: true,
         enableConcatNullYieldsNull: true,
         enableCursorCloseOnCommit: null,
         enableImplicitTransactions: false,
@@ -714,8 +714,6 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.enableArithAbort = config.options.enableArithAbort;
-      } else {
-        deprecate('The default value for `config.options.enableArithAbort` will change from `false` to `true` in the next major version of `tedious`. Set the value to `true` or `false` explicitly to silence this message.');
       }
 
       if (config.options.enableConcatNullYieldsNull !== undefined) {

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -1347,7 +1347,7 @@ describe('Boolean Config Options Test', function() {
   });
 
   it('should test arith abort default', function(done) {
-    testBooleanConfigOption(done, 'enableArithAbort', undefined, 64, false);
+    testBooleanConfigOption(done, 'enableArithAbort', undefined, 64, true);
   });
 
   it('should test arith abort on', function(done) {


### PR DESCRIPTION
According to 
https://docs.microsoft.com/en-us/sql/t-sql/statements/set-arithabort-transact-sql, setting `ARITHABORT` to `OFF` can negatively impact query optimizations and lead to performance issues.

As `ARITHABORT` is set to `ON` by default in SQL Server Management Studio, having the same default in `tedious` ensures that matching query plans are generated and makes it easier to troubleshoot poorly performing queries.

BREAKING CHANGE: Changing the `ARITHABORT` setting changes how arithmetic, overflow, divide-by-zero, or domain errors are handled, and whether transactions that encounter these error conditions are rolled back or whether execution continues on.

References: https://github.com/tediousjs/tedious/pull/1025 
Fixes: https://github.com/tediousjs/tedious/issues/509
