### PR TITLE
refactor: use `Readable` streams to generate request payloads

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -182,7 +182,7 @@ overrides:
       "@typescript-eslint/no-inferrable-types": "error"
       "@typescript-eslint/no-misused-new": "error"
       "@typescript-eslint/no-namespace": "error"
-      "@typescript-eslint/no-this-alias": "error"
+      "@typescript-eslint/no-this-alias": ["error", { allowDestructuring: true, allowedNames: ['self'] }]
       "no-unused-vars": "off"
       "@typescript-eslint/no-unused-vars": ["error", { args: "none", caughtErrors: "all" }]
       "no-use-before-define": "off"

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -3,6 +3,7 @@ import { writeToTrackingBuffer } from './all-headers';
 import Request from './request';
 import { Parameter, ParameterData } from './data-type';
 import { InternalConnectionOptions } from './connection';
+import { Readable } from 'readable-stream';
 
 // const OPTION = {
 //   WITH_RECOMPILE: 0x01,
@@ -30,6 +31,19 @@ class RpcRequestPayload {
     this.procedure = this.request.sqlTextOrProcedure!;
     this.options = options;
     this.txnDescriptor = txnDescriptor;
+  }
+
+  getStream() {
+    const self = this;
+
+    return new Readable({
+      read() {
+        self.getData((buf) => {
+          this.push(buf);
+          this.push(null);
+        });
+      }
+    });
   }
 
   getData(cb: (data: Buffer) => void) {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,5 +1,6 @@
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import { writeToTrackingBuffer } from './all-headers';
+import { Readable } from 'readable-stream';
 
 /*
   s2.2.6.8
@@ -50,7 +51,14 @@ export class Transaction {
     buffer.writeString(this.name, 'ucs2');
 
     return {
-      getData: (cb: (data: Buffer) => void) => { cb(buffer.data); },
+      getStream: () => {
+        return new Readable({
+          read() {
+            this.push(buffer.data);
+            this.push(null);
+          }
+        });
+      },
       toString: () => {
         return 'Begin Transaction: name=' + this.name + ', isolationLevel=' + isolationLevelByValue[this.isolationLevel];
       }
@@ -67,8 +75,14 @@ export class Transaction {
     buffer.writeUInt8(0);
 
     return {
-      getData: (cb: (data: Buffer) => void) => { cb(buffer.data); },
-      data: buffer.data,
+      getStream: () => {
+        return new Readable({
+          read() {
+            this.push(buffer.data);
+            this.push(null);
+          }
+        });
+      },
       toString: () => {
         return 'Commit Transaction: name=' + this.name;
       }
@@ -85,7 +99,14 @@ export class Transaction {
     buffer.writeUInt8(0);
 
     return {
-      getData: (cb: (data: Buffer) => void) => { cb(buffer.data); },
+      getStream: () => {
+        return new Readable({
+          read() {
+            this.push(buffer.data);
+            this.push(null);
+          }
+        });
+      },
       toString: () => {
         return 'Rollback Transaction: name=' + this.name;
       }
@@ -100,7 +121,14 @@ export class Transaction {
     buffer.writeString(this.name, 'ucs2');
 
     return {
-      getData: (cb: (data: Buffer) => void) => { cb(buffer.data); },
+      getStream: () => {
+        return new Readable({
+          read() {
+            this.push(buffer.data);
+            this.push(null);
+          }
+        });
+      },
       toString: () => {
         return 'Save Transaction: name=' + this.name;
       }

--- a/test/integration/errors-test.js
+++ b/test/integration/errors-test.js
@@ -149,7 +149,7 @@ describe('Errors Test', function() {
     }
   });
 
-  it('should cancel during BUILDING_CLIENT_REQUEST State', function(done) {
+  it('should support cancelling after starting query execution', function(done) {
     const connection = new Connection(config);
 
     const request = new Request("select 42, 'hello world'", function(err, rowCount) {


### PR DESCRIPTION
Up until now, request payloads were generated by calling a `.getData` 
method on the request type's payload object, which would call the given 
callback with a `Buffer` containing the full request data.

As this requires the full request data to be fully build (and held in 
memory), actually writing the request to the network is delayed until 
the final `Buffer` was built.

This changeset switches us to use `Readable` stream objects instead. 
Internally, these are still building the full data buffer before, but 
this will be changed in the future.

This is part of the work described in https://github.com/tediousjs/tedious/issues/1038.