### PR TITLE
feat: add toBuffer method to AE data types

### DIFF
--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -72,12 +72,13 @@ export interface DataType {
   writeParameterData(buf: any, data: ParameterData, options: InternalConnectionOptions, callback: () => void): void;
   validate(value: any): any; // TODO: Refactor 'any' and replace with more specific type.
   generate(parameter: ParameterData, options: InternalConnectionOptions): Generator<Buffer, void>;
+  toBuffer?(parameter: ParameterData, options: InternalConnectionOptions): Buffer | void;
 
   hasTableName?: boolean;
 
-  resolveLength?: (parameter: Parameter) => number;
+  resolveLength?: (parameter: ParameterData) => number;
   resolvePrecision?: (parameter: Parameter) => number;
-  resolveScale?: (parameter: Parameter) => number;
+  resolveScale?: (parameter: ParameterData) => number;
 }
 
 export const TYPE = {

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -34,6 +34,14 @@ const BigInt: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      const buffer = new WritableTrackingBuffer(8);
+      buffer.writeInt64LE(Number(parameter.value));
+      return buffer.data;
+    }
+  },
+
   validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/binary.ts
+++ b/src/data-types/binary.ts
@@ -59,6 +59,13 @@ const Binary: { maximumLength: number } & DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value;
+    if (value != null) {
+      return Buffer.isBuffer(value) ? value : Buffer.from(value);
+    }
+  },
+
   validate: function(value): Buffer | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/bit.ts
+++ b/src/data-types/bit.ts
@@ -34,6 +34,15 @@ const Bit: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      // Always Encrypted length must be normalized to 8 bytes for bit
+      const buffer = Buffer.alloc(8);
+      buffer.writeInt8(parameter.value ? 1 : 0, 0);
+      return buffer;
+    }
+  },
+
   validate: function(value): null | boolean {
     if (value == null) {
       return null;

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -72,6 +72,13 @@ const Char: { maximumLength: number } & DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value;
+    if (value != null) {
+      return Buffer.isBuffer(value) ? value : Buffer.from(value);
+    }
+  },
+
   validate: function(value): null | string | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/date.ts
+++ b/src/data-types/date.ts
@@ -48,6 +48,25 @@ const Date: DataType = {
     }
   },
 
