### PR TITLE
Switch from `babel-eslint` to `@typescript-eslint`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,17 @@ env:
   node: true
   es6: true
 
-parser: "babel-eslint"
+parser: "@typescript-eslint/parser"
+
+parserOptions:
+  sourceType: "module"
+
+plugins:
+  - "@typescript-eslint"
 
 rules:
   accessor-pairs: "error"
-  # array-callback-return: "error"
+  array-callback-return: "error"
   arrow-parens: ["error", "always"]
   arrow-spacing: ["error", { before: true, after: true }]
   block-spacing: "error"
@@ -24,15 +30,15 @@ rules:
   func-call-spacing: "error"
   func-name-matching: "error"
   func-style: ["error", "declaration", { allowArrowFunctions: true }]
-  # indent: ["error", 2, {
-  #   ArrayExpression: "first",
-  #   CallExpression: { arguments: "first" },
-  #   FunctionDeclaration: { parameters: "first" },
-  #   FunctionExpression: { parameters: "first" },
-  #   MemberExpression: "off",
-  #   ObjectExpression: "first",
-  #   SwitchCase: 1,
-  # }]
+  indent: ["error", 2, {
+    ArrayExpression: "first",
+    CallExpression: { arguments: "first" },
+    FunctionDeclaration: { parameters: "first" },
+    FunctionExpression: { parameters: "first" },
+    MemberExpression: "off",
+    ObjectExpression: "first",
+    SwitchCase: 1,
+  }]
   key-spacing: ["error", {mode: "strict"}]
   keyword-spacing: "error"
   linebreak-style: ["error", "unix"]
@@ -147,10 +153,49 @@ rules:
   use-isnan: "error"
   valid-typeof: "error"
 
+extends:
+  - 'plugin:@typescript-eslint/eslint-recommended'
+
 overrides:
   - files:
       - '*.ts'
     rules:
-      no-undef: off
-      no-unused-vars: off
-      no-use-before-define: off
+      "@typescript-eslint/adjacent-overload-signatures": "error"
+      "@typescript-eslint/ban-ts-ignore": "error"
+      "@typescript-eslint/ban-types": "error"
+      "@typescript-eslint/class-name-casing": "error"
+      "@typescript-eslint/consistent-type-assertions": "error"
+      "@typescript-eslint/interface-name-prefix": "error"
+      "@typescript-eslint/member-delimiter-style": ["error", {
+        "multiline": {
+          "delimiter": "semi",
+          "requireLast": true
+        },
+        "singleline": {
+          "delimiter": "comma",
+          "requireLast": false
+        }
+      }]
+      "no-array-constructor": "off"
+      "@typescript-eslint/no-array-constructor": "error"
+      "@typescript-eslint/no-empty-interface": "error"
+      "@typescript-eslint/no-inferrable-types": "error"
+      "@typescript-eslint/no-misused-new": "error"
+      "@typescript-eslint/no-namespace": "error"
+      "@typescript-eslint/no-this-alias": "error"
+      "no-unused-vars": "off"
+      "@typescript-eslint/no-unused-vars": ["error", { args: "none", caughtErrors: "all" }]
+      "no-use-before-define": "off"
+      "@typescript-eslint/no-use-before-define": ["error", {
+        classes: true,
+        functions: false,
+        variables: false
+      }]
+      "@typescript-eslint/no-var-requires": "error"
+      "@typescript-eslint/prefer-namespace-keyword": "error"
+      "@typescript-eslint/triple-slash-reference": "error"
+      "@typescript-eslint/type-annotation-spacing": "error"
+      "no-var": "error"
+      "prefer-const": "error"
+      "prefer-rest-params": "error"
+      "prefer-spread": "error"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,31 +3809,6 @@
         }
       }
     },
-    "babel-eslint": {
-      "version": "11.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-11.0.0-beta.2.tgz",
-      "integrity": "sha512-D2tunrOu04XloEdU2XVUminUu25FILlGruZmffqH5OSnLDhCheKNvUoM1ihrexdUvhizlix8bjqRnsss4V/UIQ==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "5.0.0",
-        "eslint-visitor-keys": "^1.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3257,6 +3257,12 @@
         "@types/node": "*"
       }
     },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -3273,6 +3279,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -3331,6 +3343,131 @@
       "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.16.0.tgz",
+      "integrity": "sha512-TKWbeFAKRPrvKiR9GNxErQ8sELKqg1ZvXi6uho07mcKShBnCnqNpDQWP01FEvWKf0bxM2g7uQEI5MNjSNqvUpQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.16.0",
+        "eslint-utils": "^1.4.3",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.16.0.tgz",
+      "integrity": "sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.16.0",
+        "eslint-scope": "^5.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.16.0.tgz",
+      "integrity": "sha512-+w8dMaYETM9v6il1yYYkApMSiwgnqXWJbXrA94LAWN603vXHACsZTirJduyeBOJjA9wT6xuXe5zZ1iCUzoxCfw==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "2.16.0",
+        "@typescript-eslint/typescript-estree": "2.16.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.16.0.tgz",
+      "integrity": "sha512-hyrCYjFHISos68Bk5KjUAXw0pP/455qq9nxqB1KkT67Pxjcfw+r6Yhcmqnp8etFL45UexCHUMrADHH7dI/m2WQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "JSONStream": {
@@ -13891,6 +14028,15 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
     "async": "^2.6.3",
-    "babel-eslint": "^11.0.0-beta.2",
     "babel-plugin-istanbul": "^5.2.0",
     "benchmark": "^2.1.0",
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "@types/node": "^12.12.17",
     "@types/readable-stream": "^2.3.5",
     "@types/sprintf-js": "^1.1.2",
