### PR TITLE
chore: update to `readable-stream@3.5.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12356,9 +12356,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+      "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsbi": "^3.1.1",
     "native-duplexpair": "^1.0.0",
     "punycode": "^2.1.0",
-    "readable-stream": "^3.4.0",
+    "readable-stream": "^3.5.0",
     "sprintf-js": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates `readable-stream` to `3.5.0`, which brings us the `Readable.from` static method that is a requirement for the work described over in https://github.com/tediousjs/tedious/issues/1038.