+  toBuffer: function(parameter, options) {
+    const value = parameter.value as Date;
+
+    if (value != null) {
+      let date;
+      if (options.useUTC) {
+        date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
+      } else {
+        date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
+      }
+
+      const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+      const buffer = new WritableTrackingBuffer(3);
+      buffer.writeUInt24LE(days);
+
+      return buffer.data;
+    }
+  },
+
   // TODO: value is techincally of type 'unknown'.
   validate: function(value): null | Date | TypeError {
     if (value == null) {

--- a/src/data-types/datetime.ts
+++ b/src/data-types/datetime.ts
@@ -75,6 +75,49 @@ const DateTime: DataType = {
     }
   },
 
+  toBuffer: function(parameter, options) {
+    const value = parameter.value as Date;
+
+    if (value != null) {
+      let date;
+      if (options.useUTC) {
+        date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
+      } else {
+        date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
+      }
+
+      let days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+
+      let milliseconds, threeHundredthsOfSecond;
+      if (options.useUTC) {
+        let seconds = value.getUTCHours() * 60 * 60;
+        seconds += value.getUTCMinutes() * 60;
+        seconds += value.getUTCSeconds();
+        milliseconds = (seconds * 1000) + value.getUTCMilliseconds();
+      } else {
+        let seconds = value.getHours() * 60 * 60;
+        seconds += value.getMinutes() * 60;
+        seconds += value.getSeconds();
+        milliseconds = (seconds * 1000) + value.getMilliseconds();
+      }
+
+      threeHundredthsOfSecond = milliseconds / (3 + (1 / 3));
+      threeHundredthsOfSecond = Math.round(threeHundredthsOfSecond);
+
+      // 25920000 equals one day
+      if (threeHundredthsOfSecond === 25920000) {
+        days += 1;
+        threeHundredthsOfSecond = 0;
+      }
+
+      const result = new WritableTrackingBuffer(8);
+      result.writeUInt32LE(days);
+      result.writeUInt32LE(threeHundredthsOfSecond);
+
+      return result.data;
+    }
+  },
+
   // TODO: type 'any' needs to be revisited.
   validate: function(value): null | number | TypeError {
     if (value == null) {

--- a/src/data-types/datetime2.ts
+++ b/src/data-types/datetime2.ts
@@ -87,6 +87,41 @@ const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']
     }
   },
 
+  toBuffer: function(parameter, options) {
+    const value = parameter.value as Date & { nanosecondDelta?: number | null };
+
+    if (value != null) {
+      const scale = this.resolveScale(parameter);
+
+      let timestamp;
+      if (options.useUTC) {
+        timestamp = ((value.getUTCHours() * 60 + value.getUTCMinutes()) * 60 + value.getUTCSeconds()) * 1000 + value.getUTCMilliseconds();
+      } else {
+        timestamp = ((value.getHours() * 60 + value.getMinutes()) * 60 + value.getSeconds()) * 1000 + value.getMilliseconds();
+      }
+      timestamp = timestamp * Math.pow(10, scale - 3);
+      timestamp += (value.nanosecondDelta != null ? value.nanosecondDelta : 0) * Math.pow(10, scale);
+      timestamp = Math.round(timestamp);
+
+
+      let date;
+      if (options.useUTC) {
+        date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
+      } else {
+        date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
+      }
+
+      const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+
+      // encrypted datetime2 must be 8 bytes: 5 for time, 3 for date
+      const buffer = new WritableTrackingBuffer(8);
+      buffer.writeUInt40LE(timestamp);
+      buffer.writeUInt24LE(days);
+
+      return buffer.data;
+    }
+  },
+
   validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/datetimeoffset.ts
+++ b/src/data-types/datetimeoffset.ts
@@ -75,6 +75,35 @@ const DateTimeOffset: DataType & { resolveScale: NonNullable<DataType['resolveSc
       yield buffer.data;
     }
   },
+
+  toBuffer: function(parameter) {
+    const value = parameter.value as Date & { nanosecondDelta?: number | null };
+
+    if (value != null) {
+      const scale = this.resolveScale(parameter);
+
+      let timestamp;
+      timestamp = ((value.getUTCHours() * 60 + value.getUTCMinutes()) * 60 + value.getUTCSeconds()) * 1000 + value.getMilliseconds();
+      timestamp = timestamp * Math.pow(10, scale - 3);
+      timestamp += (value.nanosecondDelta != null ? value.nanosecondDelta : 0) * Math.pow(10, scale);
+      timestamp = Math.round(timestamp);
+
+      const date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
+      const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+
+      const offset = -value.getTimezoneOffset();
+
+      // data size does not matter for encrypted datetimeoffset
+      // just choose the smallest that maintains full scale (7)
+      const buffer = new WritableTrackingBuffer(10);
+      buffer.writeUInt40LE(timestamp);
+      buffer.writeUInt24LE(days);
+      buffer.writeInt16LE(offset);
+
+      return buffer.data;
+    }
+  },
+
   validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/decimal.ts
+++ b/src/data-types/decimal.ts
@@ -88,6 +88,26 @@ const Decimal: DataType & { resolvePrecision: NonNullable<DataType['resolvePreci
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value as number;
+
+    if (value != null) {
+      const scale = this.resolveScale(parameter);
+
+      const sign = value < 0 ? 0 : 1;
+      const mag = Math.round(Math.abs(value * Math.pow(10, scale)));
+
+      // block size does not matter for encrypted decimal
+      // just choose the smallest that maintains full precision (18), instead
+      // of tailoring it for each parameter.precision
+      const result = new WritableTrackingBuffer(16);
+      result.writeUInt8(sign);
+      result.writeUInt64LE(mag);
+
+      return result.data;
+    }
+  },
+
   validate: function(value): number | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/float.ts
+++ b/src/data-types/float.ts
@@ -33,10 +33,10 @@ const Float: DataType = {
       yield buffer.data;
     }
   },
-  
+
   toBuffer: function(parameter) {
     if (parameter.value != null) {
-      const result = new WritableTrackingBuffer(8)
+      const result = new WritableTrackingBuffer(8);
       result.writeDoubleLE(parseFloat(parameter.value));
       return result.data;
     }

--- a/src/data-types/float.ts
+++ b/src/data-types/float.ts
@@ -33,6 +33,14 @@ const Float: DataType = {
       yield buffer.data;
     }
   },
+  
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      const result = new WritableTrackingBuffer(8)
+      result.writeDoubleLE(parseFloat(parameter.value));
+      return result.data;
+    }
+  },
 
   validate: function(value): number | null | TypeError {
     if (value == null) {

--- a/src/data-types/int.ts
+++ b/src/data-types/int.ts
@@ -34,6 +34,15 @@ const Int: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      // Always Encrypted length must be normalized to 8 bytes for int
+      const buffer = Buffer.alloc(8);
+      buffer.writeInt32LE(Number(parameter.value), 0);
+      return buffer;
+    }
+  },
+
   validate: function(value): number | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/money.ts