+    "@typescript-eslint/eslint-plugin": "^2.16.0",
+    "@typescript-eslint/parser": "^2.16.0",
     "async": "^2.6.3",
     "babel-eslint": "^11.0.0-beta.2",
     "babel-plugin-istanbul": "^5.2.0",

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -35,33 +35,81 @@ const DONE_STATUS = {
 };
 
 type InternalOptions = {
-  checkConstraints: boolean,
-  fireTriggers: boolean,
-  keepNulls: boolean,
-  lockTable: boolean,
+  checkConstraints: boolean;
+  fireTriggers: boolean;
+  keepNulls: boolean;
+  lockTable: boolean;
 };
 
 export interface Options {
-  checkConstraints?: InternalOptions['checkConstraints'],
-  fireTriggers?: InternalOptions['fireTriggers'],
-  keepNulls?: InternalOptions['keepNulls'],
-  lockTable?: InternalOptions['lockTable'],
+  checkConstraints?: InternalOptions['checkConstraints'];
+  fireTriggers?: InternalOptions['fireTriggers'];
+  keepNulls?: InternalOptions['keepNulls'];
+  lockTable?: InternalOptions['lockTable'];
 }
 
 export type Callback = (err: Error | undefined | null, rowCount?: number) => void;
 
 type Column = Parameter & {
-  objName: string,
+  objName: string;
 };
 
 type ColumnOptions = {
-  output?: boolean,
-  length?: number,
-  precision?: number,
-  scale?: number,
-  objName?: string,
-  nullable?: boolean
+  output?: boolean;
+  length?: number;
+  precision?: number;
+  scale?: number;
+  objName?: string;
+  nullable?: boolean;
 };
