### PR TITLE
Improve Performance - Refactor plp

### DIFF
--- a/benchmarks/request/rpcrequest-payload-tvp.js
+++ b/benchmarks/request/rpcrequest-payload-tvp.js
@@ -3,6 +3,8 @@ const { createBenchmark } = require('../common');
 const { Request, TYPES } = require('../../lib/tedious');
 const RpcRequestPayload = require('../../lib/rpcrequest-payload');
 
+const { Readable } = require('readable-stream');
+
 const bench = createBenchmark(main, {
   n: [10, 100],
   size: [10, 100, 1000, 10000]
@@ -35,7 +37,7 @@ function main({ n, size }) {
     }
 
     const payload = new RpcRequestPayload(request, Buffer.alloc(0), {});
-    const stream = payload.getStream();
+    const stream = Readable.from(payload, { objectMode: false });
     const chunks = [];
     stream.on('data', (chunk) => {
       chunks.push(chunk);

--- a/benchmarks/request/rpcrequest-payload-tvp.js
+++ b/benchmarks/request/rpcrequest-payload-tvp.js
@@ -1,0 +1,45 @@
+const { createBenchmark } = require('../common');
+
+const { Request, TYPES } = require('../../lib/tedious');
+const RpcRequestPayload = require('../../lib/rpcrequest-payload');
+
+const bench = createBenchmark(main, {
+  n: [10, 100],
+  size: [10, 100, 1000, 10000]
+});
+
+function main({ n, size }) {
+  var table = {
+    columns: [
+      { name: 'user_id', type: TYPES.Int },
+      { name: 'user_name', type: TYPES.VarChar, length: 500 },
+      { name: 'user_enabled', type: TYPES.Bit }
+    ],
+    rows: []
+  };
+
+  for (let j = 0; j < size; j++) {
+    table.rows.push([15, 'Eric', true]);
+  }
+
+  const request = new Request('...', () => {});
+  request.addParameter('value', TYPES.TVP, table);
+
+  let i = 0;
+  bench.start();
+
+  (function cb() {
+    if (i++ === n) {
+      bench.end(n);
+      return;
+    }
+
+    const payload = new RpcRequestPayload(request, Buffer.alloc(0), {});
+    const stream = payload.getStream();
+    const chunks = [];
+    stream.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+    stream.on('end', cb);
+  })();
+}

--- a/benchmarks/request/rpcrequest-payload-varbinary.js
+++ b/benchmarks/request/rpcrequest-payload-varbinary.js
@@ -8,15 +8,14 @@ const bench = createBenchmark(main, {
   size: [
     1024 * 1024,
     10 * 1024 * 1024,
-    50 * 1024 * 1024
+    50 * 1024 * 1024,
   ]
 });
 
 function main({ n, size }) {
-  const buf = Buffer.alloc(size);
-  buf.fill('x');
+  const buf = Buffer.alloc(size, 'x');
 
-  const request = new Request('INSERT INTO #benchmark ([value]) VALUES (@value)', () => {});
+  const request = new Request('...', () => {});
   request.addParameter('value', TYPES.VarBinary, buf);
 
   let i = 0;

--- a/benchmarks/request/rpcrequest-payload-varbinary.js
+++ b/benchmarks/request/rpcrequest-payload-varbinary.js
@@ -3,6 +3,8 @@ const { createBenchmark } = require('../common');
 const { Request, TYPES } = require('../../lib/tedious');
 const RpcRequestPayload = require('../../lib/rpcrequest-payload');
 
+const { Readable } = require('readable-stream');
+
 const bench = createBenchmark(main, {
   n: [10, 100],
   size: [
@@ -28,7 +30,7 @@ function main({ n, size }) {
     }
 
     const payload = new RpcRequestPayload(request, Buffer.alloc(0), {});
-    const stream = payload.getStream();
+    const stream = Readable.from(payload, { objectMode: false });
     const chunks = [];
     stream.on('data', (chunk) => {
       chunks.push(chunk);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1658,7 +1658,7 @@ class Connection extends EventEmitter {
 
     const message = new Message({ type: TYPE.SQL_BATCH });
     this.messageIo.outgoingMessageStream.write(message);
-    payload.getStream().pipe(message);
+    Readable.from(payload, { objectMode: false }).pipe(message);
   }
 
   getInitialSql() {
@@ -1984,8 +1984,8 @@ class Connection extends EventEmitter {
   }
 
   makeRequest(request: BulkLoad, packetType: number): void
-  makeRequest(request: Request, packetType: number, payload: { getStream: () => Readable, toString: (indent?: string) => string }): void
-  makeRequest(request: Request | BulkLoad, packetType: number, payload?: { getStream: () => Readable, toString: (indent?: string) => string }) {
+  makeRequest(request: Request, packetType: number, payload: Iterable<Buffer> & { toString: (indent?: string) => string }): void
+  makeRequest(request: Request | BulkLoad, packetType: number, payload?: Iterable<Buffer> & { toString: (indent?: string) => string }) {
     if (this.state !== this.STATE.LOGGED_IN) {
       const message = 'Requests can only be made in the ' + this.STATE.LOGGED_IN.name + ' state, not the ' + this.state.name + ' state';
       this.debug.log(message);
@@ -2065,7 +2065,7 @@ class Connection extends EventEmitter {
           }
         });
 
-        payload!.getStream().pipe(message);
+        Readable.from(payload!, { objectMode: false }).pipe(message);
       }
     }
   }

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -68,10 +68,9 @@ export interface DataType {
   name: string;
 
   declaration(parameter: Parameter): string;
-  writeTypeInfo(buf: any, data: ParameterData, options: InternalConnectionOptions): void;
-  writeParameterData(buf: any, data: ParameterData, options: InternalConnectionOptions, callback: () => void): void;
+  generateTypeInfo(parameter: ParameterData, options: InternalConnectionOptions): Buffer;
+  generateParameterData(parameter: ParameterData, options: InternalConnectionOptions): Generator<Buffer, void>;
   validate(value: any): any; // TODO: Refactor 'any' and replace with more specific type.
-  generate(parameter: ParameterData, options: InternalConnectionOptions): Generator<Buffer, void>;
 
   hasTableName?: boolean;
 

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -11,26 +11,18 @@ const BigInt: DataType = {
     return 'bigint';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(IntN.id);
-    buffer.writeUInt8(8);
+  generateTypeInfo() {
+    return Buffer.from([IntN.id, 0x08]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function* (parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
       const buffer = new WritableTrackingBuffer(9);
       buffer.writeUInt8(8);
       buffer.writeInt64LE(Number(parameter.value));
       yield buffer.data;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/binary.ts
+++ b/src/data-types/binary.ts
@@ -1,5 +1,4 @@
-import { DataType, ParameterData } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
+import { DataType } from '../data-type';
 
 const NULL = (1 << 16) - 1;
 
@@ -36,26 +35,25 @@ const Binary: { maximumLength: number } & DataType = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter: ParameterData<Buffer | null>) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt16LE(parameter.length);
+  generateTypeInfo(parameter) {
+    const buffer = Buffer.alloc(3);
+    buffer.writeUInt8(this.id, 0);
+    buffer.writeUInt16LE(parameter.length!, 1);
+    return buffer;
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function* (parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(parameter.length!);
-      buffer.writeBuffer(parameter.value.slice(0, parameter.length !== undefined ? Math.min(parameter.length, this.maximumLength) : this.maximumLength));
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(parameter.length!, 0);
+      yield buffer;
+
+      const value = parameter.value.slice(0, parameter.length !== undefined ? Math.min(parameter.length, this.maximumLength) : this.maximumLength);
+      yield value;
     } else {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(NULL);
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(NULL, 0);
+      yield buffer;
     }
   },
 

--- a/src/data-types/bit.ts
+++ b/src/data-types/bit.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import BitN from './bitn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const Bit: DataType = {
   id: 0x32,
@@ -11,26 +10,20 @@ const Bit: DataType = {
     return 'bit';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(BitN.id);
-    buffer.writeUInt8(1);
+  generateTypeInfo() {
+    return Buffer.from([BitN.id, 0x01]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function* (parameter, options) {
+  *generateParameterData(parameter, options) {
     if (typeof parameter.value === 'undefined' || parameter.value === null) {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      const buffer = Buffer.alloc(1);
+      buffer.writeUInt8(0, 0);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt8(1);
-      buffer.writeUInt8(parameter.value ? 1 : 0);
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt8(1, 0);
+      buffer.writeUInt8(parameter.value ? 1 : 0, 1);
+      yield buffer;
     }
   },
 

--- a/src/data-types/bitn.ts
+++ b/src/data-types/bitn.ts
@@ -9,15 +9,11 @@ const BitN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  *generate() {
+  *generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -1,5 +1,4 @@
-import { DataType, ParameterData } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
+import { DataType } from '../data-type';
 
 const NULL = (1 << 16) - 1;
 
@@ -47,28 +46,29 @@ const Char: { maximumLength: number } & DataType = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter: ParameterData<any>) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt16LE(parameter.length);
-    buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
+  generateTypeInfo(parameter) {
+    const buffer = Buffer.alloc(8);
+    buffer.writeUInt8(this.id, 0);
+    buffer.writeUInt16LE(parameter.length!, 1);
+    return buffer;
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function* (parameter, options) {
-    const value = parameter.value as any; // Temporary solution. Remove 'any' later.
+  *generateParameterData(parameter, options) {
+    let value = parameter.value as any; // Temporary solution. Remove 'any' later.
 
     if (value != null) {
-      const buffer = new WritableTrackingBuffer(0);
-      buffer.writeUsVarbyte(value, 'ascii');
-      yield buffer.data;
+      value = value.toString();
+      const length = Buffer.byteLength(value, 'ascii');
+
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(length, 0);
+      yield buffer;
+
+      yield Buffer.alloc(length, parameter.value, 'ascii');
     } else {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(NULL);
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(NULL, 0);
+      yield buffer;
     }
   },
 

--- a/src/data-types/date.ts
+++ b/src/data-types/date.ts
@@ -15,16 +15,11 @@ const Date: DataType = {
     return 'date';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(this.id);
+  generateTypeInfo: function(buffer) {
+    return Buffer.from([this.id]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function* (parameter, options) {
+  *generateParameterData(parameter, options) {
     const value = parameter.value as any; // Temporary solution. Remove 'any' later.
 
     if (value != null) {
@@ -42,9 +37,7 @@ const Date: DataType = {
       buffer.writeUInt24LE(days);
       yield buffer.data;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/datetime.ts
+++ b/src/data-types/datetime.ts
@@ -1,7 +1,6 @@
 import { DataType } from '../data-type';
 import DateTimeN from './datetimen';
 import { ChronoUnit, LocalDate } from '@js-joda/core';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const EPOCH_DATE = LocalDate.ofYearDay(1900, 1);
 
@@ -14,24 +13,14 @@ const DateTime: DataType = {
     return 'datetime';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(DateTimeN.id);
-    buffer.writeUInt8(8);
+  generateTypeInfo() {
+    return Buffer.from([DateTimeN.id, 0x08]);
   },
 
-  // ParameterData<any> is temporary solution. TODO: need to understand what type ParameterData<...> can be.
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter, options) {
     const value = parameter.value as any; // Temporary solution. Remove 'any' later.
 
     if (value != null) {
-      const buffer = new WritableTrackingBuffer(16);
-
       let date;
       if (options.useUTC) {
         date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
@@ -63,15 +52,13 @@ const DateTime: DataType = {
         threeHundredthsOfSecond = 0;
       }
 
-      buffer.writeUInt8(8);
-      buffer.writeInt32LE(days);
-      buffer.writeUInt32LE(threeHundredthsOfSecond);
-
-      yield buffer.data;
+      const buffer = Buffer.alloc(9);
+      buffer.writeUInt8(8, 0);
+      buffer.writeInt32LE(days, 1);
+      buffer.writeUInt32LE(threeHundredthsOfSecond, 5);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/datetime2.ts
+++ b/src/data-types/datetime2.ts
@@ -23,17 +23,11 @@ const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt8(parameter.scale);
+  generateTypeInfo(parameter, _options) {
+    return Buffer.from([this.id, parameter.scale!]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function* (parameter, options) {
+  *generateParameterData(parameter, options) {
     const value = parameter.value;
     let scale = parameter.scale;
 

--- a/src/data-types/datetimen.ts
+++ b/src/data-types/datetimen.ts
@@ -9,15 +9,11 @@ const DateTimeN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/datetimeoffset.ts
+++ b/src/data-types/datetimeoffset.ts
@@ -20,16 +20,12 @@ const DateTimeOffset: DataType & { resolveScale: NonNullable<DataType['resolveSc
       return 7;
     }
   },
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt8(parameter.scale);
-  },
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
+
+  generateTypeInfo(parameter) {
+    return Buffer.from([this.id, parameter.scale!]);
   },
 
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter, options) {
     const value = parameter.value;
     let scale = parameter.scale;
 

--- a/src/data-types/decimaln.ts
+++ b/src/data-types/decimaln.ts
@@ -9,15 +9,11 @@ const DecimalN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/float.ts
+++ b/src/data-types/float.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import FloatN from './floatn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const Float: DataType = {
   id: 0x3E,
@@ -11,26 +10,18 @@ const Float: DataType = {
     return 'float';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(FloatN.id);
-    buffer.writeUInt8(8);
+  generateTypeInfo() {
+    return Buffer.from([FloatN.id, 0x08]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(9);
-      buffer.writeUInt8(8);
-      buffer.writeDoubleLE(parseFloat(parameter.value));
-      yield buffer.data;
+      const buffer = Buffer.alloc(9);
+      buffer.writeUInt8(8, 0);
+      buffer.writeDoubleLE(parseFloat(parameter.value), 1);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/floatn.ts
+++ b/src/data-types/floatn.ts
@@ -9,15 +9,11 @@ const FloatN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/image.ts
+++ b/src/data-types/image.ts
@@ -1,5 +1,4 @@
 import { DataType } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const Image: DataType = {
   id: 0x22,
@@ -20,26 +19,24 @@ const Image: DataType = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
-    buffer.writeInt32LE(parameter.length);
+  generateTypeInfo(parameter) {
+    const buffer = Buffer.alloc(5);
+    buffer.writeUInt8(this.id, 0);
+    buffer.writeInt32LE(parameter.length!, 1);
+    return buffer;
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(4);
-      buffer.writeInt32LE(parameter.length!);
-      buffer.writeBuffer(parameter.value);
-      yield buffer.data;
+      const buffer = Buffer.alloc(4);
+      buffer.writeInt32LE(parameter.length!, 0);
+      yield buffer;
+
+      yield parameter.value;
     } else {
-      const buffer = new WritableTrackingBuffer(4);
-      buffer.writeInt32LE(parameter.length!);
-      yield buffer.data;
+      const buffer = Buffer.alloc(4);
+      buffer.writeInt32LE(parameter.length!, 0);
+      yield buffer;
     }
   },
 

--- a/src/data-types/int.ts
+++ b/src/data-types/int.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import IntN from './intn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const Int: DataType = {
   id: 0x38,
@@ -11,26 +10,21 @@ const Int: DataType = {
     return 'int';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(IntN.id);
-    buffer.writeUInt8(4);
+  generateTypeInfo() {
+    return Buffer.from([IntN.id, 0x04]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(5);
-      buffer.writeUInt8(4);
-      buffer.writeInt32LE(Number(parameter.value));
-      yield buffer.data;
+      const buffer = Buffer.alloc(1);
+      buffer.writeUInt8(4, 0);
+      yield buffer;
+
+      const buffer2 = Buffer.alloc(4);
+      buffer2.writeInt32LE(Number(parameter.value), 0);
+      yield buffer2;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/intn.ts
+++ b/src/data-types/intn.ts
@@ -9,15 +9,11 @@ const IntN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/money.ts
+++ b/src/data-types/money.ts
@@ -1,6 +1,8 @@
 import { DataType } from '../data-type';
 import MoneyN from './moneyn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
+
+const SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
+const SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
 
 const Money: DataType = {
   id: 0x3C,
@@ -11,26 +13,28 @@ const Money: DataType = {
     return 'money';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(MoneyN.id);
-    buffer.writeUInt8(8);
+  generateTypeInfo: function() {
+    return Buffer.from([MoneyN.id, 0x08]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(9);
-      buffer.writeUInt8(8);
-      buffer.writeMoney(parameter.value * 10000);
-      yield buffer.data;
+      const buffer = Buffer.alloc(1);
+      buffer.writeUInt8(8, 0);
+      yield buffer;
+
+      const value = parameter.value * 10000;
+
+      const buffer2 = Buffer.alloc(4);
+      buffer2.writeInt32LE(Math.floor(value * SHIFT_RIGHT_32), 0);
+      yield buffer2;
+
+      const buffer3 = Buffer.alloc(4);
+      buffer3.writeInt32LE(value & -1, 0);
+      yield buffer3;
+
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/moneyn.ts
+++ b/src/data-types/moneyn.ts
@@ -9,15 +9,11 @@ const MoneyN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/nchar.ts
+++ b/src/data-types/nchar.ts
@@ -1,5 +1,4 @@
 import { DataType } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const NULL = (1 << 16) - 1;
 
@@ -48,26 +47,38 @@ const NChar: DataType & { maximumLength: number } = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt16LE(parameter.length! * 2);
-    buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
+  generateTypeInfo: function(parameter) {
+    const buffer = Buffer.alloc(8);
+    buffer.writeUInt8(this.id, 0);
+    buffer.writeUInt16LE(parameter.length! * 2, 1);
+    return buffer;
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
+    let value = parameter.value;
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(0);
-      buffer.writeUsVarbyte(parameter.value, 'ucs2');
-      yield buffer.data;
+      if (value instanceof Buffer) {
+        const length = value.length;
+        const buffer = Buffer.alloc(2);
+
+        buffer.writeUInt16LE(length, 0);
+
+        yield buffer;
+        yield value;
+
+      } else {
+        value = value.toString();
+        const length = Buffer.byteLength(value, 'ucs2');
+        const buffer = Buffer.alloc(2);
+
+        buffer.writeUInt16LE(length, 0);
+        yield buffer;
+        yield Buffer.from(value, 'ucs2');
+      }
     } else {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(NULL);
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(NULL, 0);
+      yield buffer;
     }
   },
 

--- a/src/data-types/ntext.ts
+++ b/src/data-types/ntext.ts
@@ -11,15 +11,11 @@ const NText: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/null.ts
+++ b/src/data-types/null.ts
@@ -9,15 +9,11 @@ const Null: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/numeric.ts
+++ b/src/data-types/numeric.ts
@@ -29,37 +29,32 @@ const Numeric: DataType & { resolveScale: NonNullable<DataType['resolveScale']>,
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(NumericN.id);
+  generateTypeInfo(parameter) {
+    let precision;
     if (parameter.precision! <= 9) {
-      buffer.writeUInt8(5);
+      precision = 0x05;
     } else if (parameter.precision! <= 19) {
-      buffer.writeUInt8(9);
+      precision = 0x09;
     } else if (parameter.precision! <= 28) {
-      buffer.writeUInt8(13);
+      precision = 0x0D;
     } else {
-      buffer.writeUInt8(17);
+      precision = 0x11;
     }
-    buffer.writeUInt8(parameter.precision);
-    buffer.writeUInt8(parameter.scale);
+
+    return Buffer.from([NumericN.id, precision, parameter.precision!, parameter.scale!]);
   },
 
-
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
       const sign = parameter.value < 0 ? 0 : 1;
       const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale!)));
       if (parameter.precision! <= 9) {
-        const buffer = new WritableTrackingBuffer(6);
-        buffer.writeUInt8(5);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt32LE(value);
-        yield buffer.data;
+        const buffer = Buffer.alloc(6);
+        let offset = 0;
+        offset = buffer.writeUInt8(5, offset);
+        offset = buffer.writeUInt8(sign, offset);
+        buffer.writeUInt32LE(value, offset);
+        yield buffer;
       } else if (parameter.precision! <= 19) {
         const buffer = new WritableTrackingBuffer(10);
         buffer.writeUInt8(9);
@@ -83,9 +78,7 @@ const Numeric: DataType & { resolveScale: NonNullable<DataType['resolveScale']>,
         yield buffer.data;
       }
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/numericn.ts
+++ b/src/data-types/numericn.ts
@@ -9,15 +9,11 @@ const NumericN: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/nvarchar.ts
+++ b/src/data-types/nvarchar.ts
@@ -1,8 +1,9 @@
 import { DataType } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const NULL = (1 << 16) - 1;
 const MAX = (1 << 16) - 1;
+const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+const PLP_TERMINATOR = Buffer.from([0x00, 0x00, 0x00, 0x00]);
 
 const NVarChar: { maximumLength: number } & DataType = {
   id: 0xE7,
@@ -46,40 +47,77 @@ const NVarChar: { maximumLength: number } & DataType = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
+  generateTypeInfo(parameter) {
+    const buffer = Buffer.alloc(8);
+    buffer.writeUInt8(this.id, 0);
+
     if (parameter.length! <= this.maximumLength) {
-      buffer.writeUInt16LE(parameter.length! * 2);
+      buffer.writeUInt16LE(parameter.length! * 2, 1);
     } else {
-      buffer.writeUInt16LE(MAX);
+      buffer.writeUInt16LE(MAX, 1);
     }
-    buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
+
+    return buffer;
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(0);
+      let value = parameter.value;
+
       if (parameter.length! <= this.maximumLength) {
-        buffer.writeUsVarbyte(parameter.value, 'ucs2');
-        yield buffer.data;
+        let length;
+        if (value instanceof Buffer) {
+          length = value.length;
+
+          const buffer = Buffer.alloc(2);
+          buffer.writeUInt16LE(length, 0);
+          yield buffer;
+
+          yield value;
+        } else {
+          value = value.toString();
+          length = Buffer.byteLength(value, 'ucs2');
+
+          const buffer = Buffer.alloc(2);
+          buffer.writeUInt16LE(length, 0);
+          yield buffer;
+
+          yield Buffer.from(value, 'ucs2');
+        }
       } else {
-        buffer.writePLPBody(parameter.value, 'ucs2');
-        yield buffer.data;
+        yield UNKNOWN_PLP_LEN;
+
+        if (value instanceof Buffer) {
+          const length = value.length;
+          if (length > 0) {
+            const buffer = Buffer.alloc(4);
+            buffer.writeUInt32LE(length, 0);
+            yield buffer;
+            yield value;
+          }
+        } else {
+          value = value.toString();
+          const length = Buffer.byteLength(value, 'ucs2');
+
+          if (length > 0) {
+            const buffer = Buffer.alloc(4);
+            buffer.writeUInt32LE(length, 0);
+            yield buffer;
+            yield Buffer.from(value, 'ucs2');
+          }
+        }
+
+        yield PLP_TERMINATOR;
       }
     } else if (parameter.length! <= this.maximumLength) {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(NULL);
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(NULL, 0);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(4);
-      buffer.writeUInt32LE(0xFFFFFFFF);
-      buffer.writeUInt32LE(0xFFFFFFFF);
-      yield buffer.data;
+      const buffer = Buffer.alloc(8);
+      const offset = buffer.writeUInt32LE(0xFFFFFFFF, 0);
+      buffer.writeUInt32LE(0xFFFFFFFF, offset);
+      yield buffer;
     }
   },
 

--- a/src/data-types/real.ts
+++ b/src/data-types/real.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import FloatN from './floatn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const Real: DataType = {
   id: 0x3B,
@@ -11,30 +10,23 @@ const Real: DataType = {
     return 'real';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(FloatN.id);
-    buffer.writeUInt8(4);
+  generateTypeInfo() {
+    return Buffer.from([FloatN.id, 0x04]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(4);
-      buffer.writeFloatLE(parseFloat(parameter.value));
-      yield buffer.data;
+      const buffer = Buffer.alloc(5);
+      let offset = 0;
+      offset = buffer.writeUInt8(4, offset);
+      buffer.writeFloatLE(parseFloat(parameter.value), offset);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 
-  validate: function(value): null| number |TypeError {
+  validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;
     }

--- a/src/data-types/smalldatetime.ts
+++ b/src/data-types/smalldatetime.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import DateTimeN from './datetimen';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const EPOCH_DATE = new Date(1900, 0, 1);
 const UTC_EPOCH_DATE = new Date(Date.UTC(1900, 0, 1));
@@ -14,19 +13,14 @@ const SmallDateTime: DataType = {
     return 'smalldatetime';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(DateTimeN.id);
-    buffer.writeUInt8(4);
+  generateTypeInfo() {
+    return Buffer.from([DateTimeN.id, 0x04]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(8);
+      const buffer = Buffer.alloc(5);
+
       let days, dstDiff, minutes;
       if (options.useUTC) {
         days = Math.floor((parameter.value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
@@ -37,19 +31,17 @@ const SmallDateTime: DataType = {
         minutes = (parameter.value.getHours() * 60) + parameter.value.getMinutes();
       }
 
-      buffer.writeUInt8(4);
-      buffer.writeUInt16LE(days);
+      buffer.writeUInt8(4, 0);
+      buffer.writeUInt16LE(days, 1);
+      buffer.writeUInt16LE(minutes, 3);
 
-      buffer.writeUInt16LE(minutes);
-      yield buffer.data;
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 
-  validate: function(value): null | Date| TypeError {
+  validate: function(value): null | Date | TypeError {
     if (value == null) {
       return null;
     }

--- a/src/data-types/smallint.ts
+++ b/src/data-types/smallint.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import IntN from './intn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const SmallInt: DataType = {
   id: 0x34,
@@ -11,26 +10,18 @@ const SmallInt: DataType = {
     return 'smallint';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(IntN.id);
-    buffer.writeUInt8(2);
+  generateTypeInfo() {
+    return Buffer.from([IntN.id, 0x02]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(3);
-      buffer.writeUInt8(2);
-      buffer.writeInt16LE(Number(parameter.value));
-      yield buffer.data;
+      const buffer = Buffer.alloc(3);
+      buffer.writeUInt8(2, 0);
+      buffer.writeInt16LE(Number(parameter.value), 1);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(3);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/smallmoney.ts
+++ b/src/data-types/smallmoney.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import MoneyN from './moneyn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const SmallMoney: DataType = {
   id: 0x7A,
@@ -11,26 +10,18 @@ const SmallMoney: DataType = {
     return 'smallmoney';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(MoneyN.id);
-    buffer.writeUInt8(4);
+  generateTypeInfo: function() {
+    return Buffer.from([MoneyN.id, 0x04]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(5);
-      buffer.writeUInt8(4);
-      buffer.writeInt32LE(parameter.value * 10000);
-      yield buffer.data;
+      const buffer = Buffer.alloc(5);
+      buffer.writeUInt8(4, 0);
+      buffer.writeInt32LE(parameter.value * 10000, 1);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/sql-variant.ts
+++ b/src/data-types/sql-variant.ts
@@ -9,15 +9,11 @@ const Variant: DataType = {
     return 'sql_variant';
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/text.ts
+++ b/src/data-types/text.ts
@@ -1,5 +1,4 @@
 import { DataType } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const Text: DataType = {
   id: 0x23,
@@ -22,26 +21,26 @@ const Text: DataType = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
-    buffer.writeInt32LE(parameter.length);
+  generateTypeInfo(parameter, _options) {
+    const buffer = Buffer.alloc(5);
+    buffer.writeUInt8(this.id, 0);
+    buffer.writeInt32LE(parameter.length!, 1);
+    return buffer;
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
+  generateParameterData: function*(parameter, options) {
+    yield Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]);
 
-  generate: function*(parameter, options) {
-    const buffer = new WritableTrackingBuffer(0);
-    buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]));
     if (parameter.value != null) {
-      buffer.writeInt32LE(parameter.length!);
-      buffer.writeString(parameter.value.toString(), 'ascii');
-      yield buffer.data;
+      const buffer = Buffer.alloc(4);
+      buffer.writeInt32LE(parameter.length!, 0);
+      yield buffer;
+
+      yield Buffer.from(parameter.value.toString(), 'ascii');
     } else {
-      buffer.writeInt32LE(parameter.length!);
-      yield buffer.data;
+      const buffer = Buffer.alloc(4);
+      buffer.writeInt32LE(parameter.length!, 0);
+      yield buffer;
     }
   },
 

--- a/src/data-types/time.ts
+++ b/src/data-types/time.ts
@@ -20,17 +20,11 @@ const Time: DataType = {
     }
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt8(parameter.scale!);
+  generateTypeInfo(parameter) {
+    return Buffer.from([this.id, parameter.scale!]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter, options) {
     if (parameter.value != null) {
       const buffer = new WritableTrackingBuffer(16);
       const time = parameter.value;
@@ -67,9 +61,7 @@ const Time: DataType = {
 
       yield buffer.data;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/tinyint.ts
+++ b/src/data-types/tinyint.ts
@@ -1,6 +1,5 @@
 import { DataType } from '../data-type';
 import IntN from './intn';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const TinyInt: DataType = {
   id: 0x30,
@@ -11,28 +10,20 @@ const TinyInt: DataType = {
     return 'tinyint';
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(IntN.id);
-    buffer.writeUInt8(1);
+  generateTypeInfo() {
+    return Buffer.from([IntN.id, 0x01]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter, options) {
     if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt8(1);
-      buffer.writeUInt8(Number(parameter.value));
-      yield buffer.data;
+      const buffer = Buffer.alloc(2);
+      let offset = 0;
+      offset = buffer.writeUInt8(1, offset);
+      buffer.writeUInt8(Number(parameter.value), offset);
+      yield buffer;
     } else {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
-
   },
 
   validate: function(value): number | null | TypeError {

--- a/src/data-types/tvp.ts
+++ b/src/data-types/tvp.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
+const TVP_ROW_TOKEN = Buffer.from([0x01]);
+const TVP_END_TOKEN = Buffer.from([0x00]);
+
 const TVP: DataType = {
   id: 0xF3,
   type: 'TVPTYPE',
@@ -11,68 +14,81 @@ const TVP: DataType = {
     return value.name + ' readonly';
   },
 
-  writeTypeInfo: function(buffer, parameter) {
-    let ref, ref1, ref2, ref3;
+  generateTypeInfo(parameter) {
+    const databaseName = '';
+    const schema = parameter.value?.schema ?? '';
+    const typeName = parameter.value?.name ?? '';
+
+    const bufferLength = 1 +
+      1 + Buffer.byteLength(databaseName, 'ucs2') +
+      1 + Buffer.byteLength(schema, 'ucs2') +
+      1 + Buffer.byteLength(typeName, 'ucs2');
+
+    const buffer = new WritableTrackingBuffer(bufferLength, 'ucs2');
     buffer.writeUInt8(this.id);
-    buffer.writeBVarchar('');
-    buffer.writeBVarchar((ref = (ref1 = parameter.value) != null ? ref1.schema : undefined) != null ? ref : '');
-    buffer.writeBVarchar((ref2 = (ref3 = parameter.value) != null ? ref3.name : undefined) != null ? ref2 : '');
+    buffer.writeBVarchar(databaseName);
+    buffer.writeBVarchar(schema);
+    buffer.writeBVarchar(typeName);
+
+    return buffer.data;
   },
 
-  writeParameterData: function(buffer, parameter, options, cb) {
-    const it = this.generate(parameter, options);
-    const buffers: Buffer[] = [];
-    const next = () => {
-      const result = it.next();
-      if (result.done) {
-        buffer.writeBuffer(Buffer.concat(buffers));
-        return cb();
-      }
-      buffers.push(result.value);
-      setImmediate(next);
-    };
-    next();
-  },
-
-  generate: function*(parameter, options) {
+  *generateParameterData(parameter, options) {
     if (parameter.value == null) {
-      const buffer = new WritableTrackingBuffer(4);
-      buffer.writeUInt16LE(0xFFFF);
-      buffer.writeUInt8(0x00);
-      buffer.writeUInt8(0x00);
-      yield buffer.data;
+      const buffer = Buffer.alloc(4);
+      buffer.writeUInt16LE(0xFFFF, 0);
+      buffer.writeUInt8(0x00, 2);
+      buffer.writeUInt8(0x00, 3);
+      yield buffer;
       return;
     }
+
     const { columns, rows } = parameter.value;
-    let buffer = new WritableTrackingBuffer(200);
-    buffer.writeUInt16LE(columns.length);
+    const buffer = Buffer.alloc(2);
+    buffer.writeUInt16LE(columns.length, 0);
+    yield buffer;
+
     for (let i = 0, len = columns.length; i < len; i++) {
       const column = columns[i];
-      buffer.writeUInt32LE(0x00000000);
-      buffer.writeUInt16LE(0x0000);
-      column.type.writeTypeInfo(buffer, column);
-      buffer.writeBVarchar('');
+
+      const buff = Buffer.alloc(6);
+      // UserType
+      buff.writeUInt32LE(0x00000000, 0);
+
+      // Flags
+      buff.writeUInt16LE(0x0000, 4);
+      yield buff;
+
+      // TYPE_INFO
+      yield column.type.generateTypeInfo(column);
+
+      // ColName
+      yield Buffer.from([0x00]);
     }
-    buffer.writeUInt8(0x00);
+
+    yield TVP_END_TOKEN;
+
     for (let i = 0, length = rows.length; i < length; i++) {
+      yield TVP_ROW_TOKEN;
+
       const row = rows[i];
-      buffer.writeUInt8(0x01);
       for (let k = 0, len2 = row.length; k < len2; k++) {
         const column = columns[k];
         const value = row[k];
+
         const param = {
           value: value,
           length: column.length,
           scale: column.scale,
           precision: column.precision
         };
-        buffer.writeBuffer(Buffer.concat(Array.from(column.type.generate(param, options))));
+
+        // TvpColumnData
+        yield * column.type.generateParameterData(param, options);
       }
-      yield buffer.data;
-      buffer = new WritableTrackingBuffer(1);
     }
-    buffer.writeUInt8(0x00);
-    yield buffer.data;
+
+    yield TVP_END_TOKEN;
   },
 
   validate: function(value): Buffer | null | TypeError {

--- a/src/data-types/udt.ts
+++ b/src/data-types/udt.ts
@@ -9,15 +9,11 @@ const UDT: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/uniqueidentifier.ts
+++ b/src/data-types/uniqueidentifier.ts
@@ -15,26 +15,18 @@ const UniqueIdentifier: DataType = {
     return 16;
   },
 
-  writeTypeInfo: function(buffer) {
-    buffer.writeUInt8(this.id);
-    buffer.writeUInt8(0x10);
+  generateTypeInfo() {
+    return Buffer.from([this.id, 0x10]);
   },
 
-  writeParameterData: function(buff, parameter, options, cb) {
-    buff.writeBuffer(Buffer.concat(Array.from(this.generate(parameter, options))));
-    cb();
-  },
-
-  generate: function*(parameter, options) {
+  generateParameterData: function*(parameter, options) {
     if (parameter.value != null) {
       const buffer = new WritableTrackingBuffer(1);
       buffer.writeUInt8(0x10);
       buffer.writeBuffer(Buffer.from(guidToArray(parameter.value)));
       yield buffer.data;
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      yield Buffer.from([0x00]);
     }
   },
 

--- a/src/data-types/xml.ts
+++ b/src/data-types/xml.ts
@@ -9,15 +9,11 @@ const XML: DataType = {
     throw new Error('not implemented');
   },
 
-  writeTypeInfo() {
+  generateTypeInfo() {
     throw new Error('not implemented');
   },
 
-  writeParameterData() {
-    throw new Error('not implemented');
-  },
-
-  generate() {
+  generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -52,10 +52,9 @@ class RpcRequestPayload implements Iterable<Buffer> {
 
     const optionFlags = 0;
     buffer.writeUInt16LE(optionFlags);
-
-    const parameters = this.request.parameters;
     yield buffer.data;
 
+    const parameters = this.request.parameters;
     for (let i = 0; i < parameters.length; i++) {
       yield* this.generateParameterData(parameters[i], this.options);
     }
@@ -74,6 +73,8 @@ class RpcRequestPayload implements Iterable<Buffer> {
       statusFlags |= STATUS.BY_REF_VALUE;
     }
     buffer.writeUInt8(statusFlags);
+
+    yield buffer.data;
 
     const param: ParameterData = { value: parameter.value };
 
@@ -99,10 +100,8 @@ class RpcRequestPayload implements Iterable<Buffer> {
       param.scale = type.resolveScale(parameter);
     }
 
-    type.writeTypeInfo(buffer, param, this.options);
-
-    yield buffer.data;
-    yield* type.generate(param, options);
+    yield type.generateTypeInfo(param, this.options);
+    yield* type.generateParameterData(param, options);
   }
 }
 

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -3,7 +3,6 @@ import { writeToTrackingBuffer } from './all-headers';
 import Request from './request';
 import { Parameter, ParameterData } from './data-type';
 import { InternalConnectionOptions } from './connection';
-import { Readable } from 'readable-stream';
 
 // const OPTION = {
 //   WITH_RECOMPILE: 0x01,
@@ -19,7 +18,7 @@ const STATUS = {
 /*
   s2.2.6.5
  */
-class RpcRequestPayload {
+class RpcRequestPayload implements Iterable<Buffer> {
   request: Request;
   procedure: string | number;
 
@@ -33,8 +32,8 @@ class RpcRequestPayload {
     this.txnDescriptor = txnDescriptor;
   }
 
-  getStream() {
-    return Readable.from(this.generateData(), { objectMode: false }) as Readable;
+  [Symbol.iterator]() {
+    return this.generateData();
   }
 
   * generateData() {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,6 +1,5 @@
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import { writeToTrackingBuffer } from './all-headers';
-import { Readable } from 'readable-stream';
 
 /*
   s2.2.6.8
@@ -51,13 +50,8 @@ export class Transaction {
     buffer.writeString(this.name, 'ucs2');
 
     return {
-      getStream: () => {
-        return new Readable({
-          read() {
-            this.push(buffer.data);
-            this.push(null);
-          }
-        });
+      *[Symbol.iterator]() {
+        yield buffer.data;
       },
       toString: () => {
         return 'Begin Transaction: name=' + this.name + ', isolationLevel=' + isolationLevelByValue[this.isolationLevel];
@@ -75,13 +69,8 @@ export class Transaction {
     buffer.writeUInt8(0);
 
     return {
-      getStream: () => {
-        return new Readable({
-          read() {
-            this.push(buffer.data);
-            this.push(null);
-          }
-        });
+      *[Symbol.iterator]() {
+        yield buffer.data;
       },
       toString: () => {
         return 'Commit Transaction: name=' + this.name;
@@ -99,13 +88,8 @@ export class Transaction {
     buffer.writeUInt8(0);
 
     return {
-      getStream: () => {
-        return new Readable({
-          read() {
-            this.push(buffer.data);
-            this.push(null);
-          }
-        });
+      *[Symbol.iterator]() {
+        yield buffer.data;
       },
       toString: () => {
         return 'Rollback Transaction: name=' + this.name;
@@ -121,13 +105,8 @@ export class Transaction {
     buffer.writeString(this.name, 'ucs2');
 
     return {
-      getStream: () => {
-        return new Readable({
-          read() {
-            this.push(buffer.data);
-            this.push(null);
-          }
-        });
+      *[Symbol.iterator]() {
+        yield buffer.data;
       },
       toString: () => {
         return 'Save Transaction: name=' + this.name;

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -1,1246 +1,1108 @@
-const TYPES = require('../../src/data-type');
-const WritableTrackingBuffer = require('../../src/tracking-buffer/writable-tracking-buffer');
-const assert = require('chai').assert;
+const TYPES = require('../../src/data-type').typeByName;
 
-describe('Data Types', function() {
-  // Test date calculation for non utc date during daylight savings period
-  it('smallDateTimeDaylightSaving', () => {
-    const type = TYPES.typeByName.SmallDateTime;
-    for (const testSet of [
-      [new Date(2015, 5, 18, 23, 59, 59), 42171],
-      [new Date(2015, 5, 19, 0, 0, 0), 42172],
-      [new Date(2015, 5, 19, 23, 59, 59), 42172],
-      [new Date(2015, 5, 20, 0, 0, 0), 42173]
-    ]) {
-      const buffer = new WritableTrackingBuffer(0);
-      const parameter = { value: testSet[0] };
-      const expectedNoOfDays = testSet[1];
-      type.writeParameterData(buffer, parameter, { useUTC: false }, () => { });
-      assert.strictEqual(buffer.buffer.readUInt16LE(1), expectedNoOfDays);
-    }
-  });
+const { assert } = require('chai');
 
-  it('should writeTypeInfo DateTime', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.DateTime;
-    const expected = Buffer.from([0x6F, 8]);
+describe('BigInt', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 123456789;
+      const expected = Buffer.from('0815cd5b0700000000', 'hex');
 
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
+      const parameterValue = { value, length: 4 };
+      const buffer = Buffer.concat([...TYPES.BigInt.generateParameterData(parameterValue, { useUTC: false })]);
 
-  it('dateTimeDaylightSaving', () => {
-    const type = TYPES.typeByName.DateTime;
-    for (const testSet of [
-      [new Date(2015, 5, 18, 23, 59, 59), 42171],
-      [new Date(2015, 5, 19, 0, 0, 0), 42172],
-      [new Date(2015, 5, 19, 23, 59, 59), 42172],
-      [new Date(2015, 5, 20, 0, 0, 0), 42173]
-    ]) {
-      const buffer = new WritableTrackingBuffer(0);
-      const parameter = { value: testSet[0] };
-      const expectedNoOfDays = testSet[1];
-      type.writeParameterData(buffer, parameter, { useUTC: false }, () => { });
-      assert.strictEqual(buffer.data.readInt32LE(1), expectedNoOfDays);
-    }
-  });
+      assert.deepEqual(buffer, expected);
+    });
 
-  it('should writeTypeInfo DateTime2', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.DateTime2;
-    const expected = Buffer.from([0x2A, 1]);
+    it('correctly converts `string` values', function() {
+      const value = '123456789';
+      const expected = Buffer.from('0815cd5b0700000000', 'hex');
 
-    type.writeTypeInfo(buffer, { scale: 1 });
-    assert.deepEqual(buffer.data, expected);
-  });
+      const parameterValue = { value, length: 4 };
+      const buffer = Buffer.concat([...TYPES.BigInt.generateParameterData(parameterValue, { useUTC: false })]);
 
-  it('dateTime2DaylightSaving', () => {
-    const type = TYPES.typeByName.DateTime2;
-    for (const [value, expectedBuffer] of [
-      [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('067f5101163a0b', 'hex')],
-      [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('06000000173a0b', 'hex')],
-      [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('067f5101173a0b', 'hex')],
-      [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('06000000183a0b', 'hex')]
-    ]) {
-      const buffer = new WritableTrackingBuffer(0);
-      type.writeParameterData(buffer, { value: value, scale: 0 }, { useUTC: false }, () => { });
-      assert.deepEqual(buffer.data, expectedBuffer);
-    }
-  });
+      assert.deepEqual(buffer, expected);
+    });
 
-  it('should writeTypeInfo Date', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Date;
-    const expected = Buffer.from([0x28]);
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from([0x00]);
 
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
+      const parameterValue = { value, length: 4 };
 
-  it('dateDaylightSaving', () => {
-    const type = TYPES.typeByName.Date;
-    for (const [value, expectedBuffer] of [
-      [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('03163a0b', 'hex')],
-      [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('03173a0b', 'hex')],
-      [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('03173a0b', 'hex')],
-      [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('03183a0b', 'hex')]
-    ]) {
-      const buffer = new WritableTrackingBuffer(0);
-      type.writeParameterData(buffer, { value: value }, { useUTC: false }, () => { });
-      assert.deepEqual(buffer.data, expectedBuffer);
-    }
-  });
+      const buffer = Buffer.concat([...TYPES.BigInt.generateParameterData(parameterValue, { useUTC: false })]);
 
-  it('should writeTypeInfo Time', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Time;
-    const expected = Buffer.from([0x29, 1]);
-
-    type.writeTypeInfo(buffer, { scale: 1 });
-    assert.deepEqual(buffer.data, expected);
-  });
-
-
-  // Test rounding of nanosecondDelta
-  it('nanoSecondRounding', () => {
-    const type = TYPES.typeByName.Time;
-    for (const [value, nanosecondDelta, scale, expectedBuffer] of [
-      [new Date(2017, 6, 29, 17, 20, 3, 503), 0.0006264, 7, Buffer.from('0568fc624b91', 'hex')],
-      [new Date(2017, 9, 1, 1, 31, 4, 12), 0.0004612, 7, Buffer.from('05c422ceb80c', 'hex')],
-      [new Date(2017, 7, 3, 12, 52, 28, 373), 0.0007118, 7, Buffer.from('051e94c8e96b', 'hex')]
-    ]) {
-      const parameter = { value: value, scale: scale };
-      parameter.value.nanosecondDelta = nanosecondDelta;
-
-      const buffer = new WritableTrackingBuffer(0);
-      type.writeParameterData(buffer, parameter, { useUTC: false }, () => { });
-      assert.deepEqual(buffer.data, expectedBuffer);
-    }
-  });
-
-  it('should writeTypeInfo BigInt', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.BigInt;
-
-    const expected = Buffer.from([0x26, 8]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData BigInt (Buffer)', function(done) {
-    const value = 123456789;
-    const expected = Buffer.from('0815cd5b0700000000', 'hex');
-
-    const type = TYPES.typeByName.BigInt;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 4 };
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-
-      done();
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData BigInt (null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0x26, 8]);
 
-    const type = TYPES.typeByName.BigInt;
+      const result = TYPES.BigInt.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 4 };
+describe('Binary', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Buffer` values', function() {
+      const value = Buffer.from([0x12, 0x34, 0x00, 0x00]);
+      const expected = Buffer.from('040012340000', 'hex');
+      const parameterValue = { value, length: 4 };
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
+      const buffer = Buffer.concat([...TYPES.Binary.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
 
-      done();
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('ffff', 'hex');
+      const parameterValue = { value, length: 4 };
+
+      const buffer = Buffer.concat([...TYPES.Binary.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeTypeInfo Binary', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Binary;
-    const parameter = { length: 1 };
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Binary;
+      const parameter = { length: 1 };
 
-    const expected = Buffer.from([0xAD, 1, 0]);
+      const expected = Buffer.from([0xAD, 1, 0]);
 
-    type.writeTypeInfo(buffer, parameter);
-    assert.deepEqual(buffer.data, expected);
+      const result = type.generateTypeInfo(parameter);
+      assert.deepEqual(result, expected);
+    });
   });
+});
 
-  it('should writeParameterData Binary (Buffer)', function(done) {
-    const value = Buffer.from([0x12, 0x34, 0x00, 0x00]);
-    const expected = Buffer.from('040012340000', 'hex');
+describe('Bit', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 1;
+      const expected = Buffer.from('0101', 'hex');
+      const parameterValue = { value };
 
-    const type = TYPES.typeByName.Binary;
+      const buffer = Buffer.concat([...TYPES.Bit.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 4 };
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+      const parameterValue = { value };
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
+      const buffer = Buffer.concat([...TYPES.Bit.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
 
-      done();
+    it('correctly converts `undefined` values', function() {
+      const value = undefined;
+      const expected = Buffer.from('00', 'hex');
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...TYPES.Bit.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData binary (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('ffff', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0x68, 1]);
 
-    const type = TYPES.typeByName.Binary;
+      const result = TYPES.Bit.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 4 };
+describe('Char', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Buffer` values', function() {
+      const value = Buffer.from([0xff, 0xff, 0xff, 0xff]);
+      const expected = Buffer.from('0400ffffffff', 'hex');
+      const parameterValue = { value };
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
+      const buffer = Buffer.concat([...TYPES.Char.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
 
-      done();
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('ffff', 'hex');
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...TYPES.Char.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeTypeInfo Bit', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Bit;
-    const expected = Buffer.from([0x68, 1]);
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0xAF, 1, 0, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
+      const result = TYPES.Char.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
+    });
   });
+});
 
-  it('should writeParameterData Bit (Buffer)', function(done) {
-    const value = 1;
-    const expected = Buffer.from('0101', 'hex');
-
-    const type = TYPES.typeByName.Bit;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+describe('Date', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts dates during daylight savings period', function() {
+      for (const [value, expectedBuffer] of [
+        [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('03163a0b', 'hex')],
+        [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('03173a0b', 'hex')],
+        [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('03173a0b', 'hex')],
+        [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('03183a0b', 'hex')]
+      ]) {
+        const buffer = Buffer.concat([...TYPES.Date.generateParameterData({ value: value }, { useUTC: false })]);
+        assert.deepEqual(buffer, expectedBuffer);
+      }
     });
   });
 
-  it('should writeParameterData Bit (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Date;
+      const expected = Buffer.from([0x28]);
 
-    const type = TYPES.typeByName.Bit;
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+describe('DateTime', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts dates during daylight savings period', function() {
+      for (const testSet of [
+        [new Date(2015, 5, 18, 23, 59, 59), 42171],
+        [new Date(2015, 5, 19, 0, 0, 0), 42172],
+        [new Date(2015, 5, 19, 23, 59, 59), 42172],
+        [new Date(2015, 5, 20, 0, 0, 0), 42173]
+      ]) {
+        const parameter = { value: testSet[0] };
+        const expectedNoOfDays = testSet[1];
+        const buffer = Buffer.concat([...TYPES.DateTime.generateParameterData(parameter, { useUTC: false })]);
+        assert.strictEqual(buffer.readInt32LE(1), expectedNoOfDays);
+      }
     });
   });
 
-  it('should writeParameterData Bit (Undefined)', function(done) {
-    const value = undefined;
-    const expected = Buffer.from('00', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.DateTime;
+      const expected = Buffer.from([0x6F, 8]);
 
-    const type = TYPES.typeByName.Bit;
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+describe('DateTime2', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts dates during daylight savings period', () => {
+      for (const [value, expectedBuffer] of [
+        [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('067f5101163a0b', 'hex')],
+        [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('06000000173a0b', 'hex')],
+        [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('067f5101173a0b', 'hex')],
+        [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('06000000183a0b', 'hex')]
+      ]) {
+        const buffer = Buffer.concat([...TYPES.DateTime2.generateParameterData({ value: value, scale: 0 }, { useUTC: false })]);
+        assert.deepEqual(buffer, expectedBuffer);
+      }
     });
   });
 
-  it('should writeTypeInfo Char', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Char;
-    const expected = Buffer.from([0xAF, 1, 0, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0x2A, 1]);
 
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
+      const buffer = TYPES.DateTime2.generateTypeInfo({ scale: 1 });
+      assert.deepEqual(buffer, expected);
+    });
   });
+});
 
-  it('should writeParameterData Char (Buffer)', function(done) {
-    const value = Buffer.from([0xff, 0xff, 0xff, 0xff]);
-    const expected = Buffer.from('0400ffffffff', 'hex');
+describe('DateTimeOffset', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Date` values', function() {
+      const value = new Date(Date.UTC(2014, 1, 14, 17, 59, 59, 999));
+      const expected = Buffer.from('0820fd002d380b', 'hex');
+      const parameterValue = { value, scale: 0 };
 
-    const type = TYPES.typeByName.Char;
+      const buffer = Buffer.concat([...TYPES.DateTimeOffset.generateParameterData(parameterValue, { useUTC: true })]);
+      assert.deepEqual(buffer.slice(0, 7), expected);
+    });
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const parameterValue = { value, scale: 0 };
+      const buffer = Buffer.concat([...TYPES.DateTimeOffset.generateParameterData(parameterValue, { useUTC: true })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData Char (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('ffff', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0x2B, 1]);
 
-    const type = TYPES.typeByName.Char;
+      const buffer = TYPES.DateTimeOffset.generateTypeInfo({ scale: 1 });
+      assert.deepEqual(buffer, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
+describe('Decimal', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values (Precision <= 9)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('050101000000', 'hex');
+      const precision = 1;
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const type = TYPES.Decimal;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `number` values (Precision <= 19)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('09010100000000000000', 'hex');
+      const precision = 15;
+
+      const type = TYPES.Decimal;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `number` values (Precision <= 28)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('0d01010000000000000000000000', 'hex');
+      const precision = 25;
+
+      const type = TYPES.Decimal;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+
+    it('correctly converts `number` values (Precision > 28)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('110101000000000000000000000000000000', 'hex');
+      const precision = 30;
+
+      const type = TYPES.Decimal;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeTypeInfo DateTimeOffset', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.DateTimeOffset;
-    const expected = Buffer.from([0x2B, 1]);
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Decimal;
 
-    type.writeTypeInfo(buffer, { scale: 1 });
-    assert.deepEqual(buffer.data, expected);
+      // Precision <= 9
+      const expected1 = Buffer.from([0x6A, 5, 1, 1]);
+      const result = type.generateTypeInfo({ precision: 1, scale: 1 });
+      assert.deepEqual(result, expected1);
+
+      // Precision <= 19
+      const expected2 = Buffer.from([0x6A, 9, 15, 1]);
+      const result2 = type.generateTypeInfo({ precision: 15, scale: 1 });
+      assert.deepEqual(result2, expected2);
+
+
+      // Precision <= 28
+      const expected3 = Buffer.from([0x6A, 13, 20, 1]);
+      const result3 = type.generateTypeInfo({ precision: 20, scale: 1 });
+      assert.deepEqual(result3, expected3);
+
+      // Precision > 28
+      const expected4 = Buffer.from([0x6A, 17, 30, 1]);
+      const result4 = type.generateTypeInfo({ precision: 30, scale: 1 });
+      assert.deepEqual(result4, expected4);
+    });
+  });
+});
+
+describe('Float', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 1.2345;
+      const expected = Buffer.from('088d976e1283c0f33f', 'hex');
+
+      const type = TYPES.Float;
+      const parameterValue = { value, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.Float;
+      const parameterValue = { value, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
   });
 
-  it('should writeParameterData DateTimeOffSet (Buffer)', function(done) {
-    const value = new Date(Date.UTC(2014, 1, 14, 17, 59, 59, 999));
-    const expected = Buffer.from('0820fd002d380b', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Float;
+      const expected = Buffer.from([0x6D, 8]);
 
-    const type = TYPES.typeByName.DateTimeOffset;
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, scale: 0 };
+describe('Image', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Buffer` values', function() {
+      const value = Buffer.from('010101', 'hex');
+      const expected = Buffer.from('64000000010101', 'hex');
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: true }, () => {
-      assert.deepEqual(buffer.data.slice(0, 7), expected);
-      done();
+      const type = TYPES.Image;
+      const parameterValue = { value, length: 100 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('64000000', 'hex');
+
+      const type = TYPES.Image;
+      const parameterValue = { value, length: 100 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData DateTimeOffSet (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Image;
+      const expected = Buffer.from([0x22, 1, 0, 0, 0]);
 
-    const type = TYPES.typeByName.DateTimeOffset;
+      const result = type.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, scale: 0 };
+describe('Int', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 1234;
+      const expected = Buffer.from('04d2040000', 'hex');
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: true }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const type = TYPES.Int;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.Int;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeTypeInfo Decimal ', function() {
-    const type = TYPES.typeByName.Decimal;
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Int;
+      const expected = Buffer.from([0x26, 4]);
 
-    // Precision <= 9
-    const buffer1 = new WritableTrackingBuffer(4);
-    const expected1 = Buffer.from([0x6A, 5, 1, 1]);
-    type.writeTypeInfo(buffer1, { precision: 1, scale: 1 });
-    assert.deepEqual(buffer1.data, expected1);
-
-    // Precision <= 19
-    const buffer2 = new WritableTrackingBuffer(4);
-    const expected2 = Buffer.from([0x6A, 9, 15, 1]);
-    type.writeTypeInfo(buffer2, { precision: 15, scale: 1 });
-    assert.deepEqual(buffer2.data, expected2);
-
-
-    // Precision <= 28
-    const buffer3 = new WritableTrackingBuffer(4);
-    const expected3 = Buffer.from([0x6A, 13, 20, 1]);
-    type.writeTypeInfo(buffer3, { precision: 20, scale: 1 });
-    assert.deepEqual(buffer3.data, expected3);
-
-    // Precision > 28
-    const buffer4 = new WritableTrackingBuffer(4);
-    const expected4 = Buffer.from([0x6A, 17, 30, 1]);
-    type.writeTypeInfo(buffer4, { precision: 30, scale: 1 });
-    assert.deepEqual(buffer4.data, expected4);
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
   });
+});
 
-  it('should writeParameterData Decimal (Precision <= 9)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('050101000000', 'hex');
-    const precision = 1;
+describe('Money', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 1234;
+      const expected = Buffer.from('0800000000204bbc00', 'hex');
 
-    const type = TYPES.typeByName.Decimal;
+      const type = TYPES.Money;
+      const parameterValue = { value };
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.Money;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData Decimal (Precision <= 19)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('09010100000000000000', 'hex');
-    const precision = 15;
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Money;
+      const expected = Buffer.from([0x6E, 8]);
 
-    const type = TYPES.typeByName.Decimal;
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
+describe('NChar', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Buffer` values', function() {
+      const value = Buffer.from([0xff, 0xff, 0xff, 0xff]);
+      const expected = Buffer.from('0400ffffffff', 'hex');
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const type = TYPES.NChar;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('ffff', 'hex');
+
+      const type = TYPES.NChar;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData Decimal (Precision <= 28)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('0d01010000000000000000000000', 'hex');
-    const precision = 25;
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.NChar;
+      const expected = Buffer.from([0xEF, 2, 0, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-    const type = TYPES.typeByName.Decimal;
+      const result = type.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
+    });
+  });
+});
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
+describe('Numeric', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values (Precision <= 9)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('050101000000', 'hex');
+      const precision = 1;
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const type = TYPES.Numeric;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `number` values (Precision <= 19)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('09010100000000000000', 'hex');
+      const precision = 15;
+
+      const type = TYPES.Numeric;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `number` values (Precision <= 28)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('0d01010000000000000000000000', 'hex');
+      const precision = 25;
+
+      const type = TYPES.Numeric;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `number` values (Precision > 28)', function() {
+      const value = 1.23;
+      const expected = Buffer.from('110101000000000000000000000000000000', 'hex');
+      const precision = 30;
+
+      const type = TYPES.Numeric;
+      const parameterValue = { value, precision, scale: 0 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Numeric;
 
-  it('should writeParameterData Decimal (Precision > 28)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('110101000000000000000000000000000000', 'hex');
-    const precision = 30;
+      // Precision <= 9
+      const expected1 = Buffer.from([0x6C, 5, 1, 1]);
+      const result = type.generateTypeInfo({ precision: 1, scale: 1 });
+      assert.deepEqual(result, expected1);
 
-    const type = TYPES.typeByName.Decimal;
+      // Precision <= 19
+      const expected2 = Buffer.from([0x6C, 9, 15, 1]);
+      const result2 = type.generateTypeInfo({ precision: 15, scale: 1 });
+      assert.deepEqual(result2, expected2);
 
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
+      // Precision <= 28
+      const expected3 = Buffer.from([0x6C, 13, 20, 1]);
+      const result3 = type.generateTypeInfo({ precision: 20, scale: 1 });
+      assert.deepEqual(result3, expected3);
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      // Precision > 28
+      const expected4 = Buffer.from([0x6C, 17, 30, 1]);
+      const result4 = type.generateTypeInfo({ precision: 30, scale: 1 });
+      assert.deepEqual(result4, expected4);
     });
   });
-
-
-  it('should writeTypeInfo Float', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Float;
-    const expected = Buffer.from([0x6D, 8]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData Float (Buffer)', function(done) {
-    const value = 1.2345;
-    const expected = Buffer.from('088d976e1283c0f33f', 'hex');
-
-    const type = TYPES.typeByName.Float;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, scale: 0 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Float (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.Float;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, scale: 0 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo Image', function() {
-    const buffer = new WritableTrackingBuffer(5);
-    const type = TYPES.typeByName.Image;
-    const expected = Buffer.from([0x22, 1, 0, 0, 0]);
-
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData Image (Buffer)', function(done) {
-    const value = Buffer.from('010101', 'hex');
-    const expected = Buffer.from('64000000010101', 'hex');
-
-    const type = TYPES.typeByName.Image;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 100 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Image (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('64000000', 'hex');
-
-    const type = TYPES.typeByName.Image;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 100 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo Int', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Int;
-    const expected = Buffer.from([0x26, 4]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData Int (Buffer)', function(done) {
-    const value = 1234;
-    const expected = Buffer.from('04d2040000', 'hex');
-
-    const type = TYPES.typeByName.Int;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Int (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.Int;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo Money', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Money;
-    const expected = Buffer.from([0x6E, 8]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-
-  it('should writeParameterData Money (Buffer)', function(done) {
-    const value = 1234;
-    const expected = Buffer.from('0800000000204bbc00', 'hex');
-
-    const type = TYPES.typeByName.Money;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Money (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.Money;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo NChar', function() {
-    const buffer = new WritableTrackingBuffer(8);
-    const type = TYPES.typeByName.NChar;
-    const expected = Buffer.from([0xEF, 2, 0, 0x00, 0x00, 0x00, 0x00, 0x00]);
-
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData NChar (Buffer)', function(done) {
-    const value = Buffer.from([0xff, 0xff, 0xff, 0xff]);
-    const expected = Buffer.from('0400ffffffff', 'hex');
-
-    const type = TYPES.typeByName.NChar;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData NChar (Buffer)', function(done) {
-    const value = null;
-    const expected = Buffer.from('ffff', 'hex');
-
-    const type = TYPES.typeByName.NChar;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-
-  it('should writeTypeInfo Numeric', function() {
-    const type = TYPES.typeByName.Numeric;
-
-    // Precision <= 9
-    const buffer1 = new WritableTrackingBuffer(4);
-    const expected1 = Buffer.from([0x6C, 5, 1, 1]);
-    type.writeTypeInfo(buffer1, { precision: 1, scale: 1 });
-    assert.deepEqual(buffer1.data, expected1);
-
-    // Precision <= 19
-    const buffer2 = new WritableTrackingBuffer(4);
-    const expected2 = Buffer.from([0x6C, 9, 15, 1]);
-    type.writeTypeInfo(buffer2, { precision: 15, scale: 1 });
-    assert.deepEqual(buffer2.data, expected2);
-
-
-    // Precision <= 28
-    const buffer3 = new WritableTrackingBuffer(4);
-    const expected3 = Buffer.from([0x6C, 13, 20, 1]);
-    type.writeTypeInfo(buffer3, { precision: 20, scale: 1 });
-    assert.deepEqual(buffer3.data, expected3);
-
-    // Precision > 28
-    const buffer4 = new WritableTrackingBuffer(4);
-    const expected4 = Buffer.from([0x6C, 17, 30, 1]);
-    type.writeTypeInfo(buffer4, { precision: 30, scale: 1 });
-    assert.deepEqual(buffer4.data, expected4);
-  });
-
-  it('should writeParameterData Numeric (Precision <= 9)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('050101000000', 'hex');
-    const precision = 1;
-
-    const type = TYPES.typeByName.Numeric;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Numeric (Precision <= 19)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('09010100000000000000', 'hex');
-    const precision = 15;
-
-    const type = TYPES.typeByName.Numeric;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Numeric (Precision <= 28)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('0d01010000000000000000000000', 'hex');
-    const precision = 25;
-
-    const type = TYPES.typeByName.Numeric;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Numeric (Precision > 28)', function(done) {
-    const value = 1.23;
-    const expected = Buffer.from('110101000000000000000000000000000000', 'hex');
-    const precision = 30;
-
-    const type = TYPES.typeByName.Numeric;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, precision, scale: 0 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-
-  it('should writeTypeInfo NVarChar', function() {
-    // Length <= Maximum Length
-    const buffer = new WritableTrackingBuffer(8);
-    const type = TYPES.typeByName.NVarChar;
-    const expected = Buffer.from([0xE7, 2, 0, 0x00, 0x00, 0x00, 0x00, 0x00]);
-
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
-
-    // Length > Maximum Length
-    const buffer1 = new WritableTrackingBuffer(8);
-    const expected1 = Buffer.from([0xE7, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00]);
-
-    type.writeTypeInfo(buffer1, { length: 4100 });
-    assert.deepEqual(buffer1.data, expected1);
-  });
-
-  it('should writeParameterData NVarChar (Buffer, Length <= Maximum Length )', function(done) {
-    const value = Buffer.from([0xff, 0xff]);
-    const expected = Buffer.from('0200ffff', 'hex');
-    const length = 1;
-
-    const type = TYPES.typeByName.NVarChar;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData NVarChar (Buffer, Length > Maximum Length )', function(done) {
-    const value = Buffer.from([0xff, 0xff]);
-    const expected = Buffer.from('feffffffffffffff02000000ffff00000000', 'hex');
-    const length = 4100;
-
-    const type = TYPES.typeByName.NVarChar;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData NVarChar (Null, Length <= Maximum Length )', function(done) {
-    const value = null;
-    const expected = Buffer.from('ffff', 'hex');
-    const length = 1;
-
-    const type = TYPES.typeByName.NVarChar;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData NVarChar (Null, Length > Maximum Length )', function(done) {
-    const value = null;
-    const expected = Buffer.from('ffffffffffffffff', 'hex');
-    const length = 5000;
-
-    const type = TYPES.typeByName.NVarChar;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo Real', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Real;
-    const expected = Buffer.from([0x6D, 4]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData Real (Buffer)', function(done) {
-    const value = 123.123;
-    const expected = Buffer.from('04fa3ef642', 'hex');
-
-    const type = TYPES.typeByName.Real;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Real (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.Real;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo SmallInt', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.SmallInt;
-    const expected = Buffer.from([0x26, 2]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData SmallInt (Buffer)', function(done) {
-    const value = 2;
-    const expected = Buffer.from('020200', 'hex');
-
-    const type = TYPES.typeByName.SmallInt;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData SmallInt (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.SmallInt;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo SmallMoney', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.SmallMoney;
-    const expected = Buffer.from([0x6E, 4]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData SmallMoney (Buffer)', function(done) {
-    const value = 2;
-    const expected = Buffer.from('04204e0000', 'hex');
-
-    const type = TYPES.typeByName.SmallMoney;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData SmallMoney (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.SmallMoney;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo Text', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.Text;
-    const expected = Buffer.from([0x23, 1, 0, 0, 0]);
-
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData Text (Buffer)', function(done) {
-    const value = Buffer.from('Hello World', 'ascii');
-    const expected = Buffer.from('00000000000f00000048656c6c6f20576f726c64', 'hex');
-
-    const type = TYPES.typeByName.Text;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 15 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData Text (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00000000000f000000', 'hex');
-
-    const type = TYPES.typeByName.Text;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length: 15 };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo TinyInt', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.TinyInt;
-    const expected = Buffer.from([0x26, 1]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-
-  it('should writeParameterData TinyInt (Buffer)', function(done) {
-    const value = 1;
-    const expected = Buffer.from('0101', 'hex');
-
-    const type = TYPES.typeByName.TinyInt;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData TinyInt (Null)', function(done) {
-    const value = null;
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.TinyInt;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo TVP', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.TVP;
-    const expected = Buffer.from([0xF3, 0x00, 0x00, 0x00]);
-
-    type.writeTypeInfo(buffer, { value: null });
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData TVP (Buffer)', function(done) {
-    const value = {
-      columns: [{ name: 'user_id', type: TYPES.typeByName.Int }],
-      rows: [[ 15 ]]
-    };
-    const expected = Buffer.from('01000000000000002604000001040f00000000', 'hex');
-
-    const type = TYPES.typeByName.TVP;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData TVP (Null)', function(done) {
-    const value = null;
-
-    const expected = Buffer.from('ffff0000', 'hex');
-
-    const type = TYPES.typeByName.TVP;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo UniqueIdentifier', function() {
-    const buffer = new WritableTrackingBuffer(2);
-    const type = TYPES.typeByName.UniqueIdentifier;
-    const expected = Buffer.from([0x24, 0x10]);
-
-    type.writeTypeInfo(buffer);
-    assert.deepEqual(buffer.data, expected);
-  });
-
-  it('should writeParameterData UniqueIdentifier (Buffer)', function(done) {
-    const value = 'e062ae34-6de5-47f3-8ba3-29d25f77e71a';
-
-    const expected = Buffer.from('1034ae62e0e56df3478ba329d25f77e71a', 'hex');
-
-    const type = TYPES.typeByName.UniqueIdentifier;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData UniqueIdentifier (Null)', function(done) {
-    const value = null;
-
-    const expected = Buffer.from('00', 'hex');
-
-    const type = TYPES.typeByName.UniqueIdentifier;
-
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo VarBinary', function() {
-    const type = TYPES.typeByName.VarBinary;
-
-    // Length <= Maximum Length
-    const buffer = new WritableTrackingBuffer(2);
-    const expected = Buffer.from([0xA5, 0x40, 0x1F]);
-
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
-
-    // Length > Maximum Length
-    const buffer1 = new WritableTrackingBuffer(2);
-    const expected1 = Buffer.from([0xA5, 0xFF, 0xFF]);
-
-    type.writeTypeInfo(buffer1, { length: 8500 });
-    assert.deepEqual(buffer1.data, expected1);
-  });
-
-  it('should writeParameterData varbinary', () => {
-    const type = TYPES.typeByName.VarBinary;
-    for (const [value, length, expected] of [
-      [1, 1, Buffer.from('02003100', 'hex')],
-      [null, 1, Buffer.from('ffff', 'hex')],
-      [null, 9000, Buffer.from('FFFFFFFFFFFFFFFF', 'hex')]
-    ]) {
-      const buffer = new WritableTrackingBuffer(0);
+});
+
+describe('NVarChar', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Buffer` values (Length <= Maximum Length)', function() {
+      const value = Buffer.from([0xff, 0xff]);
+      const expected = Buffer.from('0200ffff', 'hex');
+      const length = 1;
+
+      const type = TYPES.NVarChar;
       const parameterValue = { value, length };
-      type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => { });
-      assert.isTrue(buffer.data.equals(expected));
-    }
-  });
 
-  it('should writeParameterData VarBinary (Buffer, Length <= Maximum Length)', function(done) {
-    const value = 1;
-    const length = 1;
-    const expected = Buffer.from('02003100', 'hex');
-    const type = TYPES.typeByName.VarBinary;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+    it('correctly converts `Buffer` values (Length > Maximum Length)', function() {
+      const value = Buffer.from([0xff, 0xff]);
+      const expected = Buffer.from('feffffffffffffff02000000ffff00000000', 'hex');
+      const length = 4100;
+
+      const type = TYPES.NVarChar;
+      const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values (Length <= Maximum Length)', function() {
+      const value = null;
+      const expected = Buffer.from('ffff', 'hex');
+      const length = 1;
+
+      const type = TYPES.NVarChar;
+      const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values (Length > Maximum Length)', function() {
+      const value = null;
+      const expected = Buffer.from('ffffffffffffffff', 'hex');
+      const length = 5000;
+
+      const type = TYPES.NVarChar;
+      const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-
-  it('should writeParameterData VarBinary (Buffer, Length > Maximum Length)', function(done) {
-    const value = 1;
-    const length = 9000;
-    const expected = Buffer.from('feffffffffffffff02000000310000000000', 'hex');
-    const type = TYPES.typeByName.VarBinary;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData VarBinary (Null, Length <= Maximum Length)', function(done) {
-    const value = null;
-    const length = 1;
-    const expected = Buffer.from('ffff', 'hex');
-    const type = TYPES.typeByName.VarBinary;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeParameterData VarBinary (Null, Length > Maximum Length)', function(done) {
-    const value = null;
-    const length = 9000;
-    const expected = Buffer.from('FFFFFFFFFFFFFFFF', 'hex');
-    const type = TYPES.typeByName.VarBinary;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
-
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
-    });
-  });
-
-  it('should writeTypeInfo VarChar', function() {
-    const type = TYPES.typeByName.VarChar;
-
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
     // Length <= Maximum Length
-    const buffer = new WritableTrackingBuffer(2);
-    const expected = Buffer.from('a7401f0000000000', 'hex');
+      const type = TYPES.NVarChar;
+      const expected = Buffer.from([0xE7, 2, 0, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-    type.writeTypeInfo(buffer, { length: 1 });
-    assert.deepEqual(buffer.data, expected);
+      const result = type.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
 
-    // Length > Maximum Length
-    const buffer1 = new WritableTrackingBuffer(2);
-    const expected1 = Buffer.from('a7ffff0000000000', 'hex');
+      // Length > Maximum Length
+      const expected1 = Buffer.from([0xE7, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-    type.writeTypeInfo(buffer1, { length: 8500 });
-    assert.deepEqual(buffer1.data, expected1);
+      const result2 = type.generateTypeInfo({ length: 4100 });
+      assert.deepEqual(result2, expected1);
+    });
   });
+});
 
-  it('should writeParameterData VarChar (Buffer, Length <= Maximum Length)', function(done) {
-    const value = 'hello world';
-    const length = 1;
-    const expected = Buffer.from('0b0068656c6c6f20776f726c64', 'hex');
-    const type = TYPES.typeByName.VarChar;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
+describe('Real', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 123.123;
+      const expected = Buffer.from('04fa3ef642', 'hex');
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const type = TYPES.Real;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.Real;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData VarChar (Buffer, Length > Maximum Length)', function(done) {
-    const value = 'hello world';
-    const length = 9000;
-    const expected = Buffer.from('feffffffffffffff0b00000068656c6c6f20776f726c6400000000', 'hex');
-    const type = TYPES.typeByName.VarChar;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Real;
+      const expected = Buffer.from([0x6D, 4]);
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('SmallDateTime', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts dates during daylight savings period', function() {
+      for (const [value, expectedNoOfDays] of [
+        [new Date(2015, 5, 18, 23, 59, 59), 42171],
+        [new Date(2015, 5, 19, 0, 0, 0), 42172],
+        [new Date(2015, 5, 19, 23, 59, 59), 42172],
+        [new Date(2015, 5, 20, 0, 0, 0), 42173]
+      ]) {
+        const buffer = Buffer.concat([...TYPES.SmallDateTime.generateParameterData({ value }, { useUTC: false })]);
+
+        assert.strictEqual(buffer.readUInt16LE(1), expectedNoOfDays);
+      }
     });
   });
 
-  it('should writeParameterData VarChar (Null, Length <= Maximum Length)', function(done) {
-    const value = null;
-    const length = 1;
-    const expected = Buffer.from('ffff', 'hex');
-    const type = TYPES.typeByName.VarChar;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0x6F, 0x04]);
+      const result = TYPES.SmallDateTime.generateTypeInfo();
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('SmallInt', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 2;
+      const expected = Buffer.from('020200', 'hex');
+
+      const type = TYPES.SmallInt;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.SmallInt;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
     });
   });
 
-  it('should writeParameterData VarChar (Null, Length > Maximum Length)', function(done) {
-    const value = null;
-    const length = 9000;
-    const expected = Buffer.from('FFFFFFFFFFFFFFFF', 'hex');
-    const type = TYPES.typeByName.VarChar;
-    const buffer = new WritableTrackingBuffer(0);
-    const parameterValue = { value, length };
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.SmallInt;
+      const expected = Buffer.from([0x26, 2]);
 
-    type.writeParameterData(buffer, parameterValue, { useUTC: false }, () => {
-      assert.deepEqual(buffer.data, expected);
-      done();
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('SmallMoney', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 2;
+      const expected = Buffer.from('04204e0000', 'hex');
+
+      const type = TYPES.SmallMoney;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.SmallMoney;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.SmallMoney;
+      const expected = Buffer.from([0x6E, 4]);
+
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('Text', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `Buffer` values', function() {
+      const value = Buffer.from('Hello World', 'ascii');
+      const expected = Buffer.from('00000000000f00000048656c6c6f20576f726c64', 'hex');
+
+      const type = TYPES.Text;
+      const parameterValue = { value, length: 15 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00000000000f000000', 'hex');
+
+      const type = TYPES.Text;
+      const parameterValue = { value, length: 15 };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Text;
+      const expected = Buffer.from([0x23, 1, 0, 0, 0]);
+
+      const result = type.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('Time', function() {
+  describe('.generateParameterData', function() {
+    // Test rounding of nanosecondDelta
+    it('correctly converts `Date` values with a `nanosecondDelta` property', () => {
+      const type = TYPES.Time;
+      for (const [value, nanosecondDelta, scale, expectedBuffer] of [
+        [new Date(2017, 6, 29, 17, 20, 3, 503), 0.0006264, 7, Buffer.from('0568fc624b91', 'hex')],
+        [new Date(2017, 9, 1, 1, 31, 4, 12), 0.0004612, 7, Buffer.from('05c422ceb80c', 'hex')],
+        [new Date(2017, 7, 3, 12, 52, 28, 373), 0.0007118, 7, Buffer.from('051e94c8e96b', 'hex')]
+      ]) {
+        const parameter = { value: value, scale: scale };
+        parameter.value.nanosecondDelta = nanosecondDelta;
+
+        const buffer = Buffer.concat([...type.generateParameterData(parameter, { useUTC: false }, () => { })]);
+        assert.deepEqual(buffer, expectedBuffer);
+      }
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.Time;
+      const expected = Buffer.from([0x29, 1]);
+
+      const reuslt = type.generateTypeInfo({ scale: 1 });
+      assert.deepEqual(reuslt, expected);
+    });
+  });
+});
+
+describe('TinyInt', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `number` values', function() {
+      const value = 1;
+      const expected = Buffer.from('0101', 'hex');
+
+      const type = TYPES.TinyInt;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+      const expected = Buffer.from('00', 'hex');
+
+      const type = TYPES.TinyInt;
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const type = TYPES.TinyInt;
+      const expected = Buffer.from([0x26, 1]);
+
+      const result = type.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('TVP', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts TVP table values', function() {
+      const value = {
+        columns: [{ name: 'user_id', type: TYPES.Int }],
+        rows: [[ 15 ]]
+      };
+      const expected = Buffer.from('01000000000000002604000001040f00000000', 'hex');
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...TYPES.TVP.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+
+      const expected = Buffer.from('ffff0000', 'hex');
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...TYPES.TVP.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0xF3, 0x00, 0x00, 0x00]);
+
+      const result = TYPES.TVP.generateTypeInfo({ value: null });
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('UniqueIdentifier', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `string` values', function() {
+      const value = 'e062ae34-6de5-47f3-8ba3-29d25f77e71a';
+
+      const expected = Buffer.from('1034ae62e0e56df3478ba329d25f77e71a', 'hex');
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...TYPES.UniqueIdentifier.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values', function() {
+      const value = null;
+
+      const expected = Buffer.from('00', 'hex');
+      const parameterValue = { value };
+
+      const buffer = Buffer.concat([...TYPES.UniqueIdentifier.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      const expected = Buffer.from([0x24, 0x10]);
+
+      const result = TYPES.UniqueIdentifier.generateTypeInfo();
+      assert.deepEqual(result, expected);
+    });
+  });
+});
+
+describe('VarBinary', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `null` values', () => {
+      for (const [value, length, expected] of [
+        [null, 1, Buffer.from('ffff', 'hex')],
+        [null, 9000, Buffer.from('FFFFFFFFFFFFFFFF', 'hex')]
+      ]) {
+        const parameterValue = { value, length };
+        const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false }, () => { })]);
+        assert.deepEqual(buffer, expected);
+      }
+    });
+
+    it('correctly converts `number` values', () => {
+      for (const [value, length, expected] of [
+        [1, 1, Buffer.from('02003100', 'hex')],
+      ]) {
+        const parameterValue = { value, length };
+        const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false }, () => { })]);
+        assert.deepEqual(buffer, expected);
+      }
+    });
+
+    it('correctly converts `number` values (Length <= Maximum Length)', function() {
+      const value = 1;
+      const length = 1;
+      const expected = Buffer.from('02003100', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `number` values (Length > Maximum Length)', function() {
+      const value = 1;
+      const length = 9000;
+      const expected = Buffer.from('feffffffffffffff02000000310000000000', 'hex');
+      const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values (Length <= Maximum Length)', function() {
+      const value = null;
+      const length = 1;
+      const expected = Buffer.from('ffff', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values (Length > Maximum Length)', function() {
+      const value = null;
+      const length = 9000;
+      const expected = Buffer.from('FFFFFFFFFFFFFFFF', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      // Length <= Maximum Length
+      const expected = Buffer.from([0xA5, 0x40, 0x1F]);
+
+      const result = TYPES.VarBinary.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
+
+      // Length > Maximum Length
+      const expected1 = Buffer.from([0xA5, 0xFF, 0xFF]);
+
+      const result1 = TYPES.VarBinary.generateTypeInfo({ length: 8500 });
+      assert.deepEqual(result1, expected1);
+    });
+  });
+});
+
+describe('VarChar', function() {
+  describe('.generateParameterData', function() {
+    it('correctly converts `string` values (Length <= Maximum Length)', function() {
+      const value = 'hello world';
+      const length = 1;
+      const expected = Buffer.from('0b0068656c6c6f20776f726c64', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `string` values (Length > Maximum Length)', function() {
+      const value = 'hello world';
+      const length = 9000;
+      const expected = Buffer.from('feffffffffffffff0b00000068656c6c6f20776f726c6400000000', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `null` values (Length <= Maximum Length)', function() {
+      const value = null;
+      const length = 1;
+      const expected = Buffer.from('ffff', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+
+    it('correctly converts `string` values (Length > Maximum Length)', function() {
+      const value = null;
+      const length = 9000;
+      const expected = Buffer.from('FFFFFFFFFFFFFFFF', 'hex'); const parameterValue = { value, length };
+
+      const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
+      assert.deepEqual(buffer, expected);
+    });
+  });
+
+  describe('.generateTypeInfo', function() {
+    it('returns the correct type information', function() {
+      // Length <= Maximum Length
+      const expected = Buffer.from('a7401f0000000000', 'hex');
+
+      const result = TYPES.VarChar.generateTypeInfo({ length: 1 });
+      assert.deepEqual(result, expected);
+
+      // Length > Maximum Length
+      const expected1 = Buffer.from('a7ffff0000000000', 'hex');
+
+      const result2 = TYPES.VarChar.generateTypeInfo({ length: 8500 });
+      assert.deepEqual(result2, expected1);
     });
   });
 });

--- a/test/unit/int-data-type.js
+++ b/test/unit/int-data-type.js
@@ -1,6 +1,5 @@
 const { assert } = require('chai');
 const { typeByName: { Int, SmallInt, TinyInt } } = require('../../src/data-type');
-const WritableTrackingBuffer = require('../../src/tracking-buffer/writable-tracking-buffer');
 
 describe('integer-data-types', function() {
   describe('int data type test', function() {
@@ -11,14 +10,9 @@ describe('integer-data-types', function() {
     ];
 
     params.forEach(function(item) {
-      it('test valid parameter values', function(done) {
-        const buffer = new WritableTrackingBuffer(4 + 1);
-
-        Int.writeParameterData(buffer, item.param, {}, () => {
-          assert.equal(buffer.buffer.readInt32LE(1), item.expected);
-
-          done();
-        });
+      it('test valid parameter values', function() {
+        const buffer = Buffer.concat([...Int.generateParameterData(item.param, {})]);
+        assert.equal(buffer.readInt32LE(1), item.expected);
       });
     });
   });
@@ -31,14 +25,9 @@ describe('integer-data-types', function() {
     ];
 
     params.forEach(function(item) {
-      it('test valid parameter values', function(done) {
-        const buffer = new WritableTrackingBuffer(4 + 1);
-
-        SmallInt.writeParameterData(buffer, item.param, {}, () => {
-          assert.equal(buffer.buffer.readInt32LE(1), item.expected);
-
-          done();
-        });
+      it('test valid parameter values', function() {
+        const buffer = Buffer.concat([...SmallInt.generateParameterData(item.param, {})]);
+        assert.equal(buffer.readInt16LE(1), item.expected);
       });
     });
   });
@@ -51,13 +40,9 @@ describe('integer-data-types', function() {
     ];
 
     params.forEach(function(item) {
-      it('test valid parameter values', function(done) {
-        const buffer = new WritableTrackingBuffer(4 + 1);
-        TinyInt.writeParameterData(buffer, item.param, {}, () => {
-          assert.equal(buffer.buffer.readInt32LE(1), item.expected);
-
-          done();
-        });
+      it('test valid parameter values', function() {
+        const buffer = Buffer.concat([...TinyInt.generateParameterData(item.param, {})]);
+        assert.equal(buffer.readInt8(1), item.expected);
       });
     });
   });


### PR DESCRIPTION
**My Machine**
_Comparing #1044 (before) with this PR (after)_

**Before:** 
$ node benchmarks/query/insert-varbinary.js
query\insert-varbinary.js size=10 n=10: 719.5642319011607
query\insert-varbinary.js size=1024 n=10: 705.0743708921045
query\insert-varbinary.js size=1048576 n=10: 58.216095819036425
query\insert-varbinary.js size=10485760 n=10: 10.632852494477827
query\insert-varbinary.js size=10 n=100: 1,131.653130209141
query\insert-varbinary.js size=1024 n=100: 1,121.2849153686102
query\insert-varbinary.js size=1048576 n=100: 102.65458589586083
query\insert-varbinary.js size=10485760 n=100: 13.391209246951373

$ node benchmarks/query/select-varbinary.js
query\select-varbinary.js size=10 n=10: 960.9286414390867
query\select-varbinary.js size=100 n=10: 943.1914826790902
query\select-varbinary.js size=1000 n=10: 901.0876127485875
query\select-varbinary.js size=10000 n=10: 864.8050297060528
query\select-varbinary.js size=1048576 n=10: 97.16577066384849
query\select-varbinary.js size=10485760 n=10: 23.32439309346061
query\select-varbinary.js size=10 n=100: 1,326.780805196735
query\select-varbinary.js size=100 n=100: 1,310.4786039534335
query\select-varbinary.js size=1000 n=100: 1,290.2576349027902
query\select-varbinary.js size=10000 n=100: 1,190.9922871339486
query\select-varbinary.js size=1048576 n=100: 220.8057772047495
query\select-varbinary.js size=10485760 n=100: 30.848338247833514

$ node benchmarks/request/**rpcrequest-payload.js**
request\rpcrequest-payload.js size=1048576 n=10: **630.9426914753333**
request\rpcrequest-payload.js size=10485760 n=10: **72.67632002000052**
request\rpcrequest-payload.js size=52428800 n=10: **16.142013535171973**
request\rpcrequest-payload.js size=1048576 n=100: **697.1779630412019**
request\rpcrequest-payload.js size=10485760 n=100: **81.02967322839558**
request\rpcrequest-payload.js size=52428800 n=100: **16.49164115396037**

**After:**
$ node benchmarks/query/insert-varbinary.js
query\insert-varbinary.js size=10 n=10: 705.8507474359442
query\insert-varbinary.js size=1024 n=10: 699.0954194638931
query\insert-varbinary.js size=1048576 n=10: 59.53206605439921
query\insert-varbinary.js size=10485760 n=10: 10.636543974131925
query\insert-varbinary.js size=10 n=100: 1,180.315640008451
query\insert-varbinary.js size=1024 n=100: 1,097.2540121092952
query\insert-varbinary.js size=1048576 n=100: 106.0414461868382
query\insert-varbinary.js size=10485760 n=100: 14.768045833580125

$ node benchmarks/query/select-varbinary.js
query\select-varbinary.js size=10 n=10: 968.9546916786171
query\select-varbinary.js size=100 n=10: 957.42338219384
query\select-varbinary.js size=1000 n=10: 932.0185658098309
query\select-varbinary.js size=10000 n=10: 863.4386322648539
query\select-varbinary.js size=1048576 n=10: 98.86630013633662
query\select-varbinary.js size=10485760 n=10: 24.82001764206854
query\select-varbinary.js size=10 n=100: 1,348.8013876468676
query\select-varbinary.js size=100 n=100: 1,253.9326462618387
query\select-varbinary.js size=1000 n=100: 1,259.0668551909437
query\select-varbinary.js size=10000 n=100: 1,181.2916479136618
query\select-varbinary.js size=1048576 n=100: 217.26005093879152
query\select-varbinary.js size=10485760 n=100: 32.37861637170988

$ node benchmarks/request/**rpcrequest-payload**
request\rpcrequest-payload.js size=1048576 n=10: **2,083.5069589132427**
request\rpcrequest-payload.js size=10485760 n=10: **2,155.916297843286**
request\rpcrequest-payload.js size=52428800 n=10: **1,988.6250646303145**
request\rpcrequest-payload.js size=1048576 n=100: **6,880.607221844057**
request\rpcrequest-payload.js size=10485760 n=100: **6,671.69223003381**
request\rpcrequest-payload.js size=52428800 n=100: **6,594.827017687326**

**Summary**
_rpcrequest-payload_ **increased** **ops/sec** by **230%** for smaller bytes and up to **40,000%** for larger bytes. 