### PR TITLE
Change benchmarks to load the TypeScript code

### DIFF
--- a/benchmarks/common.js
+++ b/benchmarks/common.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const fs = require('fs');
-const { Connection } = require('../lib/tedious');
 const child_process = require('child_process');
 
-// const common = require('../common');
+require('@babel/register')({ extensions: ['.ts'] });
+
+const { Connection } = require('..');
 
 // The `Benchmark` class is taken from Node.js - see
 // https://github.com/nodejs/node/blob/0f96dc266fd0cd8c1baa82ce7eb951c11b29a331/benchmark/common.js

--- a/benchmarks/connection/open.js
+++ b/benchmarks/connection/open.js
@@ -1,7 +1,5 @@
 const { createBenchmark, createConnection } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
-
 const bench = createBenchmark(main, {
   n: [10, 100]
 });

--- a/benchmarks/query/insert-varbinary.js
+++ b/benchmarks/query/insert-varbinary.js
@@ -1,6 +1,6 @@
 const { createBenchmark, createConnection } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
+const { Request, TYPES } = require('../..');
 
 const bench = createBenchmark(main, {
   n: [10, 100],

--- a/benchmarks/query/select-many-rows.js
+++ b/benchmarks/query/select-many-rows.js
@@ -1,6 +1,6 @@
 const { createBenchmark, createConnection } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
+const { Request, TYPES } = require('../..');
 
 const bench = createBenchmark(main, {
   n: [10, 100, 1000],

--- a/benchmarks/query/select-nvarchar.js
+++ b/benchmarks/query/select-nvarchar.js
@@ -1,6 +1,6 @@
 const { createBenchmark, createConnection } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
+const { Request, TYPES } = require('../..');
 
 const bench = createBenchmark(main, {
   n: [10, 100, 1000],

--- a/benchmarks/query/select-varbinary.js
+++ b/benchmarks/query/select-varbinary.js
@@ -1,6 +1,6 @@
 const { createBenchmark, createConnection } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
+const { Request, TYPES } = require('../..');
 
 const bench = createBenchmark(main, {
   n: [10, 100],

--- a/benchmarks/request/rpcrequest-payload-tvp.js
+++ b/benchmarks/request/rpcrequest-payload-tvp.js
@@ -1,7 +1,7 @@
 const { createBenchmark } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
-const RpcRequestPayload = require('../../lib/rpcrequest-payload');
+const { Request, TYPES } = require('../..');
+const RpcRequestPayload = require('../../src/rpcrequest-payload');
 
 const { Readable } = require('readable-stream');
 

--- a/benchmarks/request/rpcrequest-payload-varbinary.js
+++ b/benchmarks/request/rpcrequest-payload-varbinary.js
@@ -1,7 +1,7 @@
 const { createBenchmark } = require('../common');
 
-const { Request, TYPES } = require('../../lib/tedious');
-const RpcRequestPayload = require('../../lib/rpcrequest-payload');
+const { Request, TYPES } = require('../..');
+const RpcRequestPayload = require('../../src/rpcrequest-payload');
 
 const { Readable } = require('readable-stream');
 

--- a/benchmarks/token-parser/colmetadata-token.js
+++ b/benchmarks/token-parser/colmetadata-token.js
@@ -1,6 +1,6 @@
 const { createBenchmark } = require('../common');
 
-const { Parser } = require('../../lib/token/token-stream-parser');
+const { Parser } = require('../../src/token/token-stream-parser');
 
 const bench = createBenchmark(main, {
   n: [10, 100, 1000],

--- a/benchmarks/token-parser/done-token.js
+++ b/benchmarks/token-parser/done-token.js
@@ -1,6 +1,6 @@
 const { createBenchmark } = require('../common');
 
-const { Parser } = require('../../lib/token/token-stream-parser');
+const { Parser } = require('../../src/token/token-stream-parser');
 
 const bench = createBenchmark(main, {
   n: [10, 100, 1000],

--- a/benchmarks/token-parser/simple-tokens.js
+++ b/benchmarks/token-parser/simple-tokens.js
@@ -1,6 +1,6 @@
 const { createBenchmark } = require('../common');
 
-const { Parser } = require('../../lib/token/token-stream-parser');
+const { Parser } = require('../../src/token/token-stream-parser');
 
 const bench = createBenchmark(main, {
   n: [10, 100, 1000]


### PR DESCRIPTION
This removes the need to run `npm run build` before running benchmarks, and ensures that the latest code changes are benchmarked.