+++ b/src/data-types/money.ts
@@ -34,6 +34,14 @@ const Money: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      const buffer = new WritableTrackingBuffer(8);
+      buffer.writeMoney(parameter.value * 10000);
+      return buffer.data;
+    }
+  },
+
   validate: function(value): number | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/nchar.ts
+++ b/src/data-types/nchar.ts
@@ -71,6 +71,13 @@ const NChar: DataType & { maximumLength: number } = {
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value;
+    if (parameter.value != null) {
+      return Buffer.isBuffer(value) ? value : Buffer.from(value, 'ucs2');
+    }
+  },
+
   validate: function(value): string | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/numeric.ts
+++ b/src/data-types/numeric.ts
@@ -89,6 +89,26 @@ const Numeric: DataType & { resolveScale: NonNullable<DataType['resolveScale']>,
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value as number;
+
+    if (value != null) {
+      const scale = this.resolveScale(parameter);
+
+      const sign = value < 0 ? 0x00 : 0x01;
+      const mag = Math.round(Math.abs(value * Math.pow(10, scale)));
+
+      // block size does not matter for encrypted numeric
+      // just choose the smallest that maintains full precision (18), instead
+      // of tailoring it for each parameter.precision
+      const buffer = new WritableTrackingBuffer(16);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(mag);
+
+      return buffer.data;
+    }
+  },
+
   validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/nvarchar.ts
+++ b/src/data-types/nvarchar.ts
@@ -83,6 +83,15 @@ const NVarChar: { maximumLength: number } & DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value;
+    const length = this.resolveLength!(parameter);
+    if (value != null && length! <= this.maximumLength) {
+      // length must be less than 4000 since PLP body is not supported with Always Encrypted
+      return Buffer.isBuffer(value) ? value : Buffer.from(value, 'ucs2');
+    }
+  },
+
   validate: function(value): null | string | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/real.ts
+++ b/src/data-types/real.ts
@@ -34,6 +34,14 @@ const Real: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      const buffer = new WritableTrackingBuffer(4);
+      buffer.writeFloatLE(parseFloat(parameter.value));
+      return buffer.data;
+    }
+  },
+
   validate: function(value): null| number |TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/smalldatetime.ts
+++ b/src/data-types/smalldatetime.ts
@@ -49,6 +49,28 @@ const SmallDateTime: DataType = {
     }
   },
 
