### PR TITLE
Deprecate automatically opening a connection when building a `Connection` instance

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -204,7 +204,7 @@ interface State {
   };
 }
 
-interface ConnectionConfiguration {
+export interface ConnectionConfiguration {
   server: string;
   options?: ConnectionOptions;
   authentication?: {
@@ -290,6 +290,7 @@ class Connection extends EventEmitter {
   ntlmpacketBuffer: undefined | Buffer;
 
   STATE!: {
+    INITIALIZED: State;
     CONNECTING: State;
     SENT_PRELOGIN: State;
     REROUTING: State;
@@ -979,8 +980,31 @@ class Connection extends EventEmitter {
     this.curTransientRetryCount = 0;
     this.transientErrorLookup = new TransientErrorLookup();
 
-    this.state = this.STATE.CONNECTING;
-    this.state.enter!.call(this);
+    this.state = this.STATE.INITIALIZED;
+
+    process.nextTick(() => {
+      if (this.state === this.STATE.INITIALIZED) {
+        const message = 'In the next major version of `tedious`, creating a new ' +
+          '`Connection` instance will no longer establish a connection to the ' +
+          'server automatically. Please use the new `connect` helper function or ' +
+          'call the `.connect` method on the newly created `Connection` object to ' +
+          'silence this message.';
+        deprecate(message);
+        this.connect();
+      }
+    });
+  }
+
+  connect(connectListener?: (err?: Error) => void) {
+    if (this.state !== this.STATE.INITIALIZED) {
+      throw new ConnectionError('`.connect` can not be called on a Connection in `' + this.state.name + '` state.');
+    }
+
+    if (connectListener) {
+      this.once('connect', connectListener);
+    }
+
+    this.transitionTo(this.STATE.CONNECTING);
   }
 
   close() {
@@ -988,8 +1012,27 @@ class Connection extends EventEmitter {
   }
 
   initialiseConnection() {
-    this.connect();
     this.createConnectTimer();
+
+    if (this.config.options.port) {
+      return this.connectOnPort(this.config.options.port, this.config.options.multiSubnetFailover);
+    } else {
+      return new InstanceLookup().instanceLookup({
+        server: this.config.server,
+        instanceName: this.config.options.instanceName!,
+        timeout: this.config.options.connectTimeout
+      }, (message, port) => {
+        if (this.state === this.STATE.FINAL) {
+          return;
+        }
+
+        if (message) {
+          this.emit('connect', ConnectionError(message, 'EINSTLOOKUP'));
+        } else {
+          this.connectOnPort(port!, this.config.options.multiSubnetFailover);
+        }
+      });
+    }
   }
 
   cleanupConnection(cleanupType: typeof CLEANUP_TYPE[keyof typeof CLEANUP_TYPE]) {
@@ -1298,28 +1341,6 @@ class Connection extends EventEmitter {
     });
 
     return tokenStreamParser;
-  }
-
-  connect() {
-    if (this.config.options.port) {
-      return this.connectOnPort(this.config.options.port, this.config.options.multiSubnetFailover);
-    } else {
-      return new InstanceLookup().instanceLookup({
-        server: this.config.server,
-        instanceName: this.config.options.instanceName!,
-        timeout: this.config.options.connectTimeout
-      }, (message, port) => {
-        if (this.state === this.STATE.FINAL) {
-          return;
-        }
-
-        if (message) {
-          this.emit('connect', ConnectionError(message, 'EINSTLOOKUP'));
-        } else {
-          this.connectOnPort(port!, this.config.options.multiSubnetFailover);
-        }
-      });
-    }
   }
 
   connectOnPort(port: number, multiSubnetFailover: boolean) {
@@ -2127,6 +2148,10 @@ export default Connection;
 module.exports = Connection;
 
 Connection.prototype.STATE = {
+  INITIALIZED: {
+    name: 'Initialized',
+    events: {}
+  },
   CONNECTING: {
     name: 'Connecting',
     enter: function() {

--- a/src/tedious.ts
+++ b/src/tedious.ts
@@ -1,5 +1,5 @@
 import BulkLoad from './bulk-load';
-import Connection from './connection';
+import Connection, { ConnectionConfiguration } from './connection';
 import Request from './request';
 import { name } from './library';
 
@@ -10,6 +10,12 @@ import { ISOLATION_LEVEL } from './transaction';
 import { versions as TDS_VERSION } from './tds-versions';
 
 const library = { name: name };
+
+export function connect(config: ConnectionConfiguration, connectListener?: (err?: Error) => {}) {
+  const connection = new Connection(config);
+  connection.connect(connectListener);
+  return connection;
+}
 
 export {
   BulkLoad,

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -227,6 +227,55 @@ describe('Initiate Connect Test', function() {
     done();
   });
 
+  it('should allow connecting by calling `.connect` on the returned connection', function(done) {
+    const config = getConfig();
+
+    const connection = new Connection(config);
+    connection.connect((err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.on('end', () => { done(); });
+      connection.close();
+    });
+  });
+
+  it('should not allow calling `.connect` on a connected connection', function(done) {
+    const config = getConfig();
+
+    const connection = new Connection(config);
+    connection.connect((err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.on('end', () => { done(); });
+      process.nextTick(() => {
+        connection.close();
+      });
+
+      assert.throws(() => {
+        connection.connect();
+      }, '`.connect` can not be called on a Connection in `LoggedIn` state.');
+    });
+  });
+
+  it('should allow calling `.connect` without a callback', function(done) {
+    const config = getConfig();
+
+    const connection = new Connection(config);
+    connection.on('connect', (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.on('end', () => { done(); });
+      connection.close();
+    });
+    connection.connect();
+  });
+
   it('should emit a deprecation message if `trustServerCertificate` is `undefined`', function(done) {
     const config = getConfig();
     config.options.trustServerCertificate = undefined;


### PR DESCRIPTION
In https://github.com/tediousjs/tedious/pull/730, the ability to build a new `Connection` object without immediately opening the actual connection to the server was requested.

I think this requested behavior should actually be the **default**. This is also how `net.Socket` in NodeJS works - calling `new net.Socket` won't actually open a connection to the remove server, unless the `.connect` method is called on the returned socket object. The `net` module also provides a module level `.connect` convenience method that creates and returns a new `Socket` instance and calls `.connect` on it.

This pull request adds a similar method on the `tedious` module, that creates a new `Connection`, calls `.connect` on it and returns the created connection object.

Calling `new Connection` without immediately calling `.connect` on it will emit a new deprecation warning, but will automatically call `.connect` to emulate the existing behavior. This existing behavior will be removed in the future, and not calling `.connect` will cause the connection to never be opened.

Fixes: https://github.com/tediousjs/tedious/pull/730