+
+// A transform that converts rows to packets.
+class RowTransform extends Transform {
+  columnMetadataWritten: boolean;
+  bulkLoad: BulkLoad;
+  mainOptions: BulkLoad['options'];
+  columns: BulkLoad['columns'];
+
+  constructor(bulkLoad: BulkLoad) {
+    super({ writableObjectMode: true });
+
+    this.bulkLoad = bulkLoad;
+    this.mainOptions = bulkLoad.options;
+    this.columns = bulkLoad.columns;
+
+    this.columnMetadataWritten = false;
+  }
+
+  _transform(row: Array<any>, _encoding: string, callback: () => void) {
+    if (!this.columnMetadataWritten) {
+      this.push(this.bulkLoad.getColMetaData());
+      this.columnMetadataWritten = true;
+    }
+
+    const buf = new WritableTrackingBuffer(64, 'ucs2', true);
+    buf.writeUInt8(TOKEN_TYPE.ROW);
+
+    for (let i = 0; i < this.columns.length; i++) {
+      const c = this.columns[i];
+      c.type.writeParameterData(buf, {
+        length: c.length,
+        scale: c.scale,
+        precision: c.precision,
+        value: row[i]
+      }, this.mainOptions, () => {});
+    }
+
+    this.push(buf.data);
+
+    process.nextTick(callback);
+  }
+
+  _flush(callback: () => void) {
+    this.push(this.bulkLoad.createDoneToken());
+
+    process.nextTick(callback);
+  }
+}
 
 class BulkLoad extends EventEmitter {
   error?: Error;
@@ -344,51 +392,3 @@ class BulkLoad extends EventEmitter {
 
 export default BulkLoad;
 module.exports = BulkLoad;
-
-// A transform that converts rows to packets.
-class RowTransform extends Transform {
-  columnMetadataWritten: boolean;
-  bulkLoad: BulkLoad;
-  mainOptions: BulkLoad['options'];
-  columns: BulkLoad['columns'];
-
-  constructor(bulkLoad: BulkLoad) {
-    super({ writableObjectMode: true });
-
-    this.bulkLoad = bulkLoad;
-    this.mainOptions = bulkLoad.options;
-    this.columns = bulkLoad.columns;
-
-    this.columnMetadataWritten = false;
-  }
-
-  _transform(row: Array<any>, _encoding: string, callback: () => void) {
-    if (!this.columnMetadataWritten) {
-      this.push(this.bulkLoad.getColMetaData());
-      this.columnMetadataWritten = true;
-    }
-
-    const buf = new WritableTrackingBuffer(64, 'ucs2', true);
-    buf.writeUInt8(TOKEN_TYPE.ROW);
-
-    for (let i = 0; i < this.columns.length; i++) {
-      const c = this.columns[i];
-      c.type.writeParameterData(buf, {
-        length: c.length,
-        scale: c.scale,
-        precision: c.precision,
-        value: row[i]
-      }, this.mainOptions, () => {});
-    }
-
-    this.push(buf.data);
-
-    process.nextTick(callback);
-  }
-
-  _flush(callback: () => void) {
-    this.push(this.bulkLoad.createDoneToken());
-
-    process.nextTick(callback);
-  }
-}

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -42,6 +42,8 @@ import { createNTLMRequest } from './ntlm';
 import { ColumnMetadata } from './token/colmetadata-token-parser';
 
 import depd from 'depd';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const deprecate = depd('tedious');
 
 // A rather basic state machine for managing a connection.
@@ -61,61 +63,61 @@ const DEFAULT_LANGUAGE = 'us_english';
 const DEFAULT_DATEFORMAT = 'mdy';
 
 interface AzureActiveDirectoryMsiAppServiceAuthentication {
-  type: 'azure-active-directory-msi-app-service',
+  type: 'azure-active-directory-msi-app-service';
   options: {
-    clientId?: string,
-    msiEndpoint?: string,
-    msiSecret?: string
-  }
+    clientId?: string;
+    msiEndpoint?: string;
+    msiSecret?: string;
+  };
 }
 
 interface AzureActiveDirectoryMsiVmAuthentication {
-  type: 'azure-active-directory-msi-vm',
+  type: 'azure-active-directory-msi-vm';
   options: {
-    clientId?: string,
-    msiEndpoint?: string
-  }
+    clientId?: string;
+    msiEndpoint?: string;
+  };
 }
 
 interface AzureActiveDirectoryAccessTokenAuthentication {
-  type: 'azure-active-directory-access-token',
+  type: 'azure-active-directory-access-token';
   options: {
-    token: string
-  }
+    token: string;
+  };
 }
 
 interface AzureActiveDirectoryPasswordAuthentication {
-  type: 'azure-active-directory-password',
+  type: 'azure-active-directory-password';
   options: {
-    userName: string,
-    password: string,
-  }
+    userName: string;
+    password: string;
+  };
 }
 
 interface AzureActiveDirectoryServicePrincipalSecret {
-  type: 'azure-active-directory-service-principal-secret',
+  type: 'azure-active-directory-service-principal-secret';
   options: {
-    clientId: string,
-    clientSecret: string,
-    tenantId: string
-  }
+    clientId: string;
+    clientSecret: string;
+    tenantId: string;
+  };
 }
 
 interface NtlmAuthentication {
-  type: 'ntlm',
+  type: 'ntlm';
   options: {
-    userName: string,
-    password: string,
-    domain: string
-  }
+    userName: string;
+    password: string;
+    domain: string;
+  };
 }
 
 interface DefaultAuthentication {
-  type: 'default',
+  type: 'default';
   options: {
-    userName?: string,
-    password?: string
-  }
+    userName?: string;
+    password?: string;
+  };
 }
 
 interface ErrorWithCode extends Error {
@@ -123,141 +125,141 @@ interface ErrorWithCode extends Error {
 }
 
 interface InternalConnectionConfig {
-  server: string,
-  authentication: DefaultAuthentication | NtlmAuthentication | AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryAccessTokenAuthentication | AzureActiveDirectoryServicePrincipalSecret,
-  options: InternalConnectionOptions
+  server: string;
+  authentication: DefaultAuthentication | NtlmAuthentication | AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryAccessTokenAuthentication | AzureActiveDirectoryServicePrincipalSecret;
+  options: InternalConnectionOptions;
 }
 
 export interface InternalConnectionOptions {
-  abortTransactionOnError: boolean,
-  appName: undefined | string,
-  camelCaseColumns: boolean,
-  cancelTimeout: number,
-  columnNameReplacer: undefined| ((colName: string, index: number, metadata: Metadata) => string),
-  connectionRetryInterval: number,
-  connectTimeout: number,
-  connectionIsolationLevel: typeof ISOLATION_LEVEL[keyof typeof ISOLATION_LEVEL],
-  cryptoCredentialsDetails: SecureContextOptions,
-  database: undefined | string,
-  datefirst: number,
-  dateFormat: string,
+  abortTransactionOnError: boolean;
+  appName: undefined | string;
+  camelCaseColumns: boolean;
+  cancelTimeout: number;
+  columnNameReplacer: undefined| ((colName: string, index: number, metadata: Metadata) => string);
+  connectionRetryInterval: number;
+  connectTimeout: number;
+  connectionIsolationLevel: typeof ISOLATION_LEVEL[keyof typeof ISOLATION_LEVEL];
+  cryptoCredentialsDetails: SecureContextOptions;
+  database: undefined | string;
+  datefirst: number;
+  dateFormat: string;
   debug: {
-    data: boolean,
-    packet: boolean,
-    payload: boolean,
-    token: boolean
-  },
-  enableAnsiNull: null | boolean,
-  enableAnsiNullDefault: null | boolean,
-  enableAnsiPadding: null | boolean,
-  enableAnsiWarnings: null | boolean,
-  enableArithAbort: null | boolean,
-  enableConcatNullYieldsNull: null | boolean,
-  enableCursorCloseOnCommit: null | boolean,
-  enableImplicitTransactions: null | boolean,
-  enableNumericRoundabort: null | boolean,
-  enableQuotedIdentifier: null | boolean,
-  encrypt: boolean,
-  fallbackToDefaultDb: boolean,
-  instanceName: undefined | string,
-  isolationLevel: typeof ISOLATION_LEVEL[keyof typeof ISOLATION_LEVEL],
-  language: string,
-  localAddress: undefined | string,
-  maxRetriesOnTransientErrors: number,
-  multiSubnetFailover: boolean,
-  packetSize: number,
-  port: undefined | number,
-  readOnlyIntent: boolean,
-  requestTimeout: number,
-  rowCollectionOnDone: boolean,
-  rowCollectionOnRequestCompletion: boolean,
-  tdsVersion: string,
-  textsize: string,
-  trustServerCertificate: boolean,
-  useColumnNames: boolean,
-  useUTC: boolean,
-  lowerCaseGuids: boolean
+    data: boolean;
+    packet: boolean;
+    payload: boolean;
+    token: boolean;
+  };
+  enableAnsiNull: null | boolean;
+  enableAnsiNullDefault: null | boolean;
+  enableAnsiPadding: null | boolean;
+  enableAnsiWarnings: null | boolean;
+  enableArithAbort: null | boolean;
+  enableConcatNullYieldsNull: null | boolean;
+  enableCursorCloseOnCommit: null | boolean;
+  enableImplicitTransactions: null | boolean;
+  enableNumericRoundabort: null | boolean;
+  enableQuotedIdentifier: null | boolean;
+  encrypt: boolean;
+  fallbackToDefaultDb: boolean;
+  instanceName: undefined | string;
+  isolationLevel: typeof ISOLATION_LEVEL[keyof typeof ISOLATION_LEVEL];
+  language: string;
+  localAddress: undefined | string;
+  maxRetriesOnTransientErrors: number;
+  multiSubnetFailover: boolean;
+  packetSize: number;
+  port: undefined | number;
+  readOnlyIntent: boolean;
+  requestTimeout: number;
+  rowCollectionOnDone: boolean;
+  rowCollectionOnRequestCompletion: boolean;
+  tdsVersion: string;
+  textsize: string;
+  trustServerCertificate: boolean;
+  useColumnNames: boolean;
+  useUTC: boolean;
+  lowerCaseGuids: boolean;
 }
 
 interface State {
-  name: string,
-  enter?(this: Connection): void,
-  exit?(this: Connection, newState: State): void,
+  name: string;
+  enter?(this: Connection): void;
+  exit?(this: Connection, newState: State): void;
   events: {
-    socketError?(this: Connection, err: Error): void
-    connectTimeout?(this: Connection): void,
-    socketConnect?(this: Connection): void,
-    data?(this: Connection, data: Buffer): void,
-    message?(this: Connection): void,
-    retry?(this: Connection): void,
-    routingChange?(this: Connection): void,
-    reconnect?(this: Connection): void,
-    featureExtAck?(this: Connection, token: FeatureExtAckToken): void,
-    fedAuthInfo?(this: Connection, token: FedAuthInfoToken): void
-    endOfMessageMarkerReceived?(this: Connection): void,
-    loginFailed?(this: Connection): void,
-    attention?(this: Connection): void
-  }
+    socketError?(this: Connection, err: Error): void;
+    connectTimeout?(this: Connection): void;
+    socketConnect?(this: Connection): void;
+    data?(this: Connection, data: Buffer): void;
+    message?(this: Connection): void;
+    retry?(this: Connection): void;
+    routingChange?(this: Connection): void;
+    reconnect?(this: Connection): void;
+    featureExtAck?(this: Connection, token: FeatureExtAckToken): void;
+    fedAuthInfo?(this: Connection, token: FedAuthInfoToken): void;
+    endOfMessageMarkerReceived?(this: Connection): void;
+    loginFailed?(this: Connection): void;
+    attention?(this: Connection): void;
+  };
 }
 
 interface ConnectionConfiguration {
-  server: string,
-  options?: ConnectionOptions,
+  server: string;
+  options?: ConnectionOptions;
   authentication?: {
-    type?: string,
-    options?: any
-  }
+    type?: string;
+    options?: any;
+  };
 }
 
 interface ConnectionOptions {
-  abortTransactionOnError?: boolean,
-  appName?: string | undefined,
-  camelCaseColumns?: boolean,
-  cancelTimeout?: number,
-  columnNameReplacer?: (colName: string, index: number, metadata: Metadata) => string,
-  connectionRetryInterval?: number,
-  connectTimeout?: number,
-  connectionIsolationLevel?: number,
-  cryptoCredentialsDetails?: {},
-  database?: string | undefined,
-  datefirst?: number,
-  dateFormat?: string,
+  abortTransactionOnError?: boolean;
+  appName?: string | undefined;
+  camelCaseColumns?: boolean;
+  cancelTimeout?: number;
+  columnNameReplacer?: (colName: string, index: number, metadata: Metadata) => string;
+  connectionRetryInterval?: number;
+  connectTimeout?: number;
+  connectionIsolationLevel?: number;
+  cryptoCredentialsDetails?: {};
+  database?: string | undefined;
+  datefirst?: number;
+  dateFormat?: string;
   debug?: {
-    data: boolean,
-    packet: boolean,
-    payload: boolean,
-    token: boolean
-  },
-  enableAnsiNull?: boolean,
-  enableAnsiNullDefault?: boolean,
-  enableAnsiPadding?: boolean,
-  enableAnsiWarnings?: boolean,
-  enableArithAbort?: boolean,
-  enableConcatNullYieldsNull?: boolean,
-  enableCursorCloseOnCommit?: boolean | null,
-  enableImplicitTransactions?: boolean,
-  enableNumericRoundabort?: boolean,
-  enableQuotedIdentifier?: boolean,
-  encrypt?: boolean,
-  fallbackToDefaultDb?: boolean,
-  instanceName?: string | undefined,
-  isolationLevel?: number,
-  language?: string,
-  localAddress?: string | undefined,
-  maxRetriesOnTransientErrors?: number,
-  multiSubnetFailover?: boolean,
-  packetSize?: number,
-  port?: number,
-  readOnlyIntent?: boolean,
-  requestTimeout?: number,
-  rowCollectionOnDone?: boolean,
-  rowCollectionOnRequestCompletion?: boolean,
-  tdsVersion?: string,
-  textsize?: string,
-  trustServerCertificate?: boolean,
-  useColumnNames?: boolean,
-  useUTC?: boolean,
-  lowerCaseGuids?: boolean,
+    data: boolean;
+    packet: boolean;
+    payload: boolean;
+    token: boolean;
+  };
+  enableAnsiNull?: boolean;
+  enableAnsiNullDefault?: boolean;
+  enableAnsiPadding?: boolean;
+  enableAnsiWarnings?: boolean;
+  enableArithAbort?: boolean;
+  enableConcatNullYieldsNull?: boolean;
+  enableCursorCloseOnCommit?: boolean | null;
+  enableImplicitTransactions?: boolean;
+  enableNumericRoundabort?: boolean;
+  enableQuotedIdentifier?: boolean;
+  encrypt?: boolean;
+  fallbackToDefaultDb?: boolean;
+  instanceName?: string | undefined;
+  isolationLevel?: number;
+  language?: string;
+  localAddress?: string | undefined;
+  maxRetriesOnTransientErrors?: number;
+  multiSubnetFailover?: boolean;
+  packetSize?: number;
+  port?: number;
+  readOnlyIntent?: boolean;
+  requestTimeout?: number;
+  rowCollectionOnDone?: boolean;
+  rowCollectionOnRequestCompletion?: boolean;
+  tdsVersion?: string;
+  textsize?: string;
+  trustServerCertificate?: boolean;
+  useColumnNames?: boolean;
+  useUTC?: boolean;
+  lowerCaseGuids?: boolean;
 }
 
 const CLEANUP_TYPE = {
@@ -286,20 +288,20 @@ class Connection extends EventEmitter {
   ntlmpacketBuffer: undefined | Buffer;
 
   STATE!: {
-    CONNECTING: State,
-    SENT_PRELOGIN: State,
-    REROUTING: State,
-    TRANSIENT_FAILURE_RETRY: State,
-    SENT_TLSSSLNEGOTIATION: State,
-    SENT_LOGIN7_WITH_STANDARD_LOGIN: State,
-    SENT_LOGIN7_WITH_NTLM: State,
-    SENT_LOGIN7_WITH_FEDAUTH: State,
-    LOGGED_IN_SENDING_INITIAL_SQL: State,
-    LOGGED_IN: State,
-    BUILDING_CLIENT_REQUEST: State,
-    SENT_CLIENT_REQUEST: State,
-    SENT_ATTENTION: State,
-    FINAL: State
+    CONNECTING: State;
+    SENT_PRELOGIN: State;
+    REROUTING: State;
+    TRANSIENT_FAILURE_RETRY: State;
+    SENT_TLSSSLNEGOTIATION: State;
+    SENT_LOGIN7_WITH_STANDARD_LOGIN: State;
+    SENT_LOGIN7_WITH_NTLM: State;
+    SENT_LOGIN7_WITH_FEDAUTH: State;
+    LOGGED_IN_SENDING_INITIAL_SQL: State;
+    LOGGED_IN: State;
+    BUILDING_CLIENT_REQUEST: State;
+    SENT_CLIENT_REQUEST: State;
+    SENT_ATTENTION: State;
+    FINAL: State;
   }
 
   routingData: any;
@@ -1783,8 +1785,8 @@ class Connection extends EventEmitter {
    @param {boolean} [options.tableLock=false] - Places a bulk update(BU) lock on table while performing bulk load. Uses row locks by default.
    @param {callback} callback - Function to call after BulkLoad executes.
    */
-  newBulkLoad(table: string, callback: BulkLoadCallback) : BulkLoad
-  newBulkLoad(table: string, options: BulkLoadOptions, callback: BulkLoadCallback) : BulkLoad
+  newBulkLoad(table: string, callback: BulkLoadCallback): BulkLoad
+  newBulkLoad(table: string, options: BulkLoadOptions, callback: BulkLoadCallback): BulkLoad
   newBulkLoad(table: string, callbackOrOptions: BulkLoadOptions | BulkLoadCallback, callback?: BulkLoadCallback) {
     let options: BulkLoadOptions;
 
@@ -1925,6 +1927,7 @@ class Connection extends EventEmitter {
     return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.savePayload(this.currentTransactionDescriptor()));
   }
 
+  // eslint-disable-next-line space-before-function-paren
   transaction<T extends (...args: any[]) => void>(cb: (err: Error | null | undefined, txDone?: (err: Error | null | undefined, done: T, ...args: Parameters<T>) => void) => void, isolationLevel?: typeof ISOLATION_LEVEL[keyof typeof ISOLATION_LEVEL]) {
     if (typeof cb !== 'function') {
       throw new TypeError('`cb` must be a function');

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -41,42 +41,42 @@ import Variant from './data-types/sql-variant';
 import { InternalConnectionOptions } from './connection';
 
 export type Parameter = {
-  type: DataType,
-  name: string,
+  type: DataType;
+  name: string;
 
-  value: unknown,
+  value: unknown;
 
-  output: boolean,
-  length?: number,
-  precision?: number,
-  scale?: number,
+  output: boolean;
+  length?: number;
+  precision?: number;
+  scale?: number;
 
-  nullable?: boolean
+  nullable?: boolean;
 };
 
 export type ParameterData<T = any> = {
-  length?: number,
-  scale?: number,
-  precision?: number,
+  length?: number;
+  scale?: number;
+  precision?: number;
 
-  value: T
+  value: T;
 };
 
 export interface DataType {
-  id: number,
-  type: string,
-  name: string,
+  id: number;
+  type: string;
+  name: string;
 
-  declaration(parameter: Parameter) : string,
-  writeTypeInfo(buf: any, data: ParameterData, options: InternalConnectionOptions) : void,
-  writeParameterData(buf: any, data: ParameterData, options: InternalConnectionOptions, callback: () => void) : void,
-  validate(value: any) : any, // TODO: Refactor 'any' and replace with more specific type.
+  declaration(parameter: Parameter): string;
+  writeTypeInfo(buf: any, data: ParameterData, options: InternalConnectionOptions): void;
+  writeParameterData(buf: any, data: ParameterData, options: InternalConnectionOptions, callback: () => void): void;
+  validate(value: any): any; // TODO: Refactor 'any' and replace with more specific type.
 
-  hasTableName?: boolean,
+  hasTableName?: boolean;
 
-  resolveLength?: (parameter: Parameter) => number,
-  resolvePrecision?: (parameter: Parameter) => number,
-  resolveScale?: (parameter: Parameter) => number
+  resolveLength?: (parameter: Parameter) => number;
+  resolvePrecision?: (parameter: Parameter) => number;
+  resolveScale?: (parameter: Parameter) => number;
 }
 
 export const TYPE = {

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -26,7 +26,7 @@ const BigInt: DataType = {
     cb();
   },
 
-  validate: function(value) : null | number | TypeError {
+  validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;
     }

--- a/src/data-types/binary.ts
+++ b/src/data-types/binary.ts
@@ -11,7 +11,7 @@ const Binary: { maximumLength: number } & DataType = {
   declaration: function(parameter) {
     const value = parameter.value as Buffer | null;
 
-    var length;
+    let length;
     if (parameter.length) {
       length = parameter.length;
     } else if (value != null) {
@@ -50,7 +50,7 @@ const Binary: { maximumLength: number } & DataType = {
     cb();
   },
 
-  validate: function(value) : Buffer | null | TypeError {
+  validate: function(value): Buffer | null | TypeError {
     if (value == null) {
       return null;
     }

--- a/src/data-types/date.ts
+++ b/src/data-types/date.ts
@@ -5,7 +5,7 @@ import { ChronoUnit, LocalDate } from '@js-joda/core';
 const globalDate = global.Date;
 const EPOCH_DATE = LocalDate.ofYearDay(1, 1);
 
-const Date : DataType = {
+const Date: DataType = {
   id: 0x28,
   type: 'DATEN',
   name: 'Date',

--- a/src/data-types/smallmoney.ts
+++ b/src/data-types/smallmoney.ts
@@ -25,7 +25,7 @@ const SmallMoney: DataType = {
     cb();
   },
 
-  validate: function(value):null | number | TypeError {
+  validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;
     }

--- a/src/data-types/tvp.ts
+++ b/src/data-types/tvp.ts
@@ -40,7 +40,7 @@ const TVP: DataType = {
     buffer.writeUInt8(0x00);
 
     const ref1 = parameter.value.rows;
-    const writeNext = (i:number) => {
+    const writeNext = (i: number) => {
       if (i >= ref1.length) {
         buffer.writeUInt8(0x00);
         cb();

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -4,10 +4,10 @@ import { Packet } from './packet';
 
 class Debug extends EventEmitter {
   options: {
-    data: boolean,
-    payload: boolean,
-    packet: boolean,
-    token: boolean
+    data: boolean;
+    payload: boolean;
+    packet: boolean;
+    token: boolean;
   };
 
   indent: string;

--- a/src/login7-payload.ts
+++ b/src/login7-payload.ts
@@ -64,13 +64,13 @@ const FEDAUTH_OPTIONS = {
 const FEATURE_EXT_TERMINATOR = 0xFF;
 
 type Options = {
-  tdsVersion: number,
-  packetSize: number,
-  clientProgVer: number,
-  clientPid: number,
-  connectionId: number,
-  clientTimeZone: number,
-  clientLcid: number
+  tdsVersion: number;
+  packetSize: number;
+  clientProgVer: number;
+  clientPid: number;
+  connectionId: number;
+  clientTimeZone: number;
+  clientLcid: number;
 };
 
 /*
@@ -452,7 +452,7 @@ class Login7Payload {
     return password;
   }
 
-  toString(indent: string = '') {
+  toString(indent = '') {
     return indent + 'Login7 - ' +
       sprintf('TDS:0x%08X, PacketSize:0x%08X, ClientProgVer:0x%08X, ClientPID:0x%08X, ConnectionID:0x%08X',
               this.tdsVersion, this.packetSize, this.clientProgVer, this.clientPid, this.connectionId

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const DuplexPair = require('native-duplexpair');
 
 import { Duplex } from 'stream';
@@ -23,8 +24,8 @@ class MessageIO extends EventEmitter {
   outgoingMessageStream: OutgoingMessageStream;
 
   securePair?: {
-    cleartext: tls.TLSSocket,
-    encrypted: Duplex
+    cleartext: tls.TLSSocket;
+    encrypted: Duplex;
   }
 
   constructor(socket: Socket, packetSize: number, debug: Debug) {

--- a/src/message.ts
+++ b/src/message.ts
@@ -5,7 +5,7 @@ class Message extends PassThrough {
   resetConnection: boolean;
   ignore: boolean;
 
-  constructor({ type, resetConnection = false } : { type: number, resetConnection?: boolean }) {
+  constructor({ type, resetConnection = false }: { type: number, resetConnection?: boolean }) {
     super();
 
     this.type = type;

--- a/src/metadata-parser.ts
+++ b/src/metadata-parser.ts
@@ -6,37 +6,37 @@ import { TYPE, DataType } from './data-type';
 import { sprintf } from 'sprintf-js';
 
 type Collation = {
-  lcid: number,
-  flags: number,
-  version: number,
-  sortId: number,
-  codepage: string
+  lcid: number;
+  flags: number;
+  version: number;
+  sortId: number;
+  codepage: string;
 };
 
 type XmlSchema = {
-  dbname: string,
-  owningSchema: string,
-  xmlSchemaCollection: string
+  dbname: string;
+  owningSchema: string;
+  xmlSchemaCollection: string;
 };
 
 type UdtInfo = {
-  maxByteSize: number,
-  dbname: string,
-  owningSchema: string,
-  typeName: string,
-  assemblyName: string
+  maxByteSize: number;
+  dbname: string;
+  owningSchema: string;
+  typeName: string;
+  assemblyName: string;
 };
 
 export type Metadata = {
-  userType: number,
-  flags: number,
-  type: DataType,
-  collation: Collation | undefined,
-  precision: number | undefined,
-  scale: number | undefined,
-  dataLength: number | undefined,
-  schema: XmlSchema | undefined,
-  udtInfo: UdtInfo | undefined
+  userType: number;
+  flags: number;
+  type: DataType;
+  collation: Collation | undefined;
+  precision: number | undefined;
+  scale: number | undefined;
+  dataLength: number | undefined;
+  schema: XmlSchema | undefined;
+  udtInfo: UdtInfo | undefined;
 };
 
 function readCollation(parser: Parser, callback: (collation: Collation | undefined) => void) {

--- a/src/ntlm-payload.ts
+++ b/src/ntlm-payload.ts
@@ -3,13 +3,13 @@ import * as crypto from 'crypto';
 import JSBI from 'jsbi';
 
 type Options = {
-  domain: string,
-  userName: string,
-  password: string,
+  domain: string;
+  userName: string;
+  password: string;
   ntlmpacket: {
-    target: Buffer,
-    nonce: Buffer
-  }
+    target: Buffer;
+    nonce: Buffer;
+  };
 };
 
 class NTLMResponsePayload {
@@ -19,7 +19,7 @@ class NTLMResponsePayload {
     this.data = this.createResponse(loginData);
   }
 
-  toString(indent: string = '') {
+  toString(indent = '') {
     return indent + 'NTLM Auth';
   }
 

--- a/src/outgoing-message-stream.ts
+++ b/src/outgoing-message-stream.ts
@@ -12,7 +12,7 @@ class OutgoingMessageStream extends Duplex {
 
   currentMessage: Message | undefined;
 
-  constructor(debug: Debug, { packetSize } : { packetSize: number }) {
+  constructor(debug: Debug, { packetSize }: { packetSize: number }) {
     super({ writableObjectMode: true });
 
     this.packetSize = packetSize;

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -147,12 +147,12 @@ export class Packet {
     return statuses.join(' ').trim();
   }
 
-  headerToString(indent: string = '') {
+  headerToString(indent = '') {
     const text = sprintf('type:0x%02X(%s), status:0x%02X(%s), length:0x%04X, spid:0x%04X, packetId:0x%02X, window:0x%02X', this.buffer.readUInt8(OFFSET.Type), typeByValue[this.buffer.readUInt8(OFFSET.Type)], this.buffer.readUInt8(OFFSET.Status), this.statusAsString(), this.buffer.readUInt16BE(OFFSET.Length), this.buffer.readUInt16BE(OFFSET.SPID), this.buffer.readUInt8(OFFSET.PacketID), this.buffer.readUInt8(OFFSET.Window));
     return indent + text;
   }
 
-  dataToString(indent: string = '') {
+  dataToString(indent = '') {
     const BYTES_PER_GROUP = 0x04;
     const CHARS_PER_GROUP = 0x08;
     const BYTES_PER_LINE = 0x20;
@@ -201,7 +201,7 @@ export class Packet {
     return dataDump;
   }
 
-  toString(indent: string = '') {
+  toString(indent = '') {
     return this.headerToString(indent) + '\n' + this.dataToString(indent + indent);
   }
 

--- a/src/prelogin-payload.ts
+++ b/src/prelogin-payload.ts
@@ -46,7 +46,7 @@ for (const name in MARS) {
 
 
 type Options = {
-  encrypt: boolean
+  encrypt: boolean;
 };
 
 /*
@@ -57,11 +57,11 @@ class PreloginPayload {
   options: Options;
 
   version!: {
-    major: number,
-    minor: number,
-    patch: number,
-    trivial: number,
-    subbuild: number
+    major: number;
+    minor: number;
+    patch: number;
+    trivial: number;
+    subbuild: number;
   };
 
   encryption!: number;
@@ -242,7 +242,7 @@ class PreloginPayload {
     this.fedAuthRequired = this.data.readUInt8(offset);
   }
 
-  toString(indent: string = '') {
+  toString(indent = '') {
     return indent + 'PreLogin - ' + sprintf(
       'version:%d.%d.%d.%d %d, encryption:0x%02X(%s), instopt:0x%02X, threadId:0x%08X, mars:0x%02X(%s)',
       this.version.major, this.version.minor, this.version.patch, this.version.trivial, this.version.subbuild,

--- a/src/request.ts
+++ b/src/request.ts
@@ -8,10 +8,10 @@ import Connection from './connection';
 type CompletionCallback = (error: Error | null | undefined, rowCount?: number, rows?: any) => void;
 
 type ParameterOptions = {
-  output?: boolean,
-  length?: number,
-  precision?: number,
-  scale?: number
+  output?: boolean;
+  length?: number;
+  precision?: number;
+  scale?: number;
 }
 
 class Request extends EventEmitter {

--- a/src/sqlbatch-payload.ts
+++ b/src/sqlbatch-payload.ts
@@ -25,7 +25,7 @@ class SqlBatchPayload {
     cb(buffer.data);
   }
 
-  toString(indent: string = '') {
+  toString(indent = '') {
     return indent + ('SQL Batch - ' + this.sqlText);
   }
 }

--- a/src/token/colmetadata-token-parser.ts
+++ b/src/token/colmetadata-token-parser.ts
@@ -5,8 +5,8 @@ import { InternalConnectionOptions } from '../connection';
 import { ColMetadataToken } from './token';
 
 export type ColumnMetadata = Metadata & {
-  colName: string,
-  tableName?: string | string[]
+  colName: string;
+  tableName?: string | string[];
 };
 
 function readTableName(parser: Parser, options: InternalConnectionOptions, metadata: Metadata, callback: (tableName?: string | string[]) => void) {

--- a/src/token/done-token-parser.ts
+++ b/src/token/done-token-parser.ts
@@ -18,12 +18,12 @@ const STATUS = {
 };
 
 type TokenData = {
-  more: boolean,
-  sqlError: boolean,
-  attention: boolean,
-  serverError: boolean,
-  rowCount: number | undefined,
-  curCmd: number
+  more: boolean;
+  sqlError: boolean;
+  attention: boolean;
+  serverError: boolean;
+  rowCount: number | undefined;
+  curCmd: number;
 };
 
 function parseToken(parser: Parser, options: InternalConnectionOptions, callback: (data: TokenData) => void) {

--- a/src/token/infoerror-token-parser.ts
+++ b/src/token/infoerror-token-parser.ts
@@ -5,13 +5,13 @@ import { InternalConnectionOptions } from '../connection';
 import { InfoMessageToken, ErrorMessageToken } from './token';
 
 type TokenData = {
-  number: number,
-  state: number,
-  class: number,
-  message: string,
-  serverName: string,
-  procName: string,
-  lineNumber: number,
+  number: number;
+  state: number;
+  class: number;
+  message: string;
+  serverName: string;
+  procName: string;
+  lineNumber: number;
 };
 
 function parseToken(parser: Parser, options: InternalConnectionOptions, callback: (data: TokenData) => void) {

--- a/src/token/nbcrow-token-parser.ts
+++ b/src/token/nbcrow-token-parser.ts
@@ -13,8 +13,8 @@ function nullHandler(_parser: Parser, _columnMetadata: ColumnMetadata, _options:
 }
 
 type Column = {
-  value: unknown,
-  metadata: ColumnMetadata
+  value: unknown;
+  metadata: ColumnMetadata;
 };
 
 function nbcRowParser(parser: Parser, columnsMetaData: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: NBCRowToken) => void) {

--- a/src/token/row-token-parser.ts
+++ b/src/token/row-token-parser.ts
@@ -9,8 +9,8 @@ import { RowToken } from './token';
 import valueParse from '../value-parser';
 
 type Column = {
-  value: unknown,
-  metadata: ColumnMetadata
+  value: unknown;
+  metadata: ColumnMetadata;
 };
 
 function rowParser(parser: Parser, colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: RowToken) => void) {

--- a/src/token/sspi-token-parser.ts
+++ b/src/token/sspi-token-parser.ts
@@ -5,20 +5,20 @@ import { InternalConnectionOptions } from '../connection';
 import { SSPIToken } from './token';
 
 type Data = {
-  magic: string,
-  type: number,
-  domainLen: number,
-  domainMax: number,
-  domainOffset: number,
-  flags: number,
-  nonce: Buffer,
-  zeroes: Buffer,
-  targetLen: number,
-  targetMax: number,
-  targetOffset: number,
-  oddData: Buffer,
-  domain: string,
-  target: Buffer
+  magic: string;
+  type: number;
+  domainLen: number;
+  domainMax: number;
+  domainOffset: number;
+  flags: number;
+  nonce: Buffer;
+  zeroes: Buffer;
+  targetLen: number;
+  targetMax: number;
+  targetOffset: number;
+  oddData: Buffer;
+  domain: string;
+  target: Buffer;
 };
 
 function parseChallenge(buffer: Buffer) {

--- a/src/value-parser.ts
+++ b/src/value-parser.ts
@@ -631,7 +631,7 @@ function readDateTime(parser: Parser, useUTC: boolean, callback: (value: Date) =
 }
 
 interface DateWithNanosecondsDelta extends Date {
-  nanosecondsDelta: number
+  nanosecondsDelta: number;
 }
 
 function readTime(parser: Parser, dataLength: number, scale: number, useUTC: boolean, callback: (value: DateWithNanosecondsDelta) => void) {


### PR DESCRIPTION
To support TypeScript syntax in `eslint`, we've used the `babel-eslint` parser module so far.

Unfortunately, that required disabling quite a few rules in our `eslintrc` config file:

https://github.com/tediousjs/tedious/blob/62ff4a10c4b1e1ef99b7f452cbaddef40c32f2cf/.eslintrc#L9

https://github.com/tediousjs/tedious/blob/62ff4a10c4b1e1ef99b7f452cbaddef40c32f2cf/.eslintrc#L27-L35

https://github.com/tediousjs/tedious/blob/62ff4a10c4b1e1ef99b7f452cbaddef40c32f2cf/.eslintrc#L47

These rules did not know about some of the specifics of TypeScript syntax or were simply not compatible with the AST that was returned by `babel-eslint`, and caused `eslint` to simply error out.

Luckily, there's an alternative and official way of making `eslint` better understand TypeScript syntax, called `@typescript-eslint`. Even better, the project does not simply provide only a parser, but it also comes with it's own set of TypeScript specific rules.

I enabled a set of rules that I deemed the most useful, and updated our code base to pass those rules.

