### PR TITLE
Deprecate default value for `trustServerCertificate ` being `true`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ before_install:
         },
         "options": {
           "port": 1433,
-          "database": "master"
+          "database": "master",
+          "trustServerCertificate": true
         }
       }
     }' > ~/.tedious/test-connection.json
@@ -85,7 +86,8 @@ jobs:
               }
             },
             "options": {
-              "database": "test"
+              "database": "test",
+              "trustServerCertificate": true
             }
           }
         }' > ~/.tedious/test-connection.json
@@ -108,7 +110,8 @@ jobs:
               }
             },
             "options": {
-              "database": "test"
+              "database": "test",
+              "trustServerCertificate": true
             }
           }
         }' > ~/.tedious/test-connection.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,8 @@ before_test:
             }
           },
           "options": {
-            "database": "master"
+            "database": "master",
+            "trustServerCertificate": true
           }
         },
 
@@ -60,7 +61,8 @@ before_test:
             }
           },
           "options": {
-            "database": "master"
+            "database": "master",
+            "trustServerCertificate": true
           }
         }
       }') -Path C:\Users\appveyor\.tedious\test-connection.json

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -915,6 +915,8 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.trustServerCertificate = config.options.trustServerCertificate;
+      } else {
+        deprecate('The default value for `config.options.trustServerCertificate` will change from `true` to `false` in the next major version of `tedious`. Set the value to `true` or `false` explicitly to silence this message.');
       }
 
       if (config.options.useColumnNames !== undefined) {

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -227,6 +227,77 @@ describe('Initiate Connect Test', function() {
     done();
   });
 
+  it('should emit a deprecation message if `trustServerCertificate` is `undefined`', function(done) {
+    const config = getConfig();
+    config.options.trustServerCertificate = undefined;
+
+    let deprecationEmitted = false;
+
+    process.once('deprecation', (error) => {
+      deprecationEmitted = true;
+
+      assert.include(error.message, 'config.options.trustServerCertificate');
+    });
+
+    const connection = new Connection(config);
+    connection.on('connect', (err) => {
+      assert.isTrue(deprecationEmitted);
+
+      if (err) {
+        return done();
+      }
+
+      connection.on('end', () => { done(); });
+      connection.close();
+    });
+  });
+
+  it('should not emit a deprecation message if `trustServerCertificate` is `false`', function(done) {
+    const config = getConfig();
+    config.options.trustServerCertificate = false;
+
+    let deprecationEmitted = false;
+
+    process.once('deprecation', () => {
+      deprecationEmitted = true;
+    });
+
+    const connection = new Connection(config);
+    connection.on('connect', (err) => {
+      assert.isFalse(deprecationEmitted);
+
+      if (err) {
+        return done();
+      }
+
+      connection.on('end', () => { done(); });
+      connection.close();
+    });
+  });
+
+  it('should not emit a deprecation message if `trustServerCertificate` is `true`', function(done) {
+    const config = getConfig();
+    config.options.trustServerCertificate = true;
+
+    let deprecationEmitted = false;
+
+    process.once('deprecation', () => {
+      deprecationEmitted = true;
+    });
+
+    const connection = new Connection(config);
+    connection.on('connect', (err) => {
+      assert.isFalse(deprecationEmitted);
+
+      if (err) {
+        return done();
+      }
+
+      connection.on('end', () => { done(); });
+      connection.close();
+    });
+  });
+
   it('should fail if no cipher can be negotiated', function(done) {
     const config = getConfig();
     config.options.encrypt = true;


### PR DESCRIPTION
Defaulting `trustServerCertificate` to `true` is a potential security issue, so we should switch to it being set to false, and maybe even update our documentation to guide users to use the correct `cryptoCredentialsDetails` values to verify server certificates instead of relying on `trustServerCertificate`.

References: https://github.com/tediousjs/tedious/issues/983