### PR TITLE
feat: allow validating bulk load parameters

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -367,6 +367,7 @@ export interface InternalConnectionOptions {
   trustServerCertificate: boolean;
   useColumnNames: boolean;
   useUTC: boolean;
+  validateBulkLoadParameters: boolean;
   workstationId: undefined | string;
   lowerCaseGuids: boolean;
 }
@@ -806,6 +807,13 @@ interface ConnectionOptions {
   useUTC?: boolean;
 
   /**
+   * A boolean determining whether BulkLoad parameters should be validated.
+   *
+   * (default: `false`).
+   */
+  validateBulkLoadParameters?: boolean;
+
+  /**
    * The workstation ID (WSID) of the client, default os.hostname().
    * Used for identifying a specific client in profiling, logging or
    * tracing client activity in SQLServer.
@@ -1236,6 +1244,7 @@ class Connection extends EventEmitter {
         trustServerCertificate: false,
         useColumnNames: false,
         useUTC: true,
+        validateBulkLoadParameters: false,
         workstationId: undefined,
         lowerCaseGuids: false
       }
@@ -1628,6 +1637,16 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.useUTC = config.options.useUTC;
+      }
+
+      if (config.options.validateBulkLoadParameters !== undefined) {
+        if (typeof config.options.validateBulkLoadParameters !== 'boolean') {
+          throw new TypeError('The "config.options.validateBulkLoadParameters" property must be of type boolean.');
+        }
+
+        this.config.options.validateBulkLoadParameters = config.options.validateBulkLoadParameters;
+      } else {
+        deprecate('The default value for "config.options.validateBulkLoadParameters" will change from `false` to `true` in the next major version of `tedious`. Set the value to `true` or `false` explicitly to silence this message.');
       }
 
       if (config.options.workstationId !== undefined) {

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -351,7 +351,7 @@ describe('Bulk Load Tests', function() {
   });
 
   it('should test stream bulk load', function(done) {
-    this.timeout(50000);
+    this.timeout(200000);
 
     const totalRows = 500000;
     const tableName = '#streamingBulkLoadTest';
@@ -494,7 +494,7 @@ describe('Bulk Load Tests', function() {
       assert.ok(err);
       assert.strictEqual(err.message, 'Canceled.');
 
-      assert.equal(rowCount, 0);
+      assert.isUndefined(rowCount);
       startVerifyTableContent();
     }
 
@@ -519,6 +519,103 @@ describe('Bulk Load Tests', function() {
       assert.equal(rowCount, 1);
 
       done();
+    }
+  });
+});
+
+describe('Bulk Loads when `config.options.validateBulkLoadParameters` is `true`', () => {
+  let connection;
+
+  beforeEach(function(done) {
+    const config = getConfig();
+    config.options = { ...config.options, validateBulkLoadParameters: true };
+    connection = new Connection(config);
+    connection.on('connect', done);
+
+    if (debugMode) {
+      connection.on('debug', (message) => console.log(message));
+      connection.on('infoMessage', (info) =>
+        console.log('Info: ' + info.number + ' - ' + info.message)
+      );
+      connection.on('errorMessage', (error) =>
+        console.log('Error: ' + error.number + ' - ' + error.message)
+      );
+    }
+  });
+
+  beforeEach(function(done) {
+    const request = new Request('create table #stream_test ([value] date)', (err) => {
+      done(err);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  afterEach(function(done) {
+    if (!connection.closed) {
+      connection.on('end', done);
+      connection.close();
+    } else {
+      done();
+    }
+  });
+
+  it('should handle validation errors during streaming bulk loads', (done) => {
+    const bulkLoad = connection.newBulkLoad('#stream_test', completeBulkLoad);
+    bulkLoad.addColumn('value', TYPES.Date, { nullable: false });
+
+    const rowStream = bulkLoad.getRowStream();
+    connection.execBulkLoad(bulkLoad);
+
+    const rowSource = Readable.from([
+      ['invalid date']
+    ]);
+
+    pipeline(rowSource, rowStream, function(err) {
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid date.');
+    });
+
+    function completeBulkLoad(err, rowCount) {
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid date.');
+
+      done();
+    }
+  });
+
+  it('should allow reusing the connection after validation errors during streaming bulk loads', (done) => {
+    const bulkLoad = connection.newBulkLoad('#stream_test', completeBulkLoad);
+    bulkLoad.addColumn('value', TYPES.Date, { nullable: false });
+
+    const rowStream = bulkLoad.getRowStream();
+    connection.execBulkLoad(bulkLoad);
+
+    const rowSource = Readable.from([ ['invalid date'] ]);
+
+    pipeline(rowSource, rowStream, function(err) {
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid date.');
+    });
+
+    function completeBulkLoad(err, rowCount) {
+      assert.ok(err);
+      assert.strictEqual(err.message, 'Invalid date.');
+
+      const rows = [];
+      const request = new Request('SELECT 1', (err) => {
+        assert.ifError(err);
+
+        assert.deepEqual([1], rows);
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        rows.push(row[0].value);
+      });
+
+      connection.execSql(request);
     }
   });
 });

--- a/test/unit/bulk-load-test.js
+++ b/test/unit/bulk-load-test.js
@@ -1,11 +1,20 @@
 const { assert } = require('chai');
 
 const BulkLoad = require('../../src/bulk-load');
+const TYPES = require('../../src/data-type').typeByName;
 
 describe('BulkLoad', function() {
   it('starts out as not being canceled', function() {
     const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
     assert.strictEqual(request.canceled, false);
+  });
+
+  it('throws an error when adding row with a value has the wrong data type', function() {
+    const request = new BulkLoad('tablename', { tdsVersion: '7_2', validateBulkLoadParameters: true }, { });
+    request.addColumn('columnName', TYPES.Date, { nullable: true });
+    assert.throws(() => {
+      request.addRow({ columnName: 'Wrong Input' });
+    }, TypeError, 'Invalid date.');
   });
 
   describe('#cancel', function() {

--- a/test/unit/connection-config-validation.js
+++ b/test/unit/connection-config-validation.js
@@ -94,4 +94,13 @@ describe('Connection configuration validation', function() {
       new Connection(config);
     });
   });
+
+  it('bad validateBulkLoadParameters value', () => {
+    const validateBulkLoadParametersVal = 'text';
+    config.options.validateBulkLoadParameters = validateBulkLoadParametersVal;
+    config.options.tdsVersion = '7_2';
+    assert.throws(() => {
+      new Connection(config);
+    });
+  });
 });


### PR DESCRIPTION
Validate function will report error is input data do not match the data type check. However, the current bulk logic does not expose this error. Added some logic to expose these errors. 

Related issue: #889 