+  toBuffer: function(parameter, options) {
+    const value = parameter.value as Date;
+
+    if (value != null) {
+      let days, dstDiff, minutes;
+      if (options.useUTC) {
+        days = Math.floor((value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
+        minutes = (value.getUTCHours() * 60) + value.getUTCMinutes();
+      } else {
+        dstDiff = -(value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
+        days = Math.floor((value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
+        minutes = (value.getHours() * 60) + value.getMinutes();
+      }
+
+      const result = new WritableTrackingBuffer(4);
+      result.writeUInt16LE(days);
+      result.writeUInt16LE(minutes);
+
+      return result.data;
+    }
+  },
+
   validate: function(value): null | Date| TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/smallint.ts
+++ b/src/data-types/smallint.ts
@@ -34,6 +34,15 @@ const SmallInt: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      // Always Encrypted length must be normalized to 8 bytes for smallint
+      const buffer = Buffer.alloc(8);
+      buffer.writeInt16LE(Number(parameter.value), 0);
+      return buffer;
+    }
+  },
+
   validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/smallmoney.ts
+++ b/src/data-types/smallmoney.ts
@@ -34,6 +34,15 @@ const SmallMoney: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      // SmallMoney is still 8 bytes, but the first 4 are always ignored
+      const buffer = Buffer.alloc(8);
+      buffer.writeInt32LE(parameter.value * 10000, 4);
+      return buffer;
+    }
+  },
+
   validate: function(value): null | number | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/tinyint.ts
+++ b/src/data-types/tinyint.ts
@@ -35,6 +35,15 @@ const TinyInt: DataType = {
 
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      // Always Encrypted length must be normalized to 8 bytes for tinyint
+      const result = Buffer.alloc(8);
+      result.writeUInt8(Number(parameter.value), 0);
+      return result;
+    }
+  },
+
   validate: function(value): number | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/uniqueidentifier.ts
+++ b/src/data-types/uniqueidentifier.ts
@@ -38,6 +38,12 @@ const UniqueIdentifier: DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    if (parameter.value != null) {
+      return Buffer.from(guidToArray(parameter.value));
+    }
+  },
+
   validate: function(value): string | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/varbinary.ts
+++ b/src/data-types/varbinary.ts
@@ -76,6 +76,14 @@ const VarBinary: { maximumLength: number } & DataType = {
     }
   },
 
+  toBuffer: function(parameter) {
+    const value = parameter.value;
+    const length = this.resolveLength!(parameter);
+    if (parameter.value != null && length <= this.maximumLength) {
+      return Buffer.isBuffer(value) ? value : Buffer.from(value);
+    }
+  },
+
   validate: function(value): Buffer | null | TypeError {
     if (value == null) {
       return null;

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -62,7 +62,6 @@ const VarChar: { maximumLength: number } & DataType = {
     cb();
   },
 
-
   generate: function*(parameter, options) {
     if (parameter.value != null) {
       const buffer = new WritableTrackingBuffer(0);
@@ -81,6 +80,14 @@ const VarChar: { maximumLength: number } & DataType = {
       buffer.writeUInt32LE(0xFFFFFFFF);
       buffer.writeUInt32LE(0xFFFFFFFF);
       yield buffer.data;
+    }
+  },
+
+  toBuffer: function(parameter) {
+    const value = parameter.value;
+    const length = this.resolveLength!(parameter);
+    if (value != null && length <= this.maximumLength) {
+      return Buffer.isBuffer(value) ? value : Buffer.from(value);
     }
   },
 

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -1244,3 +1244,693 @@ describe('Data Types', function() {
     });
   });
 });
