### PR TITLE
Split generation of parameter length and data

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -177,6 +177,7 @@ class RowTransform extends Transform {
         value: row[i]
       };
 
+      this.push(c.type.generateParameterLength(parameter, this.mainOptions));
       for (const chunk of c.type.generateParameterData(parameter, this.mainOptions)) {
         this.push(chunk);
       }

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -69,6 +69,7 @@ export interface DataType {
 
   declaration(parameter: Parameter): string;
   generateTypeInfo(parameter: ParameterData, options: InternalConnectionOptions): Buffer;
+  generateParameterLength(parameter: ParameterData, options: InternalConnectionOptions): Buffer;
   generateParameterData(parameter: ParameterData, options: InternalConnectionOptions): Generator<Buffer, void>;
   validate(value: any): any; // TODO: Refactor 'any' and replace with more specific type.
 

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -2,6 +2,9 @@ import { DataType } from '../data-type';
 import IntN from './intn';
 import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
+const DATA_LENGTH = Buffer.from([0x08]);
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const BigInt: DataType = {
   id: 0x7F,
   type: 'INT8',
@@ -15,15 +18,22 @@ const BigInt: DataType = {
     return Buffer.from([IntN.id, 0x08]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(9);
-      buffer.writeUInt8(8);
-      buffer.writeInt64LE(Number(parameter.value));
-      yield buffer.data;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = new WritableTrackingBuffer(8);
+    buffer.writeInt64LE(Number(parameter.value));
+    yield buffer.data;
   },
 
   validate: function(value): null | number | TypeError {

--- a/src/data-types/binary.ts
+++ b/src/data-types/binary.ts
@@ -1,6 +1,6 @@
 import { DataType } from '../data-type';
 
-const NULL = (1 << 16) - 1;
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF]);
 
 const Binary: { maximumLength: number } & DataType = {
   id: 0xAD,
@@ -42,19 +42,22 @@ const Binary: { maximumLength: number } & DataType = {
     return buffer;
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(2);
-      buffer.writeUInt16LE(parameter.length!, 0);
-      yield buffer;
-
-      const value = parameter.value.slice(0, parameter.length !== undefined ? Math.min(parameter.length, this.maximumLength) : this.maximumLength);
-      yield value;
-    } else {
-      const buffer = Buffer.alloc(2);
-      buffer.writeUInt16LE(NULL, 0);
-      yield buffer;
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    const buffer = Buffer.alloc(2);
+    buffer.writeUInt16LE(parameter.length!, 0);
+    return buffer;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    yield parameter.value.slice(0, parameter.length !== undefined ? Math.min(parameter.length, this.maximumLength) : this.maximumLength);
   },
 
   validate: function(value): Buffer | null | TypeError {

--- a/src/data-types/bit.ts
+++ b/src/data-types/bit.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import BitN from './bitn';
 
+const DATA_LENGTH = Buffer.from([0x01]);
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const Bit: DataType = {
   id: 0x32,
   type: 'BIT',
@@ -14,17 +17,20 @@ const Bit: DataType = {
     return Buffer.from([BitN.id, 0x01]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (typeof parameter.value === 'undefined' || parameter.value === null) {
-      const buffer = Buffer.alloc(1);
-      buffer.writeUInt8(0, 0);
-      yield buffer;
-    } else {
-      const buffer = Buffer.alloc(2);
-      buffer.writeUInt8(1, 0);
-      buffer.writeUInt8(parameter.value ? 1 : 0, 1);
-      yield buffer;
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    yield parameter.value ? Buffer.from([0x01]) : Buffer.from([0x00]);
   },
 
   validate: function(value): null | boolean {

--- a/src/data-types/bitn.ts
+++ b/src/data-types/bitn.ts
@@ -13,7 +13,11 @@ const BitN: DataType = {
     throw new Error('not implemented');
   },
 
-  *generateParameterData() {
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
+  * generateParameterData() {
     throw new Error('not implemented');
   },
 

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -1,6 +1,6 @@
 import { DataType } from '../data-type';
 
-const NULL = (1 << 16) - 1;
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF]);
 
 const Char: { maximumLength: number } & DataType = {
   id: 0xAF,
@@ -53,23 +53,24 @@ const Char: { maximumLength: number } & DataType = {
     return buffer;
   },
 
-  *generateParameterData(parameter, options) {
-    let value = parameter.value as any; // Temporary solution. Remove 'any' later.
-
-    if (value != null) {
-      value = value.toString();
-      const length = Buffer.byteLength(value, 'ascii');
-
-      const buffer = Buffer.alloc(2);
-      buffer.writeUInt16LE(length, 0);
-      yield buffer;
-
-      yield Buffer.alloc(length, parameter.value, 'ascii');
-    } else {
-      const buffer = Buffer.alloc(2);
-      buffer.writeUInt16LE(NULL, 0);
-      yield buffer;
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    const length = Buffer.byteLength(parameter.value.toString(), 'ascii');
+
+    const buffer = Buffer.alloc(2);
+    buffer.writeUInt16LE(length, 0);
+    return buffer;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    yield Buffer.from(parameter.value, 'ascii');
   },
 
   validate: function(value): null | string | TypeError {

--- a/src/data-types/date.ts
+++ b/src/data-types/date.ts
@@ -1,10 +1,11 @@
 import { DataType } from '../data-type';
 import { ChronoUnit, LocalDate } from '@js-joda/core';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 // globalDate is to be used for JavaScript's global 'Date' object to avoid name clashing with the 'Date' constant below
 const globalDate = global.Date;
 const EPOCH_DATE = LocalDate.ofYearDay(1, 1);
+const NULL_LENGTH = Buffer.from([0x00]);
+const DATA_LENGTH = Buffer.from([0x03]);
 
 const Date: DataType = {
   id: 0x28,
@@ -15,30 +16,36 @@ const Date: DataType = {
     return 'date';
   },
 
-  generateTypeInfo: function(buffer) {
+  generateTypeInfo: function() {
     return Buffer.from([this.id]);
   },
 
-  *generateParameterData(parameter, options) {
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
+    }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
     const value = parameter.value as any; // Temporary solution. Remove 'any' later.
 
-    if (value != null) {
-      const buffer = new WritableTrackingBuffer(16);
-      buffer.writeUInt8(3);
-
-      let date;
-      if (options.useUTC) {
-        date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
-      } else {
-        date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
-      }
-
-      const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
-      buffer.writeUInt24LE(days);
-      yield buffer.data;
+    let date;
+    if (options.useUTC) {
+      date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
     } else {
-      yield Buffer.from([0x00]);
+      date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
     }
+
+    const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+    const buffer = Buffer.alloc(3);
+    buffer.writeUIntLE(days, 0, 3);
+    yield buffer;
   },
 
   // TODO: value is techincally of type 'unknown'.

--- a/src/data-types/datetime.ts
+++ b/src/data-types/datetime.ts
@@ -3,6 +3,8 @@ import DateTimeN from './datetimen';
 import { ChronoUnit, LocalDate } from '@js-joda/core';
 
 const EPOCH_DATE = LocalDate.ofYearDay(1900, 1);
+const NULL_LENGTH = Buffer.from([0x00]);
+const DATA_LENGTH = Buffer.from([0x08]);
 
 const DateTime: DataType = {
   id: 0x3D,
@@ -17,49 +19,56 @@ const DateTime: DataType = {
     return Buffer.from([DateTimeN.id, 0x08]);
   },
 
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
+    }
+
+    return DATA_LENGTH;
+  },
+
   generateParameterData: function*(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
     const value = parameter.value as any; // Temporary solution. Remove 'any' later.
 
-    if (value != null) {
-      let date;
-      if (options.useUTC) {
-        date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
-      } else {
-        date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
-      }
-
-      let days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
-
-      let milliseconds, threeHundredthsOfSecond;
-      if (options.useUTC) {
-        let seconds = value.getUTCHours() * 60 * 60;
-        seconds += value.getUTCMinutes() * 60;
-        seconds += value.getUTCSeconds();
-        milliseconds = (seconds * 1000) + value.getUTCMilliseconds();
-      } else {
-        let seconds = value.getHours() * 60 * 60;
-        seconds += value.getMinutes() * 60;
-        seconds += value.getSeconds();
-        milliseconds = (seconds * 1000) + value.getMilliseconds();
-      }
-
-      threeHundredthsOfSecond = milliseconds / (3 + (1 / 3));
-      threeHundredthsOfSecond = Math.round(threeHundredthsOfSecond);
-
-      // 25920000 equals one day
-      if (threeHundredthsOfSecond === 25920000) {
-        days += 1;
-        threeHundredthsOfSecond = 0;
-      }
-
-      const buffer = Buffer.alloc(9);
-      buffer.writeUInt8(8, 0);
-      buffer.writeInt32LE(days, 1);
-      buffer.writeUInt32LE(threeHundredthsOfSecond, 5);
-      yield buffer;
+    let date;
+    if (options.useUTC) {
+      date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
     } else {
-      yield Buffer.from([0x00]);
+      date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
     }
+
+    let days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+
+    let milliseconds, threeHundredthsOfSecond;
+    if (options.useUTC) {
+      let seconds = value.getUTCHours() * 60 * 60;
+      seconds += value.getUTCMinutes() * 60;
+      seconds += value.getUTCSeconds();
+      milliseconds = (seconds * 1000) + value.getUTCMilliseconds();
+    } else {
+      let seconds = value.getHours() * 60 * 60;
+      seconds += value.getMinutes() * 60;
+      seconds += value.getSeconds();
+      milliseconds = (seconds * 1000) + value.getMilliseconds();
+    }
+
+    threeHundredthsOfSecond = milliseconds / (3 + (1 / 3));
+    threeHundredthsOfSecond = Math.round(threeHundredthsOfSecond);
+
+    // 25920000 equals one day
+    if (threeHundredthsOfSecond === 25920000) {
+      days += 1;
+      threeHundredthsOfSecond = 0;
+    }
+
+    const buffer = Buffer.alloc(8);
+    buffer.writeInt32LE(days, 0);
+    buffer.writeUInt32LE(threeHundredthsOfSecond, 4);
+    yield buffer;
   },
 
   // TODO: type 'any' needs to be revisited.

--- a/src/data-types/datetime2.ts
+++ b/src/data-types/datetime2.ts
@@ -3,6 +3,7 @@ import { ChronoUnit, LocalDate } from '@js-joda/core';
 import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
 const EPOCH_DATE = LocalDate.ofYearDay(1, 1);
+const NULL_LENGTH = Buffer.from([0x00]);
 
 const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']> } = {
   id: 0x2A,
@@ -27,58 +28,78 @@ const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']
     return Buffer.from([this.id, parameter.scale!]);
   },
 
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
+    }
+
+    switch (parameter.scale!) {
+      case 0:
+      case 1:
+      case 2:
+        return Buffer.from([0x06]);
+
+      case 3:
+      case 4:
+        return Buffer.from([0x07]);
+
+      case 5:
+      case 6:
+      case 7:
+        return Buffer.from([0x08]);
+
+      default:
+        throw new Error('invalid scale');
+    }
+  },
+
   *generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
     const value = parameter.value;
     let scale = parameter.scale;
 
-    if (value != null) {
-      const buffer = new WritableTrackingBuffer(16);
-      scale = scale!;
+    const buffer = new WritableTrackingBuffer(16);
+    scale = scale!;
 
-      let timestamp;
-      if (options.useUTC) {
-        timestamp = ((value.getUTCHours() * 60 + value.getUTCMinutes()) * 60 + value.getUTCSeconds()) * 1000 + value.getUTCMilliseconds();
-      } else {
-        timestamp = ((value.getHours() * 60 + value.getMinutes()) * 60 + value.getSeconds()) * 1000 + value.getMilliseconds();
-      }
-      timestamp = timestamp * Math.pow(10, scale - 3);
-      timestamp += (value.nanosecondDelta != null ? value.nanosecondDelta : 0) * Math.pow(10, scale);
-      timestamp = Math.round(timestamp);
-
-      switch (scale) {
-        case 0:
-        case 1:
-        case 2:
-          buffer.writeUInt8(6);
-          buffer.writeUInt24LE(timestamp);
-          break;
-        case 3:
-        case 4:
-          buffer.writeUInt8(7);
-          buffer.writeUInt32LE(timestamp);
-          break;
-        case 5:
-        case 6:
-        case 7:
-          buffer.writeUInt8(8);
-          buffer.writeUInt40LE(timestamp);
-      }
-
-      let date;
-      if (options.useUTC) {
-        date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
-      } else {
-        date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
-      }
-
-      const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
-      buffer.writeUInt24LE(days);
-      yield buffer.data;
+    let timestamp;
+    if (options.useUTC) {
+      timestamp = ((value.getUTCHours() * 60 + value.getUTCMinutes()) * 60 + value.getUTCSeconds()) * 1000 + value.getUTCMilliseconds();
     } else {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0);
-      yield buffer.data;
+      timestamp = ((value.getHours() * 60 + value.getMinutes()) * 60 + value.getSeconds()) * 1000 + value.getMilliseconds();
     }
+    timestamp = timestamp * Math.pow(10, scale - 3);
+    timestamp += (value.nanosecondDelta != null ? value.nanosecondDelta : 0) * Math.pow(10, scale);
+    timestamp = Math.round(timestamp);
+
+    switch (scale) {
+      case 0:
+      case 1:
+      case 2:
+        buffer.writeUInt24LE(timestamp);
+        break;
+      case 3:
+      case 4:
+        buffer.writeUInt32LE(timestamp);
+        break;
+      case 5:
+      case 6:
+      case 7:
+        buffer.writeUInt40LE(timestamp);
+    }
+
+    let date;
+    if (options.useUTC) {
+      date = LocalDate.of(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
+    } else {
+      date = LocalDate.of(value.getFullYear(), value.getMonth() + 1, value.getDate());
+    }
+
+    const days = EPOCH_DATE.until(date, ChronoUnit.DAYS);
+    buffer.writeUInt24LE(days);
+    yield buffer.data;
   },
 
   validate: function(value): null | number | TypeError {

--- a/src/data-types/datetimen.ts
+++ b/src/data-types/datetimen.ts
@@ -13,6 +13,10 @@ const DateTimeN: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/decimal.ts
+++ b/src/data-types/decimal.ts
@@ -2,6 +2,8 @@ import { DataType } from '../data-type';
 import DecimalN from './decimaln';
 import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const Decimal: DataType & { resolvePrecision: NonNullable<DataType['resolvePrecision']>, resolveScale: NonNullable<DataType['resolveScale']> } = {
   id: 0x37,
   type: 'DECIMAL',
@@ -44,41 +46,54 @@ const Decimal: DataType & { resolvePrecision: NonNullable<DataType['resolvePreci
     return Buffer.from([DecimalN.id, precision, parameter.precision!, parameter.scale!]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const sign = parameter.value < 0 ? 0 : 1;
-      const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale!)));
-      if (parameter.precision! <= 9) {
-        const buffer = Buffer.alloc(6);
-        let offset = 0;
-        offset = buffer.writeUInt8(5, offset);
-        offset = buffer.writeUInt8(sign, offset);
-        buffer.writeUInt32LE(value, offset);
-        yield buffer;
-      } else if (parameter.precision! <= 19) {
-        const buffer = new WritableTrackingBuffer(10);
-        buffer.writeUInt8(9);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt64LE(value);
-        yield buffer.data;
-      } else if (parameter.precision! <= 28) {
-        const buffer = new WritableTrackingBuffer(14);
-        buffer.writeUInt8(13);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt64LE(value);
-        buffer.writeUInt32LE(0x00000000);
-        yield buffer.data;
-      } else {
-        const buffer = new WritableTrackingBuffer(18);
-        buffer.writeUInt8(17);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt64LE(value);
-        buffer.writeUInt32LE(0x00000000);
-        buffer.writeUInt32LE(0x00000000);
-        yield buffer.data;
-      }
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
+    }
+
+    const precision = parameter.precision!;
+    if (precision <= 9) {
+      return Buffer.from([0x05]);
+    } else if (precision <= 19) {
+      return Buffer.from([0x09]);
+    } else if (precision <= 28) {
+      return Buffer.from([0x0D]);
     } else {
-      yield Buffer.from([0x00]);
+      return Buffer.from([0x11]);
+    }
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const sign = parameter.value < 0 ? 0 : 1;
+    const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale!)));
+    const precision = parameter.precision!;
+    if (precision <= 9) {
+      const buffer = Buffer.alloc(5);
+      buffer.writeUInt8(sign, 0);
+      buffer.writeUInt32LE(value, 1);
+      yield buffer;
+    } else if (precision <= 19) {
+      const buffer = new WritableTrackingBuffer(9);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(value);
+      yield buffer.data;
+    } else if (precision <= 28) {
+      const buffer = new WritableTrackingBuffer(13);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(value);
+      buffer.writeUInt32LE(0x00000000);
+      yield buffer.data;
+    } else {
+      const buffer = new WritableTrackingBuffer(17);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(value);
+      buffer.writeUInt32LE(0x00000000);
+      buffer.writeUInt32LE(0x00000000);
+      yield buffer.data;
     }
   },
 

--- a/src/data-types/decimaln.ts
+++ b/src/data-types/decimaln.ts
@@ -13,6 +13,10 @@ const DecimalN: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/float.ts
+++ b/src/data-types/float.ts
@@ -1,6 +1,8 @@
 import { DataType } from '../data-type';
 import FloatN from './floatn';
 
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const Float: DataType = {
   id: 0x3E,
   type: 'FLT8',
@@ -14,15 +16,22 @@ const Float: DataType = {
     return Buffer.from([FloatN.id, 0x08]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(9);
-      buffer.writeUInt8(8, 0);
-      buffer.writeDoubleLE(parseFloat(parameter.value), 1);
-      yield buffer;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return Buffer.from([0x08]);
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(8);
+    buffer.writeDoubleLE(parseFloat(parameter.value), 0);
+    yield buffer;
   },
 
   validate: function(value): number | null | TypeError {

--- a/src/data-types/floatn.ts
+++ b/src/data-types/floatn.ts
@@ -13,6 +13,10 @@ const FloatN: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/image.ts
+++ b/src/data-types/image.ts
@@ -1,5 +1,7 @@
 import { DataType } from '../data-type';
 
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]);
+
 const Image: DataType = {
   id: 0x22,
   type: 'IMAGE',
@@ -26,18 +28,22 @@ const Image: DataType = {
     return buffer;
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(4);
-      buffer.writeInt32LE(parameter.length!, 0);
-      yield buffer;
-
-      yield parameter.value;
-    } else {
-      const buffer = Buffer.alloc(4);
-      buffer.writeInt32LE(parameter.length!, 0);
-      yield buffer;
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    const buffer = Buffer.alloc(4);
+    buffer.writeInt32LE(parameter.length!, 0);
+    return buffer;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    yield parameter.value;
   },
 
   validate: function(value): null | TypeError | Buffer {

--- a/src/data-types/int.ts
+++ b/src/data-types/int.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import IntN from './intn';
 
+const NULL_LENGTH = Buffer.from([0x00]);
+const DATA_LENGTH = Buffer.from([0x04]);
+
 const Int: DataType = {
   id: 0x38,
   type: 'INT4',
@@ -14,18 +17,22 @@ const Int: DataType = {
     return Buffer.from([IntN.id, 0x04]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(1);
-      buffer.writeUInt8(4, 0);
-      yield buffer;
-
-      const buffer2 = Buffer.alloc(4);
-      buffer2.writeInt32LE(Number(parameter.value), 0);
-      yield buffer2;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(4);
+    buffer.writeInt32LE(Number(parameter.value), 0);
+    yield buffer;
   },
 
   validate: function(value): number | null | TypeError {

--- a/src/data-types/intn.ts
+++ b/src/data-types/intn.ts
@@ -13,6 +13,10 @@ const IntN: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/money.ts
+++ b/src/data-types/money.ts
@@ -4,6 +4,9 @@ import MoneyN from './moneyn';
 const SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
 const SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
 
+const NULL_LENGTH = Buffer.from([0x00]);
+const DATA_LENGTH = Buffer.from([0x08]);
+
 const Money: DataType = {
   id: 0x3C,
   type: 'MONEY',
@@ -17,25 +20,25 @@ const Money: DataType = {
     return Buffer.from([MoneyN.id, 0x08]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(1);
-      buffer.writeUInt8(8, 0);
-      yield buffer;
-
-      const value = parameter.value * 10000;
-
-      const buffer2 = Buffer.alloc(4);
-      buffer2.writeInt32LE(Math.floor(value * SHIFT_RIGHT_32), 0);
-      yield buffer2;
-
-      const buffer3 = Buffer.alloc(4);
-      buffer3.writeInt32LE(value & -1, 0);
-      yield buffer3;
-
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const value = parameter.value * 10000;
+
+    const buffer = Buffer.alloc(8);
+    buffer.writeInt32LE(Math.floor(value * SHIFT_RIGHT_32), 0);
+    buffer.writeInt32LE(value & -1, 4);
+    yield buffer;
   },
 
   validate: function(value): number | null | TypeError {

--- a/src/data-types/moneyn.ts
+++ b/src/data-types/moneyn.ts
@@ -13,6 +13,10 @@ const MoneyN: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/ntext.ts
+++ b/src/data-types/ntext.ts
@@ -15,6 +15,10 @@ const NText: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/null.ts
+++ b/src/data-types/null.ts
@@ -13,6 +13,10 @@ const Null: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/numeric.ts
+++ b/src/data-types/numeric.ts
@@ -2,6 +2,8 @@ import { DataType } from '../data-type';
 import NumericN from './numericn';
 import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const Numeric: DataType & { resolveScale: NonNullable<DataType['resolveScale']>, resolvePrecision: NonNullable<DataType['resolvePrecision']> } = {
   id: 0x3F,
   type: 'NUMERIC',
@@ -44,41 +46,53 @@ const Numeric: DataType & { resolveScale: NonNullable<DataType['resolveScale']>,
     return Buffer.from([NumericN.id, precision, parameter.precision!, parameter.scale!]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const sign = parameter.value < 0 ? 0 : 1;
-      const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale!)));
-      if (parameter.precision! <= 9) {
-        const buffer = Buffer.alloc(6);
-        let offset = 0;
-        offset = buffer.writeUInt8(5, offset);
-        offset = buffer.writeUInt8(sign, offset);
-        buffer.writeUInt32LE(value, offset);
-        yield buffer;
-      } else if (parameter.precision! <= 19) {
-        const buffer = new WritableTrackingBuffer(10);
-        buffer.writeUInt8(9);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt64LE(value);
-        yield buffer.data;
-      } else if (parameter.precision! <= 28) {
-        const buffer = new WritableTrackingBuffer(14);
-        buffer.writeUInt8(13);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt64LE(value);
-        buffer.writeUInt32LE(0x00000000);
-        yield buffer.data;
-      } else {
-        const buffer = new WritableTrackingBuffer(18);
-        buffer.writeUInt8(17);
-        buffer.writeUInt8(sign);
-        buffer.writeUInt64LE(value);
-        buffer.writeUInt32LE(0x00000000);
-        buffer.writeUInt32LE(0x00000000);
-        yield buffer.data;
-      }
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
+    }
+
+    const precision = parameter.precision!;
+    if (precision <= 9) {
+      return Buffer.from([0x05]);
+    } else if (precision <= 19) {
+      return Buffer.from([0x09]);
+    } else if (precision <= 28) {
+      return Buffer.from([0x0D]);
     } else {
-      yield Buffer.from([0x00]);
+      return Buffer.from([0x11]);
+    }
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const sign = parameter.value < 0 ? 0 : 1;
+    const value = Math.round(Math.abs(parameter.value * Math.pow(10, parameter.scale!)));
+    if (parameter.precision! <= 9) {
+      const buffer = Buffer.alloc(5);
+      buffer.writeUInt8(sign, 0);
+      buffer.writeUInt32LE(value, 1);
+      yield buffer;
+    } else if (parameter.precision! <= 19) {
+      const buffer = new WritableTrackingBuffer(10);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(value);
+      yield buffer.data;
+    } else if (parameter.precision! <= 28) {
+      const buffer = new WritableTrackingBuffer(14);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(value);
+      buffer.writeUInt32LE(0x00000000);
+      yield buffer.data;
+    } else {
+      const buffer = new WritableTrackingBuffer(18);
+      buffer.writeUInt8(sign);
+      buffer.writeUInt64LE(value);
+      buffer.writeUInt32LE(0x00000000);
+      buffer.writeUInt32LE(0x00000000);
+      yield buffer.data;
     }
   },
 

--- a/src/data-types/numericn.ts
+++ b/src/data-types/numericn.ts
@@ -13,6 +13,10 @@ const NumericN: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/nvarchar.ts
+++ b/src/data-types/nvarchar.ts
@@ -1,9 +1,11 @@
 import { DataType } from '../data-type';
 
-const NULL = (1 << 16) - 1;
 const MAX = (1 << 16) - 1;
 const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const PLP_TERMINATOR = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF]);
+const MAX_NULL_LENGTH = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
 
 const NVarChar: { maximumLength: number } & DataType = {
   id: 0xE7,
@@ -60,64 +62,70 @@ const NVarChar: { maximumLength: number } & DataType = {
     return buffer;
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      let value = parameter.value;
-
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
       if (parameter.length! <= this.maximumLength) {
-        let length;
-        if (value instanceof Buffer) {
-          length = value.length;
+        return NULL_LENGTH;
+      } else {
+        return MAX_NULL_LENGTH;
+      }
+    }
 
-          const buffer = Buffer.alloc(2);
-          buffer.writeUInt16LE(length, 0);
+    let value = parameter.value;
+    if (parameter.length! <= this.maximumLength) {
+      let length;
+      if (value instanceof Buffer) {
+        length = value.length;
+      } else {
+        value = value.toString();
+        length = Buffer.byteLength(value, 'ucs2');
+      }
+
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(length, 0);
+      return buffer;
+    } else {
+      return UNKNOWN_PLP_LEN;
+    }
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    let value = parameter.value;
+
+    if (parameter.length! <= this.maximumLength) {
+      if (value instanceof Buffer) {
+        yield value;
+      } else {
+        value = value.toString();
+        yield Buffer.from(value, 'ucs2');
+      }
+    } else {
+      if (value instanceof Buffer) {
+        const length = value.length;
+
+        if (length > 0) {
+          const buffer = Buffer.alloc(4);
+          buffer.writeUInt32LE(length, 0);
           yield buffer;
-
           yield value;
-        } else {
-          value = value.toString();
-          length = Buffer.byteLength(value, 'ucs2');
-
-          const buffer = Buffer.alloc(2);
-          buffer.writeUInt16LE(length, 0);
-          yield buffer;
-
-          yield Buffer.from(value, 'ucs2');
         }
       } else {
-        yield UNKNOWN_PLP_LEN;
+        value = value.toString();
+        const length = Buffer.byteLength(value, 'ucs2');
 
-        if (value instanceof Buffer) {
-          const length = value.length;
-          if (length > 0) {
-            const buffer = Buffer.alloc(4);
-            buffer.writeUInt32LE(length, 0);
-            yield buffer;
-            yield value;
-          }
-        } else {
-          value = value.toString();
-          const length = Buffer.byteLength(value, 'ucs2');
-
-          if (length > 0) {
-            const buffer = Buffer.alloc(4);
-            buffer.writeUInt32LE(length, 0);
-            yield buffer;
-            yield Buffer.from(value, 'ucs2');
-          }
+        if (length > 0) {
+          const buffer = Buffer.alloc(4);
+          buffer.writeUInt32LE(length, 0);
+          yield buffer;
+          yield Buffer.from(value, 'ucs2');
         }
-
-        yield PLP_TERMINATOR;
       }
-    } else if (parameter.length! <= this.maximumLength) {
-      const buffer = Buffer.alloc(2);
-      buffer.writeUInt16LE(NULL, 0);
-      yield buffer;
-    } else {
-      const buffer = Buffer.alloc(8);
-      const offset = buffer.writeUInt32LE(0xFFFFFFFF, 0);
-      buffer.writeUInt32LE(0xFFFFFFFF, offset);
-      yield buffer;
+
+      yield PLP_TERMINATOR;
     }
   },
 

--- a/src/data-types/real.ts
+++ b/src/data-types/real.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import FloatN from './floatn';
 
+const NULL_LENGTH = Buffer.from([0x00]);
+const DATA_LENGTH = Buffer.from([0x04]);
+
 const Real: DataType = {
   id: 0x3B,
   type: 'FLT4',
@@ -14,16 +17,22 @@ const Real: DataType = {
     return Buffer.from([FloatN.id, 0x04]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(5);
-      let offset = 0;
-      offset = buffer.writeUInt8(4, offset);
-      buffer.writeFloatLE(parseFloat(parameter.value), offset);
-      yield buffer;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(4);
+    buffer.writeFloatLE(parseFloat(parameter.value), 0);
+    yield buffer;
   },
 
   validate: function(value): null | number | TypeError {

--- a/src/data-types/smalldatetime.ts
+++ b/src/data-types/smalldatetime.ts
@@ -4,6 +4,9 @@ import DateTimeN from './datetimen';
 const EPOCH_DATE = new Date(1900, 0, 1);
 const UTC_EPOCH_DATE = new Date(Date.UTC(1900, 0, 1));
 
+const DATA_LENGTH = Buffer.from([0x04]);
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const SmallDateTime: DataType = {
   id: 0x3A,
   type: 'DATETIM4',
@@ -17,28 +20,35 @@ const SmallDateTime: DataType = {
     return Buffer.from([DateTimeN.id, 0x04]);
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(5);
-
-      let days, dstDiff, minutes;
-      if (options.useUTC) {
-        days = Math.floor((parameter.value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
-        minutes = (parameter.value.getUTCHours() * 60) + parameter.value.getUTCMinutes();
-      } else {
-        dstDiff = -(parameter.value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
-        days = Math.floor((parameter.value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
-        minutes = (parameter.value.getHours() * 60) + parameter.value.getMinutes();
-      }
-
-      buffer.writeUInt8(4, 0);
-      buffer.writeUInt16LE(days, 1);
-      buffer.writeUInt16LE(minutes, 3);
-
-      yield buffer;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  generateParameterData: function*(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(4);
+
+    let days, dstDiff, minutes;
+    if (options.useUTC) {
+      days = Math.floor((parameter.value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24));
+      minutes = (parameter.value.getUTCHours() * 60) + parameter.value.getUTCMinutes();
+    } else {
+      dstDiff = -(parameter.value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000;
+      days = Math.floor((parameter.value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24));
+      minutes = (parameter.value.getHours() * 60) + parameter.value.getMinutes();
+    }
+
+    buffer.writeUInt16LE(days, 0);
+    buffer.writeUInt16LE(minutes, 2);
+
+    yield buffer;
   },
 
   validate: function(value): null | Date | TypeError {

--- a/src/data-types/smallint.ts
+++ b/src/data-types/smallint.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import IntN from './intn';
 
+const DATA_LENGTH = Buffer.from([0x02]);
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const SmallInt: DataType = {
   id: 0x34,
   type: 'INT2',
@@ -14,15 +17,22 @@ const SmallInt: DataType = {
     return Buffer.from([IntN.id, 0x02]);
   },
 
-  generateParameterData: function*(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(3);
-      buffer.writeUInt8(2, 0);
-      buffer.writeInt16LE(Number(parameter.value), 1);
-      yield buffer;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(2);
+    buffer.writeInt16LE(Number(parameter.value), 0);
+    yield buffer;
   },
 
   validate: function(value): null | number | TypeError {

--- a/src/data-types/smallmoney.ts
+++ b/src/data-types/smallmoney.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import MoneyN from './moneyn';
 
+const DATA_LENGTH = Buffer.from([0x04]);
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const SmallMoney: DataType = {
   id: 0x7A,
   type: 'MONEY4',
@@ -14,15 +17,22 @@ const SmallMoney: DataType = {
     return Buffer.from([MoneyN.id, 0x04]);
   },
 
-  generateParameterData: function*(parameter) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(5);
-      buffer.writeUInt8(4, 0);
-      buffer.writeInt32LE(parameter.value * 10000, 1);
-      yield buffer;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(4);
+    buffer.writeInt32LE(parameter.value * 10000, 0);
+    yield buffer;
   },
 
   validate: function(value): null | number | TypeError {

--- a/src/data-types/sql-variant.ts
+++ b/src/data-types/sql-variant.ts
@@ -13,6 +13,10 @@ const Variant: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/text.ts
+++ b/src/data-types/text.ts
@@ -1,5 +1,7 @@
 import { DataType } from '../data-type';
 
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]);
+
 const Text: DataType = {
   id: 0x23,
   type: 'TEXT',
@@ -22,26 +24,29 @@ const Text: DataType = {
   },
 
   generateTypeInfo(parameter, _options) {
-    const buffer = Buffer.alloc(5);
+    const buffer = Buffer.alloc(10);
     buffer.writeUInt8(this.id, 0);
     buffer.writeInt32LE(parameter.length!, 1);
+    // TODO: Collation handling
+    return buffer;
+  },
+
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
+    }
+
+    const buffer = Buffer.alloc(4);
+    buffer.writeInt32LE(parameter.length!, 0);
     return buffer;
   },
 
   generateParameterData: function*(parameter, options) {
-    yield Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00]);
-
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(4);
-      buffer.writeInt32LE(parameter.length!, 0);
-      yield buffer;
-
-      yield Buffer.from(parameter.value.toString(), 'ascii');
-    } else {
-      const buffer = Buffer.alloc(4);
-      buffer.writeInt32LE(parameter.length!, 0);
-      yield buffer;
+    if (parameter.value == null) {
+      return;
     }
+
+    yield Buffer.from(parameter.value.toString(), 'ascii');
   },
 
   validate: function(value): string | null | TypeError {

--- a/src/data-types/time.ts
+++ b/src/data-types/time.ts
@@ -1,6 +1,8 @@
 import { DataType } from '../data-type';
 import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const Time: DataType = {
   id: 0x29,
   type: 'TIMEN',
@@ -24,45 +26,64 @@ const Time: DataType = {
     return Buffer.from([this.id, parameter.scale!]);
   },
 
-  generateParameterData: function*(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(16);
-      const time = parameter.value;
-
-      let timestamp;
-      if (options.useUTC) {
-        timestamp = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
-      } else {
-        timestamp = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
-      }
-
-      timestamp = timestamp * Math.pow(10, parameter.scale! - 3);
-      timestamp += (parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0) * Math.pow(10, parameter.scale!);
-      timestamp = Math.round(timestamp);
-
-      switch (parameter.scale) {
-        case 0:
-        case 1:
-        case 2:
-          buffer.writeUInt8(3);
-          buffer.writeUInt24LE(timestamp);
-          break;
-        case 3:
-        case 4:
-          buffer.writeUInt8(4);
-          buffer.writeUInt32LE(timestamp);
-          break;
-        case 5:
-        case 6:
-        case 7:
-          buffer.writeUInt8(5);
-          buffer.writeUInt40LE(timestamp);
-      }
-
-      yield buffer.data;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    switch (parameter.scale) {
+      case 0:
+      case 1:
+      case 2:
+        return Buffer.from([0x03]);
+      case 3:
+      case 4:
+        return Buffer.from([0x04]);
+      case 5:
+      case 6:
+      case 7:
+        return Buffer.from([0x05]);
+      default:
+        throw new Error('invalid scale');
+    }
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = new WritableTrackingBuffer(16);
+    const time = parameter.value;
+
+    let timestamp;
+    if (options.useUTC) {
+      timestamp = ((time.getUTCHours() * 60 + time.getUTCMinutes()) * 60 + time.getUTCSeconds()) * 1000 + time.getUTCMilliseconds();
+    } else {
+      timestamp = ((time.getHours() * 60 + time.getMinutes()) * 60 + time.getSeconds()) * 1000 + time.getMilliseconds();
+    }
+
+    timestamp = timestamp * Math.pow(10, parameter.scale! - 3);
+    timestamp += (parameter.value.nanosecondDelta != null ? parameter.value.nanosecondDelta : 0) * Math.pow(10, parameter.scale!);
+    timestamp = Math.round(timestamp);
+
+    switch (parameter.scale) {
+      case 0:
+      case 1:
+      case 2:
+        buffer.writeUInt24LE(timestamp);
+        break;
+      case 3:
+      case 4:
+        buffer.writeUInt32LE(timestamp);
+        break;
+      case 5:
+      case 6:
+      case 7:
+        buffer.writeUInt40LE(timestamp);
+    }
+
+    yield buffer.data;
   },
 
   validate: function(value): null | number | TypeError | Date {

--- a/src/data-types/tinyint.ts
+++ b/src/data-types/tinyint.ts
@@ -1,6 +1,9 @@
 import { DataType } from '../data-type';
 import IntN from './intn';
 
+const DATA_LENGTH = Buffer.from([0x01]);
+const NULL_LENGTH = Buffer.from([0x00]);
+
 const TinyInt: DataType = {
   id: 0x30,
   type: 'INT1',
@@ -14,16 +17,22 @@ const TinyInt: DataType = {
     return Buffer.from([IntN.id, 0x01]);
   },
 
-  generateParameterData: function*(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = Buffer.alloc(2);
-      let offset = 0;
-      offset = buffer.writeUInt8(1, offset);
-      buffer.writeUInt8(Number(parameter.value), offset);
-      yield buffer;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    const buffer = Buffer.alloc(1);
+    buffer.writeUInt8(Number(parameter.value), 0);
+    yield buffer;
   },
 
   validate: function(value): number | null | TypeError {

--- a/src/data-types/udt.ts
+++ b/src/data-types/udt.ts
@@ -13,6 +13,10 @@ const UDT: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/data-types/uniqueidentifier.ts
+++ b/src/data-types/uniqueidentifier.ts
@@ -1,6 +1,8 @@
 import { DataType } from '../data-type';
 import { guidToArray } from '../guid-parser';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
+
+const NULL_LENGTH = Buffer.from([0x00]);
+const DATA_LENGTH = Buffer.from([0x10]);
 
 const UniqueIdentifier: DataType = {
   id: 0x24,
@@ -19,15 +21,20 @@ const UniqueIdentifier: DataType = {
     return Buffer.from([this.id, 0x10]);
   },
 
-  generateParameterData: function*(parameter, options) {
-    if (parameter.value != null) {
-      const buffer = new WritableTrackingBuffer(1);
-      buffer.writeUInt8(0x10);
-      buffer.writeBuffer(Buffer.from(guidToArray(parameter.value)));
-      yield buffer.data;
-    } else {
-      yield Buffer.from([0x00]);
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      return NULL_LENGTH;
     }
+
+    return DATA_LENGTH;
+  },
+
+  generateParameterData: function*(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    yield Buffer.from(guidToArray(parameter.value));
   },
 
   validate: function(value): string | null | TypeError {

--- a/src/data-types/varbinary.ts
+++ b/src/data-types/varbinary.ts
@@ -1,10 +1,11 @@
 import { DataType } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
-const NULL = (1 << 16) - 1;
 const MAX = (1 << 16) - 1;
 const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const PLP_TERMINATOR = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF]);
+const MAX_NULL_LENGTH = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
 
 const VarBinary: { maximumLength: number } & DataType = {
   id: 0xA5,
@@ -56,19 +57,54 @@ const VarBinary: { maximumLength: number } & DataType = {
     return buffer;
   },
 
-  *generateParameterData(parameter, options) {
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      if (parameter.length! <= this.maximumLength) {
+        return NULL_LENGTH;
+      } else {
+        return MAX_NULL_LENGTH;
+      }
+    }
+
+    let value = parameter.value;
+    if (!Buffer.isBuffer(value)) {
+      value = value.toString();
+    }
+
+    const length = Buffer.byteLength(value, 'ucs2');
+
+    if (parameter.length! <= this.maximumLength) {
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(length, 0);
+      return buffer;
+    } else { // writePLPBody
+      return UNKNOWN_PLP_LEN;
+    }
+  },
+
+  * generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
     let value = parameter.value;
 
-    if (value != null) {
+    if (parameter.length! <= this.maximumLength) {
+      if (Buffer.isBuffer(value)) {
+        yield value;
+      } else {
+        yield Buffer.from(value.toString(), 'ucs2');
+      }
+    } else { // writePLPBody
       if (!Buffer.isBuffer(value)) {
         value = value.toString();
       }
 
       const length = Buffer.byteLength(value, 'ucs2');
 
-      if (parameter.length! <= this.maximumLength) {
-        const buffer = Buffer.alloc(2);
-        buffer.writeUInt16LE(length, 0);
+      if (length > 0) {
+        const buffer = Buffer.alloc(4);
+        buffer.writeUInt32LE(length, 0);
         yield buffer;
 
         if (Buffer.isBuffer(value)) {
@@ -76,33 +112,9 @@ const VarBinary: { maximumLength: number } & DataType = {
         } else {
           yield Buffer.from(value, 'ucs2');
         }
-      } else { // writePLPBody
-        yield UNKNOWN_PLP_LEN;
-
-        if (length > 0) {
-          const buffer = Buffer.alloc(4);
-          buffer.writeUInt32LE(length, 0);
-          yield buffer;
-
-          if (Buffer.isBuffer(value)) {
-            yield value;
-          } else {
-            yield Buffer.from(value, 'ucs2');
-          }
-        }
-
-        yield PLP_TERMINATOR;
       }
 
-    } else if (parameter.length! <= this.maximumLength) {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(NULL);
-      yield buffer.data;
-    } else {
-      const buffer = new WritableTrackingBuffer(8);
-      buffer.writeUInt32LE(0xFFFFFFFF);
-      buffer.writeUInt32LE(0xFFFFFFFF);
-      yield buffer.data;
+      yield PLP_TERMINATOR;
     }
   },
 

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -1,10 +1,11 @@
 import { DataType } from '../data-type';
-import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer';
 
-const NULL = (1 << 16) - 1;
 const MAX = (1 << 16) - 1;
 const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 const PLP_TERMINATOR = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+
+const NULL_LENGTH = Buffer.from([0xFF, 0xFF]);
+const MAX_NULL_LENGTH = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
 
 const VarChar: { maximumLength: number } & DataType = {
   id: 0xA7,
@@ -62,19 +63,54 @@ const VarChar: { maximumLength: number } & DataType = {
     return buffer;
   },
 
-  *generateParameterData(parameter, options) {
-    if (parameter.value != null) {
-      let value = parameter.value;
+  generateParameterLength(parameter, options) {
+    if (parameter.value == null) {
+      if (parameter.length! <= this.maximumLength) {
+        return NULL_LENGTH;
+      } else {
+        return MAX_NULL_LENGTH;
+      }
+    }
 
-      const length = Buffer.byteLength(value, 'ascii');
-
+    let value = parameter.value;
+    if (parameter.length! <= this.maximumLength) {
       if (!Buffer.isBuffer(value)) {
         value = value.toString();
       }
 
-      if (parameter.length! <= this.maximumLength) {
-        const buffer = Buffer.alloc(2);
-        buffer.writeUInt16LE(length, 0);
+      const length = Buffer.byteLength(value, 'ascii');
+
+      const buffer = Buffer.alloc(2);
+      buffer.writeUInt16LE(length, 0);
+      return buffer;
+    } else {
+      return UNKNOWN_PLP_LEN;
+    }
+  },
+
+  *generateParameterData(parameter, options) {
+    if (parameter.value == null) {
+      return;
+    }
+
+    let value = parameter.value;
+
+    if (!Buffer.isBuffer(value)) {
+      value = value.toString();
+    }
+
+    if (parameter.length! <= this.maximumLength) {
+      if (Buffer.isBuffer(value)) {
+        yield value;
+      } else {
+        yield Buffer.from(value, 'ascii');
+      }
+    } else {
+      const length = Buffer.byteLength(value, 'ascii');
+
+      if (length > 0) {
+        const buffer = Buffer.alloc(4);
+        buffer.writeUInt32LE(length, 0);
         yield buffer;
 
         if (Buffer.isBuffer(value)) {
@@ -82,32 +118,9 @@ const VarChar: { maximumLength: number } & DataType = {
         } else {
           yield Buffer.from(value, 'ascii');
         }
-      } else {
-        yield UNKNOWN_PLP_LEN;
-
-        if (length > 0) {
-          const buffer = Buffer.alloc(4);
-          buffer.writeUInt32LE(length, 0);
-          yield buffer;
-
-          if (Buffer.isBuffer(value)) {
-            yield value;
-          } else {
-            yield Buffer.from(value, 'ascii');
-          }
-        }
-
-        yield PLP_TERMINATOR;
       }
-    } else if (parameter.length! <= this.maximumLength) {
-      const buffer = new WritableTrackingBuffer(2);
-      buffer.writeUInt16LE(NULL);
-      yield buffer.data;
-    } else {
-      const buffer = new WritableTrackingBuffer(8);
-      buffer.writeUInt32LE(0xFFFFFFFF);
-      buffer.writeUInt32LE(0xFFFFFFFF);
-      yield buffer.data;
+
+      yield PLP_TERMINATOR;
     }
   },
 

--- a/src/data-types/xml.ts
+++ b/src/data-types/xml.ts
@@ -13,6 +13,10 @@ const XML: DataType = {
     throw new Error('not implemented');
   },
 
+  generateParameterLength() {
+    throw new Error('not implemented');
+  },
+
   generateParameterData() {
     throw new Error('not implemented');
   },

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -56,7 +56,7 @@ class RpcRequestPayload implements Iterable<Buffer> {
 
     const parameters = this.request.parameters;
     for (let i = 0; i < parameters.length; i++) {
-      yield* this.generateParameterData(parameters[i], this.options);
+      yield * this.generateParameterData(parameters[i]);
     }
   }
 
@@ -64,7 +64,7 @@ class RpcRequestPayload implements Iterable<Buffer> {
     return indent + ('RPC Request - ' + this.procedure);
   }
 
-  * generateParameterData(parameter: Parameter, options: any) {
+  * generateParameterData(parameter: Parameter) {
     const buffer = new WritableTrackingBuffer(1 + 2 + Buffer.byteLength(parameter.name, 'ucs-2') + 1);
     buffer.writeBVarchar('@' + parameter.name);
 
@@ -101,7 +101,8 @@ class RpcRequestPayload implements Iterable<Buffer> {
     }
 
     yield type.generateTypeInfo(param, this.options);
-    yield* type.generateParameterData(param, options);
+    yield type.generateParameterLength(param, this.options);
+    yield * type.generateParameterData(param, this.options);
   }
 }
 

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -3,10 +3,17 @@ const TYPES = require('../../src/data-type').typeByName;
 const { assert } = require('chai');
 
 describe('BigInt', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.BigInt.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.BigInt.generateParameterLength({ value: 123 }), Buffer.from([0x08]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 123456789;
-      const expected = Buffer.from('0815cd5b0700000000', 'hex');
+      const expected = Buffer.from('15cd5b0700000000', 'hex');
 
       const parameterValue = { value, length: 4 };
       const buffer = Buffer.concat([...TYPES.BigInt.generateParameterData(parameterValue, { useUTC: false })]);
@@ -16,7 +23,7 @@ describe('BigInt', function() {
 
     it('correctly converts `string` values', function() {
       const value = '123456789';
-      const expected = Buffer.from('0815cd5b0700000000', 'hex');
+      const expected = Buffer.from('15cd5b0700000000', 'hex');
 
       const parameterValue = { value, length: 4 };
       const buffer = Buffer.concat([...TYPES.BigInt.generateParameterData(parameterValue, { useUTC: false })]);
@@ -26,7 +33,7 @@ describe('BigInt', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from([0x00]);
+      const expected = Buffer.from([]);
 
       const parameterValue = { value, length: 4 };
 
@@ -47,10 +54,18 @@ describe('BigInt', function() {
 });
 
 describe('Binary', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Binary.generateParameterLength({ value: null, length: 10 }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(TYPES.Binary.generateParameterLength({ value: Buffer.alloc(0), length: 0 }), Buffer.from([0x00, 0x00]));
+      assert.deepEqual(TYPES.Binary.generateParameterLength({ value: Buffer.alloc(100), length: 100 }), Buffer.from([0x64, 0x00]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Buffer` values', function() {
       const value = Buffer.from([0x12, 0x34, 0x00, 0x00]);
-      const expected = Buffer.from('040012340000', 'hex');
+      const expected = Buffer.from('12340000', 'hex');
       const parameterValue = { value, length: 4 };
 
       const buffer = Buffer.concat([...TYPES.Binary.generateParameterData(parameterValue, { useUTC: false })]);
@@ -59,7 +74,7 @@ describe('Binary', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('ffff', 'hex');
+      const expected = Buffer.from([]);
       const parameterValue = { value, length: 4 };
 
       const buffer = Buffer.concat([...TYPES.Binary.generateParameterData(parameterValue, { useUTC: false })]);
@@ -81,10 +96,18 @@ describe('Binary', function() {
 });
 
 describe('Bit', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Bit.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Bit.generateParameterLength({ value: true }), Buffer.from([0x01]));
+      assert.deepEqual(TYPES.Bit.generateParameterLength({ value: false }), Buffer.from([0x01]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 1;
-      const expected = Buffer.from('0101', 'hex');
+      const expected = Buffer.from([0x01]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.Bit.generateParameterData(parameterValue, { useUTC: false })]);
@@ -93,7 +116,7 @@ describe('Bit', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.Bit.generateParameterData(parameterValue, { useUTC: false })]);
@@ -102,7 +125,7 @@ describe('Bit', function() {
 
     it('correctly converts `undefined` values', function() {
       const value = undefined;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.Bit.generateParameterData(parameterValue, { useUTC: false })]);
@@ -121,19 +144,25 @@ describe('Bit', function() {
 });
 
 describe('Char', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Char.generateParameterLength({ value: null }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(TYPES.Char.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]) }), Buffer.from([0x04, 0x00]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Buffer` values', function() {
-      const value = Buffer.from([0xff, 0xff, 0xff, 0xff]);
-      const expected = Buffer.from('0400ffffffff', 'hex');
+      const value = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.Char.generateParameterData(parameterValue, { useUTC: false })]);
-      assert.deepEqual(buffer, expected);
+      assert.deepEqual(buffer, value);
     });
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('ffff', 'hex');
+      const expected = Buffer.from([]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.Char.generateParameterData(parameterValue, { useUTC: false })]);
@@ -152,13 +181,20 @@ describe('Char', function() {
 });
 
 describe('Date', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Date.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Date.generateParameterLength({ value: new Date() }), Buffer.from([0x03]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts dates during daylight savings period', function() {
       for (const [value, expectedBuffer] of [
-        [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('03163a0b', 'hex')],
-        [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('03173a0b', 'hex')],
-        [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('03173a0b', 'hex')],
-        [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('03183a0b', 'hex')]
+        [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('163a0b', 'hex')],
+        [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('173a0b', 'hex')],
+        [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('173a0b', 'hex')],
+        [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('183a0b', 'hex')]
       ]) {
         const buffer = Buffer.concat([...TYPES.Date.generateParameterData({ value: value }, { useUTC: false })]);
         assert.deepEqual(buffer, expectedBuffer);
@@ -178,6 +214,13 @@ describe('Date', function() {
 });
 
 describe('DateTime', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.DateTime.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime.generateParameterLength({ value: new Date() }), Buffer.from([0x08]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts dates during daylight savings period', function() {
       for (const testSet of [
@@ -189,7 +232,7 @@ describe('DateTime', function() {
         const parameter = { value: testSet[0] };
         const expectedNoOfDays = testSet[1];
         const buffer = Buffer.concat([...TYPES.DateTime.generateParameterData(parameter, { useUTC: false })]);
-        assert.strictEqual(buffer.readInt32LE(1), expectedNoOfDays);
+        assert.strictEqual(buffer.readInt32LE(0), expectedNoOfDays);
       }
     });
   });
@@ -206,13 +249,35 @@ describe('DateTime', function() {
 });
 
 describe('DateTime2', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 0 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 1 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 2 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 3 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 4 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 5 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 6 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: null, scale: 7 }), Buffer.from([0x00]));
+
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 0 }), Buffer.from([0x06]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 1 }), Buffer.from([0x06]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 2 }), Buffer.from([0x06]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 3 }), Buffer.from([0x07]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 4 }), Buffer.from([0x07]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 5 }), Buffer.from([0x08]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 6 }), Buffer.from([0x08]));
+      assert.deepEqual(TYPES.DateTime2.generateParameterLength({ value: new Date(), scale: 7 }), Buffer.from([0x08]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts dates during daylight savings period', () => {
       for (const [value, expectedBuffer] of [
-        [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('067f5101163a0b', 'hex')],
-        [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('06000000173a0b', 'hex')],
-        [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('067f5101173a0b', 'hex')],
-        [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('06000000183a0b', 'hex')]
+        [new Date(2015, 5, 18, 23, 59, 59), Buffer.from('7f5101163a0b', 'hex')],
+        [new Date(2015, 5, 19, 0, 0, 0), Buffer.from('000000173a0b', 'hex')],
+        [new Date(2015, 5, 19, 23, 59, 59), Buffer.from('7f5101173a0b', 'hex')],
+        [new Date(2015, 5, 20, 0, 0, 0), Buffer.from('000000183a0b', 'hex')]
       ]) {
         const buffer = Buffer.concat([...TYPES.DateTime2.generateParameterData({ value: value, scale: 0 }, { useUTC: false })]);
         assert.deepEqual(buffer, expectedBuffer);
@@ -231,19 +296,41 @@ describe('DateTime2', function() {
 });
 
 describe('DateTimeOffset', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 0 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 1 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 2 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 3 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 4 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 5 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 6 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: null, scale: 7 }), Buffer.from([0x00]));
+
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 0 }), Buffer.from([0x08]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 1 }), Buffer.from([0x08]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 2 }), Buffer.from([0x08]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 3 }), Buffer.from([0x09]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 4 }), Buffer.from([0x09]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 5 }), Buffer.from([0x0A]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 6 }), Buffer.from([0x0A]));
+      assert.deepEqual(TYPES.DateTimeOffset.generateParameterLength({ value: new Date(), scale: 7 }), Buffer.from([0x0A]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Date` values', function() {
       const value = new Date(Date.UTC(2014, 1, 14, 17, 59, 59, 999));
-      const expected = Buffer.from('0820fd002d380b', 'hex');
+      const expected = Buffer.from('20fd002d380b', 'hex');
       const parameterValue = { value, scale: 0 };
 
       const buffer = Buffer.concat([...TYPES.DateTimeOffset.generateParameterData(parameterValue, { useUTC: true })]);
-      assert.deepEqual(buffer.slice(0, 7), expected);
+      assert.deepEqual(buffer.slice(0, 6), expected);
     });
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const parameterValue = { value, scale: 0 };
       const buffer = Buffer.concat([...TYPES.DateTimeOffset.generateParameterData(parameterValue, { useUTC: true })]);
@@ -262,10 +349,34 @@ describe('DateTimeOffset', function() {
 });
 
 describe('Decimal', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      for (let i = 1; i <= 38; i++) {
+        assert.deepEqual(TYPES.Decimal.generateParameterLength({ value: null, precision: i }), Buffer.from([0x00]));
+      }
+
+      for (let i = 1; i <= 9; i++) {
+        assert.deepEqual(TYPES.Decimal.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x05]));
+      }
+
+      for (let i = 10; i <= 19; i++) {
+        assert.deepEqual(TYPES.Decimal.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x09]));
+      }
+
+      for (let i = 20; i <= 28; i++) {
+        assert.deepEqual(TYPES.Decimal.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x0D]));
+      }
+
+      for (let i = 29; i <= 38; i++) {
+        assert.deepEqual(TYPES.Decimal.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x11]));
+      }
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values (Precision <= 9)', function() {
       const value = 1.23;
-      const expected = Buffer.from('050101000000', 'hex');
+      const expected = Buffer.from('0101000000', 'hex');
       const precision = 1;
 
       const type = TYPES.Decimal;
@@ -277,7 +388,7 @@ describe('Decimal', function() {
 
     it('correctly converts `number` values (Precision <= 19)', function() {
       const value = 1.23;
-      const expected = Buffer.from('09010100000000000000', 'hex');
+      const expected = Buffer.from('010100000000000000', 'hex');
       const precision = 15;
 
       const type = TYPES.Decimal;
@@ -289,7 +400,7 @@ describe('Decimal', function() {
 
     it('correctly converts `number` values (Precision <= 28)', function() {
       const value = 1.23;
-      const expected = Buffer.from('0d01010000000000000000000000', 'hex');
+      const expected = Buffer.from('01010000000000000000000000', 'hex');
       const precision = 25;
 
       const type = TYPES.Decimal;
@@ -299,10 +410,9 @@ describe('Decimal', function() {
       assert.deepEqual(buffer, expected);
     });
 
-
     it('correctly converts `number` values (Precision > 28)', function() {
       const value = 1.23;
-      const expected = Buffer.from('110101000000000000000000000000000000', 'hex');
+      const expected = Buffer.from('0101000000000000000000000000000000', 'hex');
       const precision = 30;
 
       const type = TYPES.Decimal;
@@ -342,13 +452,20 @@ describe('Decimal', function() {
 });
 
 describe('Float', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Float.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Float.generateParameterLength({ value: 1.2345 }), Buffer.from([0x08]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 1.2345;
-      const expected = Buffer.from('088d976e1283c0f33f', 'hex');
+      const expected = Buffer.from('8d976e1283c0f33f', 'hex');
 
       const type = TYPES.Float;
-      const parameterValue = { value, scale: 0 };
+      const parameterValue = { value };
 
       const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -356,15 +473,14 @@ describe('Float', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.Float;
-      const parameterValue = { value, scale: 0 };
+      const parameterValue = { value };
 
       const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
     });
-
   });
 
   describe('.generateTypeInfo', function() {
@@ -379,24 +495,30 @@ describe('Float', function() {
 });
 
 describe('Image', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Image.generateParameterLength({ value: null, length: -1 }), Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]));
+      assert.deepEqual(TYPES.Image.generateParameterLength({ value: Buffer.alloc(10), length: 10 }), Buffer.from([0x0A, 0x00, 0x00, 0x00]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Buffer` values', function() {
       const value = Buffer.from('010101', 'hex');
-      const expected = Buffer.from('64000000010101', 'hex');
 
       const type = TYPES.Image;
       const parameterValue = { value, length: 100 };
 
       const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
-      assert.deepEqual(buffer, expected);
+      assert.deepEqual(buffer, value);
     });
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('64000000', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.Image;
-      const parameterValue = { value, length: 100 };
+      const parameterValue = { value, length: -1 };
 
       const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -415,10 +537,17 @@ describe('Image', function() {
 });
 
 describe('Int', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Int.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Int.generateParameterLength({ value: 123 }), Buffer.from([0x04]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 1234;
-      const expected = Buffer.from('04d2040000', 'hex');
+      const expected = Buffer.from('d2040000', 'hex');
 
       const type = TYPES.Int;
       const parameterValue = { value };
@@ -429,7 +558,7 @@ describe('Int', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.Int;
       const parameterValue = { value };
@@ -451,10 +580,17 @@ describe('Int', function() {
 });
 
 describe('Money', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Money.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Money.generateParameterLength({ value: 123 }), Buffer.from([0x08]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 1234;
-      const expected = Buffer.from('0800000000204bbc00', 'hex');
+      const expected = Buffer.from('00000000204bbc00', 'hex');
 
       const type = TYPES.Money;
       const parameterValue = { value };
@@ -465,7 +601,7 @@ describe('Money', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.Money;
       const parameterValue = { value };
@@ -487,21 +623,27 @@ describe('Money', function() {
 });
 
 describe('NChar', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.NChar.generateParameterLength({ value: null }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(TYPES.NChar.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]) }), Buffer.from([0x04, 0x00]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Buffer` values', function() {
       const value = Buffer.from([0xff, 0xff, 0xff, 0xff]);
-      const expected = Buffer.from('0400ffffffff', 'hex');
 
       const type = TYPES.NChar;
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
-      assert.deepEqual(buffer, expected);
+      assert.deepEqual(buffer, value);
     });
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('ffff', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.NChar;
       const parameterValue = { value };
@@ -523,10 +665,34 @@ describe('NChar', function() {
 });
 
 describe('Numeric', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      for (let i = 1; i <= 38; i++) {
+        assert.deepEqual(TYPES.Numeric.generateParameterLength({ value: null, precision: i }), Buffer.from([0x00]));
+      }
+
+      for (let i = 1; i <= 9; i++) {
+        assert.deepEqual(TYPES.Numeric.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x05]));
+      }
+
+      for (let i = 10; i <= 19; i++) {
+        assert.deepEqual(TYPES.Numeric.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x09]));
+      }
+
+      for (let i = 20; i <= 28; i++) {
+        assert.deepEqual(TYPES.Numeric.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x0D]));
+      }
+
+      for (let i = 29; i <= 38; i++) {
+        assert.deepEqual(TYPES.Numeric.generateParameterLength({ value: 1.23, precision: i }), Buffer.from([0x11]));
+      }
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values (Precision <= 9)', function() {
       const value = 1.23;
-      const expected = Buffer.from('050101000000', 'hex');
+      const expected = Buffer.from('0101000000', 'hex');
       const precision = 1;
 
       const type = TYPES.Numeric;
@@ -538,7 +704,7 @@ describe('Numeric', function() {
 
     it('correctly converts `number` values (Precision <= 19)', function() {
       const value = 1.23;
-      const expected = Buffer.from('09010100000000000000', 'hex');
+      const expected = Buffer.from('010100000000000000', 'hex');
       const precision = 15;
 
       const type = TYPES.Numeric;
@@ -550,7 +716,7 @@ describe('Numeric', function() {
 
     it('correctly converts `number` values (Precision <= 28)', function() {
       const value = 1.23;
-      const expected = Buffer.from('0d01010000000000000000000000', 'hex');
+      const expected = Buffer.from('01010000000000000000000000', 'hex');
       const precision = 25;
 
       const type = TYPES.Numeric;
@@ -562,7 +728,7 @@ describe('Numeric', function() {
 
     it('correctly converts `number` values (Precision > 28)', function() {
       const value = 1.23;
-      const expected = Buffer.from('110101000000000000000000000000000000', 'hex');
+      const expected = Buffer.from('0101000000000000000000000000000000', 'hex');
       const precision = 30;
 
       const type = TYPES.Numeric;
@@ -601,10 +767,20 @@ describe('Numeric', function() {
 });
 
 describe('NVarChar', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.NVarChar.generateParameterLength({ value: null, length: 10 }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(TYPES.NVarChar.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]), length: 10 }), Buffer.from([0x04, 0x00]));
+
+      assert.deepEqual(TYPES.NVarChar.generateParameterLength({ value: null, length: 10000 }), Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+      assert.deepEqual(TYPES.NVarChar.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]), length: 10000 }), Buffer.from([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Buffer` values (Length <= Maximum Length)', function() {
       const value = Buffer.from([0xff, 0xff]);
-      const expected = Buffer.from('0200ffff', 'hex');
+      const expected = Buffer.from('ffff', 'hex');
       const length = 1;
 
       const type = TYPES.NVarChar;
@@ -616,7 +792,7 @@ describe('NVarChar', function() {
 
     it('correctly converts `Buffer` values (Length > Maximum Length)', function() {
       const value = Buffer.from([0xff, 0xff]);
-      const expected = Buffer.from('feffffffffffffff02000000ffff00000000', 'hex');
+      const expected = Buffer.from('02000000ffff00000000', 'hex');
       const length = 4100;
 
       const type = TYPES.NVarChar;
@@ -628,7 +804,7 @@ describe('NVarChar', function() {
 
     it('correctly converts `null` values (Length <= Maximum Length)', function() {
       const value = null;
-      const expected = Buffer.from('ffff', 'hex');
+      const expected = Buffer.from([]);
       const length = 1;
 
       const type = TYPES.NVarChar;
@@ -640,7 +816,7 @@ describe('NVarChar', function() {
 
     it('correctly converts `null` values (Length > Maximum Length)', function() {
       const value = null;
-      const expected = Buffer.from('ffffffffffffffff', 'hex');
+      const expected = Buffer.from([]);
       const length = 5000;
 
       const type = TYPES.NVarChar;
@@ -670,10 +846,17 @@ describe('NVarChar', function() {
 });
 
 describe('Real', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Real.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Real.generateParameterLength({ value: 123.123 }), Buffer.from([0x04]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 123.123;
-      const expected = Buffer.from('04fa3ef642', 'hex');
+      const expected = Buffer.from('fa3ef642', 'hex');
 
       const type = TYPES.Real;
       const parameterValue = { value };
@@ -684,7 +867,7 @@ describe('Real', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.Real;
       const parameterValue = { value };
@@ -706,6 +889,13 @@ describe('Real', function() {
 });
 
 describe('SmallDateTime', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.SmallDateTime.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.SmallDateTime.generateParameterLength({ value: new Date() }), Buffer.from([0x04]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts dates during daylight savings period', function() {
       for (const [value, expectedNoOfDays] of [
@@ -716,7 +906,7 @@ describe('SmallDateTime', function() {
       ]) {
         const buffer = Buffer.concat([...TYPES.SmallDateTime.generateParameterData({ value }, { useUTC: false })]);
 
-        assert.strictEqual(buffer.readUInt16LE(1), expectedNoOfDays);
+        assert.strictEqual(buffer.readUInt16LE(0), expectedNoOfDays);
       }
     });
   });
@@ -732,10 +922,17 @@ describe('SmallDateTime', function() {
 });
 
 describe('SmallInt', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.SmallInt.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.SmallInt.generateParameterLength({ value: 123 }), Buffer.from([0x02]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 2;
-      const expected = Buffer.from('020200', 'hex');
+      const expected = Buffer.from('0200', 'hex');
 
       const type = TYPES.SmallInt;
       const parameterValue = { value };
@@ -746,7 +943,7 @@ describe('SmallInt', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.SmallInt;
       const parameterValue = { value };
@@ -768,10 +965,17 @@ describe('SmallInt', function() {
 });
 
 describe('SmallMoney', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.SmallMoney.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.SmallMoney.generateParameterLength({ value: 123 }), Buffer.from([0x04]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 2;
-      const expected = Buffer.from('04204e0000', 'hex');
+      const expected = Buffer.from('204e0000', 'hex');
 
       const type = TYPES.SmallMoney;
       const parameterValue = { value };
@@ -782,7 +986,7 @@ describe('SmallMoney', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.SmallMoney;
       const parameterValue = { value };
@@ -804,10 +1008,17 @@ describe('SmallMoney', function() {
 });
 
 describe('Text', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Text.generateParameterLength({ value: null, length: -1 }), Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]));
+      assert.deepEqual(TYPES.Text.generateParameterLength({ value: Buffer.from('Hello World', 'ascii'), length: 11 }), Buffer.from([0x0B, 0x00, 0x00, 0x00]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `Buffer` values', function() {
       const value = Buffer.from('Hello World', 'ascii');
-      const expected = Buffer.from('00000000000f00000048656c6c6f20576f726c64', 'hex');
+      const expected = Buffer.from('48656c6c6f20576f726c64', 'hex');
 
       const type = TYPES.Text;
       const parameterValue = { value, length: 15 };
@@ -818,10 +1029,10 @@ describe('Text', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00000000000f000000', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.Text;
-      const parameterValue = { value, length: 15 };
+      const parameterValue = { value, length: -1 };
 
       const buffer = Buffer.concat([...type.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -831,7 +1042,7 @@ describe('Text', function() {
   describe('.generateTypeInfo', function() {
     it('returns the correct type information', function() {
       const type = TYPES.Text;
-      const expected = Buffer.from([0x23, 1, 0, 0, 0]);
+      const expected = Buffer.from([0x23, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
       const result = type.generateTypeInfo({ length: 1 });
       assert.deepEqual(result, expected);
@@ -840,14 +1051,35 @@ describe('Text', function() {
 });
 
 describe('Time', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 0 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 1 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 2 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 3 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 4 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 5 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 6 }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: null, scale: 7 }), Buffer.from([0x00]));
+
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 0 }), Buffer.from([0x03]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 1 }), Buffer.from([0x03]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 2 }), Buffer.from([0x03]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 3 }), Buffer.from([0x04]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 4 }), Buffer.from([0x04]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 5 }), Buffer.from([0x05]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 6 }), Buffer.from([0x05]));
+      assert.deepEqual(TYPES.Time.generateParameterLength({ value: new Date(), scale: 7 }), Buffer.from([0x05]));
+    });
+  });
   describe('.generateParameterData', function() {
     // Test rounding of nanosecondDelta
     it('correctly converts `Date` values with a `nanosecondDelta` property', () => {
       const type = TYPES.Time;
       for (const [value, nanosecondDelta, scale, expectedBuffer] of [
-        [new Date(2017, 6, 29, 17, 20, 3, 503), 0.0006264, 7, Buffer.from('0568fc624b91', 'hex')],
-        [new Date(2017, 9, 1, 1, 31, 4, 12), 0.0004612, 7, Buffer.from('05c422ceb80c', 'hex')],
-        [new Date(2017, 7, 3, 12, 52, 28, 373), 0.0007118, 7, Buffer.from('051e94c8e96b', 'hex')]
+        [new Date(2017, 6, 29, 17, 20, 3, 503), 0.0006264, 7, Buffer.from('68fc624b91', 'hex')],
+        [new Date(2017, 9, 1, 1, 31, 4, 12), 0.0004612, 7, Buffer.from('c422ceb80c', 'hex')],
+        [new Date(2017, 7, 3, 12, 52, 28, 373), 0.0007118, 7, Buffer.from('1e94c8e96b', 'hex')]
       ]) {
         const parameter = { value: value, scale: scale };
         parameter.value.nanosecondDelta = nanosecondDelta;
@@ -870,10 +1102,17 @@ describe('Time', function() {
 });
 
 describe('TinyInt', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.TinyInt.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.TinyInt.generateParameterLength({ value: 4 }), Buffer.from([0x01]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `number` values', function() {
       const value = 1;
-      const expected = Buffer.from('0101', 'hex');
+      const expected = Buffer.from('01', 'hex');
 
       const type = TYPES.TinyInt;
       const parameterValue = { value };
@@ -884,7 +1123,7 @@ describe('TinyInt', function() {
 
     it('correctly converts `null` values', function() {
       const value = null;
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
 
       const type = TYPES.TinyInt;
       const parameterValue = { value };
@@ -906,13 +1145,28 @@ describe('TinyInt', function() {
 });
 
 describe('TVP', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.TVP.generateParameterLength({ value: null }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(
+        TYPES.TVP.generateParameterLength({
+          value: {
+            columns: [{ name: 'user_id', type: TYPES.Int }],
+            rows: [[ 15 ], [ 16 ]]
+          }
+        }),
+        Buffer.from([0x01, 0x00])
+      );
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts TVP table values', function() {
       const value = {
         columns: [{ name: 'user_id', type: TYPES.Int }],
         rows: [[ 15 ]]
       };
-      const expected = Buffer.from('01000000000000002604000001040f00000000', 'hex');
+      const expected = Buffer.from('0000000000002604000001040f00000000', 'hex');
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.TVP.generateParameterData(parameterValue, { useUTC: false })]);
@@ -922,7 +1176,7 @@ describe('TVP', function() {
     it('correctly converts `null` values', function() {
       const value = null;
 
-      const expected = Buffer.from('ffff0000', 'hex');
+      const expected = Buffer.from([0x00, 0x00]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.TVP.generateParameterData(parameterValue, { useUTC: false })]);
@@ -941,11 +1195,18 @@ describe('TVP', function() {
 });
 
 describe('UniqueIdentifier', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.UniqueIdentifier.generateParameterLength({ value: null }), Buffer.from([0x00]));
+      assert.deepEqual(TYPES.UniqueIdentifier.generateParameterLength({ value: 'e062ae34-6de5-47f3-8ba3-29d25f77e71a' }), Buffer.from([0x10]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `string` values', function() {
       const value = 'e062ae34-6de5-47f3-8ba3-29d25f77e71a';
 
-      const expected = Buffer.from('1034ae62e0e56df3478ba329d25f77e71a', 'hex');
+      const expected = Buffer.from('34ae62e0e56df3478ba329d25f77e71a', 'hex');
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.UniqueIdentifier.generateParameterData(parameterValue, { useUTC: false })]);
@@ -955,7 +1216,7 @@ describe('UniqueIdentifier', function() {
     it('correctly converts `null` values', function() {
       const value = null;
 
-      const expected = Buffer.from('00', 'hex');
+      const expected = Buffer.from([]);
       const parameterValue = { value };
 
       const buffer = Buffer.concat([...TYPES.UniqueIdentifier.generateParameterData(parameterValue, { useUTC: false })]);
@@ -988,11 +1249,21 @@ describe('UniqueIdentifier', function() {
 });
 
 describe('VarBinary', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.VarBinary.generateParameterLength({ value: null, length: 10 }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(TYPES.VarBinary.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]), length: 10 }), Buffer.from([0x04, 0x00]));
+
+      assert.deepEqual(TYPES.VarBinary.generateParameterLength({ value: null, length: 10000 }), Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+      assert.deepEqual(TYPES.VarBinary.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]), length: 10000 }), Buffer.from([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `null` values', () => {
       for (const [value, length, expected] of [
-        [null, 1, Buffer.from('ffff', 'hex')],
-        [null, 9000, Buffer.from('FFFFFFFFFFFFFFFF', 'hex')]
+        [null, 1, Buffer.from([])],
+        [null, 9000, Buffer.from([])]
       ]) {
         const parameterValue = { value, length };
         const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false }, () => { })]);
@@ -1002,7 +1273,7 @@ describe('VarBinary', function() {
 
     it('correctly converts `number` values', () => {
       for (const [value, length, expected] of [
-        [1, 1, Buffer.from('02003100', 'hex')],
+        [1, 1, Buffer.from('3100', 'hex')],
       ]) {
         const parameterValue = { value, length };
         const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false }, () => { })]);
@@ -1013,7 +1284,7 @@ describe('VarBinary', function() {
     it('correctly converts `number` values (Length <= Maximum Length)', function() {
       const value = 1;
       const length = 1;
-      const expected = Buffer.from('02003100', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from('3100', 'hex'); const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1022,7 +1293,7 @@ describe('VarBinary', function() {
     it('correctly converts `number` values (Length > Maximum Length)', function() {
       const value = 1;
       const length = 9000;
-      const expected = Buffer.from('feffffffffffffff02000000310000000000', 'hex');
+      const expected = Buffer.from('02000000310000000000', 'hex');
       const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
@@ -1032,7 +1303,8 @@ describe('VarBinary', function() {
     it('correctly converts `null` values (Length <= Maximum Length)', function() {
       const value = null;
       const length = 1;
-      const expected = Buffer.from('ffff', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from([]);
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1041,7 +1313,8 @@ describe('VarBinary', function() {
     it('correctly converts `null` values (Length > Maximum Length)', function() {
       const value = null;
       const length = 9000;
-      const expected = Buffer.from('FFFFFFFFFFFFFFFF', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from([]);
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1066,11 +1339,21 @@ describe('VarBinary', function() {
 });
 
 describe('VarChar', function() {
+  describe('.generateParameterLength', function() {
+    it('returns the correct data length', function() {
+      assert.deepEqual(TYPES.VarChar.generateParameterLength({ value: null, length: 10 }), Buffer.from([0xFF, 0xFF]));
+      assert.deepEqual(TYPES.VarChar.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]), length: 10 }), Buffer.from([0x04, 0x00]));
+
+      assert.deepEqual(TYPES.VarChar.generateParameterLength({ value: null, length: 10000 }), Buffer.from([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+      assert.deepEqual(TYPES.VarChar.generateParameterLength({ value: Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]), length: 10000 }), Buffer.from([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+    });
+  });
+
   describe('.generateParameterData', function() {
     it('correctly converts `string` values (Length <= Maximum Length)', function() {
       const value = 'hello world';
       const length = 1;
-      const expected = Buffer.from('0b0068656c6c6f20776f726c64', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from('68656c6c6f20776f726c64', 'hex'); const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1079,7 +1362,7 @@ describe('VarChar', function() {
     it('correctly converts `string` values (Length > Maximum Length)', function() {
       const value = 'hello world';
       const length = 9000;
-      const expected = Buffer.from('feffffffffffffff0b00000068656c6c6f20776f726c6400000000', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from('0b00000068656c6c6f20776f726c6400000000', 'hex'); const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1088,7 +1371,8 @@ describe('VarChar', function() {
     it('correctly converts `null` values (Length <= Maximum Length)', function() {
       const value = null;
       const length = 1;
-      const expected = Buffer.from('ffff', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from([]);
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1097,7 +1381,8 @@ describe('VarChar', function() {
     it('correctly converts `string` values (Length > Maximum Length)', function() {
       const value = null;
       const length = 9000;
-      const expected = Buffer.from('FFFFFFFFFFFFFFFF', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from([]);
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);

--- a/test/unit/int-data-type.js
+++ b/test/unit/int-data-type.js
@@ -12,7 +12,7 @@ describe('integer-data-types', function() {
     params.forEach(function(item) {
       it('test valid parameter values', function() {
         const buffer = Buffer.concat([...Int.generateParameterData(item.param, {})]);
-        assert.equal(buffer.readInt32LE(1), item.expected);
+        assert.equal(buffer.readInt32LE(0), item.expected);
       });
     });
   });
@@ -27,7 +27,7 @@ describe('integer-data-types', function() {
     params.forEach(function(item) {
       it('test valid parameter values', function() {
         const buffer = Buffer.concat([...SmallInt.generateParameterData(item.param, {})]);
-        assert.equal(buffer.readInt16LE(1), item.expected);
+        assert.equal(buffer.readInt16LE(0), item.expected);
       });
     });
   });
@@ -42,7 +42,7 @@ describe('integer-data-types', function() {
     params.forEach(function(item) {
       it('test valid parameter values', function() {
         const buffer = Buffer.concat([...TinyInt.generateParameterData(item.param, {})]);
-        assert.equal(buffer.readInt8(1), item.expected);
+        assert.equal(buffer.readInt8(0), item.expected);
       });
     });
   });


### PR DESCRIPTION
This splits the generation of parameter length and parameter data into two separate methods.

This supersedes https://github.com/tediousjs/tedious/pull/1053, where a new `toBuffer` method was proposed to perform essentially the same task.

@fredwes Does this cover all the use cases of the `toBuffer` method?