### PR TITLE
Add error listenter to readable stream

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2095,7 +2095,11 @@ class Connection extends EventEmitter {
           }
         });
 
-        Readable.from(payload!).pipe(message);
+        const readable = Readable.from(payload!);
+        readable.on('error', (e) => {
+          request.callback(e);
+        });
+        readable.pipe(message);
       }
     }
   }


### PR DESCRIPTION
Fixes #1085 

Currently the readstream that is created doesn't have any error handlers attached, so if the value parsing errors the emitted error is not caught causing node to crash.

This catches the error and passes it to the request so it can be handled.