+
+describe('DataType.toBuffer', () => {
+  const emptyBuffer = Buffer.from([]);
+
+  const undefinedValueCase = {
+    name: 'value is undefined',
+    parameter: {},
+    expected: undefined,
+  };
+  const nullValueCase = {
+    name: 'value is null',
+    parameter: { value: null },
+    expected: undefined,
+  };
+
+  describe('TinyInt.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a tiny int',
+        parameter: { value: 12 },
+        expected: Buffer.from([ 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a tiny int string',
+        parameter: { value: '12' },
+        expected: Buffer.from([ 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.TinyInt.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('SmallInt.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a small int',
+        parameter: { value: 1234 },
+        expected: Buffer.from([ 0xD2, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a small int string',
+        parameter: { value: '1234' },
+        expected: Buffer.from([ 0xD2, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.SmallInt.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Int.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is an int',
+        parameter: { value: 123456 },
+        expected: Buffer.from([ 0x40, 0xE2, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is an int string',
+        parameter: { value: '123456' },
+        expected: Buffer.from([ 0x40, 0xE2, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Int.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('BigInt.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a big int number',
+        parameter: { value: 123456789 },
+        expected: Buffer.from([ 0x15, 0xCD, 0x5B, 0x07, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a big int string',
+        parameter: { value: '123456789' },
+        expected: Buffer.from([ 0x15, 0xCD, 0x5B, 0x07, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.BigInt.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Real.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a float number',
+        parameter: { value: 1234.5678 },
+        expected: Buffer.from([ 0x2B, 0x52, 0x9A, 0x44 ]),
+      },
+      {
+        name: 'value is a float string',
+        parameter: { value: '1234.5678' },
+        expected: Buffer.from([ 0x2B, 0x52, 0x9A, 0x44 ]),
+      },
+      {
+        name: 'value is a float in scientific format',
+        parameter: { value: '12345678e-4' },
+        expected: Buffer.from([ 0x2B, 0x52, 0x9A, 0x44 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Real.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Float.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a float number',
+        parameter: { value: 1234.5678 },
+        expected: Buffer.from([ 0xAD, 0xFA, 0x5C, 0x6D, 0x45, 0x4A, 0x93, 0x40 ]),
+      },
+      {
+        name: 'value is a float string',
+        parameter: { value: '1234.5678' },
+        expected: Buffer.from([ 0xAD, 0xFA, 0x5C, 0x6D, 0x45, 0x4A, 0x93, 0x40 ]),
+      },
+      {
+        name: 'value is a float in scientific format',
+        parameter: { value: '12345678e-4' },
+        expected: Buffer.from([ 0xAD, 0xFA, 0x5C, 0x6D, 0x45, 0x4A, 0x93, 0x40 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Float.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('SmallMoney.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a float number',
+        parameter: { value: 1234.5678 },
+        expected: Buffer.from([ 0x00, 0x00, 0x00, 0x00, 0x4E, 0x61, 0xBC, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.SmallMoney.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Money.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a float number',
+        parameter: { value: 12345678.1234 },
+        expected: Buffer.from([ 0x1C, 0x00, 0x00, 0x00, 0xB2, 0xFB, 0x98, 0xBE ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Money.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Bit.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is true',
+        parameter: { value: true },
+        expected: Buffer.from([ 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is false',
+        parameter: { value: false },
+        expected: Buffer.from([ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is truthy',
+        parameter: { value: 'test' },
+        expected: Buffer.from([ 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is falsy',
+        parameter: { value: '' },
+        expected: Buffer.from([ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Bit.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('VarChar.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is empty string',
+        parameter: { value: '' },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is empty buffer',
+        parameter: { value: emptyBuffer },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is printable string',
+        parameter: { value: 'test' },
+        expected: Buffer.from('test'),
+      },
+      {
+        name: 'value is binary string',
+        parameter: { value: '\x12\x34\x56\x78' },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+      {
+        name: 'value is binary buffer',
+        parameter: { value: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]) },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.VarChar.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Char.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is empty string',
+        parameter: { value: '' },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is empty buffer',
+        parameter: { value: emptyBuffer },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is printable string',
+        parameter: { value: 'test' },
+        expected: Buffer.from('test'),
+      },
+      {
+        name: 'value is binary string',
+        parameter: { value: '\x12\x34\x56\x78' },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+      {
+        name: 'value is binary buffer',
+        parameter: { value: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]) },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Char.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('NVarChar.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is empty string',
+        parameter: { value: '' },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is empty buffer',
+        parameter: { value: emptyBuffer },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is printable string',
+        parameter: { value: 'test' },
+        expected: Buffer.from('test', 'ucs2'),
+      },
+      {
+        name: 'value is binary string',
+        parameter: { value: '\x12\x34\x56\x78' },
+        expected: Buffer.from([ 0x12, 0x00, 0x34, 0x00, 0x56, 0x00, 0x78, 0x00 ]),
+      },
+      {
+        name: 'value is binary buffer',
+        parameter: { value: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]) },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.NVarChar.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('NChar.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is empty string',
+        parameter: { value: '' },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is empty buffer',
+        parameter: { value: emptyBuffer },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is printable string',
+        parameter: { value: 'test' },
+        expected: Buffer.from('test', 'ucs2'),
+      },
+      {
+        name: 'value is binary string',
+        parameter: { value: '\x12\x34\x56\x78' },
+        expected: Buffer.from([ 0x12, 0x00, 0x34, 0x00, 0x56, 0x00, 0x78, 0x00 ]),
+      },
+      {
+        name: 'value is binary buffer',
+        parameter: { value: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]) },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.NChar.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('VarBinary.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is empty string',
+        parameter: { value: '' },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is empty buffer',
+        parameter: { value: emptyBuffer },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is printable string',
+        parameter: { value: 'test' },
+        expected: Buffer.from('test'),
+      },
+      {
+        name: 'value is binary string',
+        parameter: { value: '\x12\x34\x56\x78' },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+      {
+        name: 'value is binary buffer',
+        parameter: { value: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]) },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.VarBinary.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Binary.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is empty string',
+        parameter: { value: '' },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is empty buffer',
+        parameter: { value: emptyBuffer },
+        expected: emptyBuffer,
+      },
+      {
+        name: 'value is printable string',
+        parameter: { value: 'test' },
+        expected: Buffer.from('test'),
+      },
+      {
+        name: 'value is binary string',
+        parameter: { value: '\x12\x34\x56\x78' },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+      {
+        name: 'value is binary buffer',
+        parameter: { value: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]) },
+        expected: Buffer.from([ 0x12, 0x34, 0x56, 0x78 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Binary.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('SmallDateTime.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is utc date, with use utc true',
+        parameter: { value: new Date(Date.UTC(1970, 1, 23, 12, 0, 0)) },
+        options: { useUTC: true },
+        expected: Buffer.from([ 0x14, 0x64, 0xD0, 0x02 ]),
+      },
+      {
+        name: 'value is local date, with use utc false',
+        parameter: { value: new Date(1970, 1, 23, 12, 0, 0) },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x14, 0x64, 0xD0, 0x02 ]),
+      },
+    ].forEach(({ name, parameter, options, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.SmallDateTime.toBuffer(parameter, options);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('DateTime.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is utc date, with use utc true',
+        parameter: { value: new Date(Date.UTC(1970, 1, 23, 12, 0, 0)) },
+        options: { useUTC: true },
+        expected: Buffer.from([ 0x14, 0x64, 0x00, 0x00, 0x00, 0xC1, 0xC5, 0x00 ]),
+      },
+      {
+        name: 'value is local date, with use utc false',
+        parameter: { value: new Date(1970, 1, 23, 12, 0, 0) },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x14, 0x64, 0x00, 0x00, 0x00, 0xC1, 0xC5, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, options, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.DateTime.toBuffer(parameter, options);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Time.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is utc date, with use utc true',
+        parameter: { value: new Date(Date.UTC(1970, 1, 23, 12, 0, 0)) },
+        options: { useUTC: true },
+        expected: Buffer.from([ 0x00, 0xE0, 0x34, 0x95, 0x64 ]),
+      },
+      {
+        name: 'value is local date, with use utc false',
+        parameter: { value: new Date(1970, 1, 23, 12, 0, 0) },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x00, 0xE0, 0x34, 0x95, 0x64 ]),
+      },
+      {
+        name: 'value is local date, with nanoseconds',
+        parameter: {
+          value: Object.assign(
+            new Date(1970, 1, 23, 12, 0, 0),
+            { nanosecondDelta: 1234 },
+          ),
+        },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x00, 0x55, 0xBA, 0x74, 0x67 ]),
+      },
+    ].forEach(({ name, parameter, options, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Time.toBuffer(parameter, options);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Date.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is utc date, with use utc true',
+        parameter: { value: new Date(Date.UTC(1970, 1, 23, 12, 0, 0)) },
+        options: { useUTC: true },
+        expected: Buffer.from([ 0x6F, 0xF9, 0x0A ]),
+      },
+      {
+        name: 'value is local date, with use utc false',
+        parameter: { value: new Date(1970, 1, 23, 12, 0, 0) },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x6F, 0xF9, 0x0A ]),
+      },
+    ].forEach(({ name, parameter, options, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Date.toBuffer(parameter, options);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('DateTime2.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is utc date, with use utc true',
+        parameter: { value: new Date(Date.UTC(1970, 1, 23, 12, 0, 0)) },
+        options: { useUTC: true },
+        expected: Buffer.from([ 0x00, 0xE0, 0x34, 0x95, 0x64, 0x6F, 0xF9, 0x0A ]),
+      },
+      {
+        name: 'value is local date, with use utc false',
+        parameter: { value: new Date(1970, 1, 23, 12, 0, 0) },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x00, 0xE0, 0x34, 0x95, 0x64, 0x6F, 0xF9, 0x0A ]),
+      },
+      {
+        name: 'value is local date, with nanoseconds',
+        parameter: {
+          value: Object.assign(
+            new Date(1970, 1, 23, 12, 0, 0),
+            { nanosecondDelta: 1234 },
+          ),
+        },
+        options: { useUTC: false },
+        expected: Buffer.from([ 0x00, 0x55, 0xBA, 0x74, 0x67, 0x6F, 0xF9, 0x0A ]),
+      },
+    ].forEach(({ name, parameter, options, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.DateTime2.toBuffer(parameter, options);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  // DateTimeOffset is already tested by Date, and only has the additional time-zone offset
+  // Adding a portable, dynamic test for it wouldn't really be testing much, so skip it
+
+  describe('Numeric.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a float number',
+        parameter: { value: 1234.5678 },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a float string',
+        parameter: { value: '1234.5678' },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a float in scientific format',
+        parameter: { value: '12345678e-4' },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a float, with a specific scale',
+        parameter: { value: 0.12345678, scale: 4 },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Numeric.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('Decimal.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is a float number',
+        parameter: { value: 1234.5678 },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a float string',
+        parameter: { value: '1234.5678' },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a float in scientific format',
+        parameter: { value: '12345678e-4' },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+      {
+        name: 'value is a float, with a specific scale',
+        parameter: { value: 0.12345678, scale: 4 },
+        expected: Buffer.from([ 0x01, 0xD3, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.Decimal.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+
+  describe('UniqueIdentifier.toBuffer', () => {
+    [
+      undefinedValueCase,
+      nullValueCase,
+      {
+        name: 'value is an upper-case guid',
+        parameter: { value: 'ABCD1234-ABCD-1234-ABCD-1234567890AB' },
+        expected: Buffer.from([
+          0x34, 0x12, 0xCD, 0xAB, 0xCD, 0xAB, 0x34, 0x12,
+          0xAB, 0xCD, 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB,
+        ]),
+      },
+      {
+        name: 'value is a lower-case guid',
+        parameter: { value: 'abcd1234-abcd-1234-abcd-1234567890ab' },
+        expected: Buffer.from([
+          0x34, 0x12, 0xCD, 0xAB, 0xCD, 0xAB, 0x34, 0x12,
+          0xAB, 0xCD, 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB,
+        ]),
+      },
+      {
+        name: 'value is a mixed-case guid',
+        parameter: { value: 'ABcd1234-aBcD-1234-AbCd-1234567890ab' },
+        expected: Buffer.from([
+          0x34, 0x12, 0xCD, 0xAB, 0xCD, 0xAB, 0x34, 0x12,
+          0xAB, 0xCD, 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB,
+        ]),
+      },
+    ].forEach(({ name, parameter, expected }) => {
+      it(name, () => {
+        const actual = TYPES.typeByName.UniqueIdentifier.toBuffer(parameter);
+        assert.deepEqual(actual, expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Co-authored-by: akshayganeshen <me@aganeshen.com>

Implement `toBuffer()` method for all data types that are supported by Always Encrypted (https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/always-encrypted-database-engine?view=sql-server-ver15#feature-details). This method will normalize parameter values as buffers to allow them to be encrypted and sent to the database as VarBinary.

This is the first PR of the effort to break down the large Always Encrypted PR into smaller, more manageable ones for review. https://github.com/tediousjs/tedious/pull/1020