### PR TITLE
refactor: simplify `Parser` constructor

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1071,7 +1071,7 @@ class Connection extends EventEmitter {
   }
 
   createTokenStreamParser() {
-    const tokenStreamParser = new TokenStreamParser(this.debug, undefined, this.config.options);
+    const tokenStreamParser = new TokenStreamParser(this.debug, this.config.options);
 
     tokenStreamParser.on('infoMessage', (token) => {
       this.emit('infoMessage', token);

--- a/src/token/colmetadata-token-parser.ts
+++ b/src/token/colmetadata-token-parser.ts
@@ -78,7 +78,7 @@ function readColumn(parser: Parser, options: InternalConnectionOptions, index: n
   });
 }
 
-function colMetadataParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: ColMetadataToken) => void) {
+function colMetadataParser(parser: Parser, options: InternalConnectionOptions, callback: (token: ColMetadataToken) => void) {
   parser.readUInt16LE((columnCount) => {
     const columns: ColumnMetadata[] = [];
 

--- a/src/token/done-token-parser.ts
+++ b/src/token/done-token-parser.ts
@@ -1,7 +1,6 @@
 import JSBI from 'jsbi';
 
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 import { DoneToken, DoneInProcToken, DoneProcToken } from './token';
 
@@ -57,19 +56,19 @@ function parseToken(parser: Parser, options: InternalConnectionOptions, callback
   });
 }
 
-export function doneParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: DoneToken) => void) {
+export function doneParser(parser: Parser, options: InternalConnectionOptions, callback: (token: DoneToken) => void) {
   parseToken(parser, options, (data) => {
     callback(new DoneToken(data));
   });
 }
 
-export function doneInProcParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: DoneInProcToken) => void) {
+export function doneInProcParser(parser: Parser, options: InternalConnectionOptions, callback: (token: DoneInProcToken) => void) {
   parseToken(parser, options, (data) => {
     callback(new DoneInProcToken(data));
   });
 }
 
-export function doneProcParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: DoneProcToken) => void) {
+export function doneProcParser(parser: Parser, options: InternalConnectionOptions, callback: (token: DoneProcToken) => void) {
   parseToken(parser, options, (data) => {
     callback(new DoneProcToken(data));
   });

--- a/src/token/env-change-token-parser.ts
+++ b/src/token/env-change-token-parser.ts
@@ -1,5 +1,4 @@
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import {
@@ -175,7 +174,7 @@ function readNewAndOldValue(parser: Parser, length: number, type: { name: string
   }
 }
 
-function envChangeParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: EnvChangeToken | undefined) => void) {
+function envChangeParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: EnvChangeToken | undefined) => void) {
   parser.readUInt16LE((length) => {
     parser.readUInt8((typeNumber) => {
       const type = types[typeNumber];

--- a/src/token/feature-ext-ack-parser.ts
+++ b/src/token/feature-ext-ack-parser.ts
@@ -1,5 +1,4 @@
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { FeatureExtAckToken } from './token';
@@ -13,7 +12,7 @@ const FEATURE_ID = {
   TERMINATOR: 0xFF
 };
 
-function featureExtAckParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: FeatureExtAckToken) => void) {
+function featureExtAckParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: FeatureExtAckToken) => void) {
   let fedAuth: Buffer | undefined;
 
   function next() {

--- a/src/token/fedauth-info-parser.ts
+++ b/src/token/fedauth-info-parser.ts
@@ -1,5 +1,4 @@
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 import { FedAuthInfoToken } from './token';
 
@@ -8,7 +7,7 @@ const FEDAUTHINFOID = {
   SPN: 0x02
 };
 
-function fedAuthInfoParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: FedAuthInfoToken) => void) {
+function fedAuthInfoParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: FedAuthInfoToken) => void) {
   parser.readUInt32LE((tokenLength) => {
     parser.readBuffer(tokenLength, (data) => {
       let spn: string | undefined, stsurl: string | undefined;

--- a/src/token/infoerror-token-parser.ts
+++ b/src/token/infoerror-token-parser.ts
@@ -1,5 +1,4 @@
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { InfoMessageToken, ErrorMessageToken } from './token';
@@ -43,13 +42,13 @@ function parseToken(parser: Parser, options: InternalConnectionOptions, callback
   });
 }
 
-export function infoParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: InfoMessageToken) => void) {
+export function infoParser(parser: Parser, options: InternalConnectionOptions, callback: (token: InfoMessageToken) => void) {
   parseToken(parser, options, (data) => {
     callback(new InfoMessageToken(data));
   });
 }
 
-export function errorParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: ErrorMessageToken) => void) {
+export function errorParser(parser: Parser, options: InternalConnectionOptions, callback: (token: ErrorMessageToken) => void) {
   parseToken(parser, options, (data) => {
     callback(new ErrorMessageToken(data));
   });

--- a/src/token/loginack-token-parser.ts
+++ b/src/token/loginack-token-parser.ts
@@ -1,5 +1,4 @@
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { LoginAckToken } from './token';
@@ -11,7 +10,7 @@ const interfaceTypes: { [key: number]: string } = {
   1: 'SQL_TSQL'
 };
 
-function loginAckParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: LoginAckToken) => void) {
+function loginAckParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: LoginAckToken) => void) {
   // length
   parser.readUInt16LE(() => {
     parser.readUInt8((interfaceNumber) => {

--- a/src/token/nbcrow-token-parser.ts
+++ b/src/token/nbcrow-token-parser.ts
@@ -17,7 +17,8 @@ type Column = {
   metadata: ColumnMetadata;
 };
 
-function nbcRowParser(parser: Parser, columnsMetaData: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: NBCRowToken) => void) {
+function nbcRowParser(parser: Parser, options: InternalConnectionOptions, callback: (token: NBCRowToken) => void) {
+  const columnsMetaData = parser.colMetadata;
   const length = Math.ceil(columnsMetaData.length / 8);
   parser.readBuffer(length, (bytes) => {
     const bitmap: boolean[] = [];

--- a/src/token/order-token-parser.ts
+++ b/src/token/order-token-parser.ts
@@ -1,11 +1,10 @@
 // s2.2.7.14
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { OrderToken } from './token';
 
-function orderParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: OrderToken) => void) {
+function orderParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: OrderToken) => void) {
   parser.readUInt16LE((length) => {
     const columnCount = length / 2;
     const orderColumns: number[] = [];

--- a/src/token/returnstatus-token-parser.ts
+++ b/src/token/returnstatus-token-parser.ts
@@ -1,11 +1,10 @@
 // s2.2.7.16
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { ReturnStatusToken } from './token';
 
-function returnStatusParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: ReturnStatusToken) => void) {
+function returnStatusParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: ReturnStatusToken) => void) {
   parser.readInt32LE((value) => {
     callback(new ReturnStatusToken(value));
   });

--- a/src/token/returnvalue-token-parser.ts
+++ b/src/token/returnvalue-token-parser.ts
@@ -1,7 +1,6 @@
 // s2.2.7.16
 
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { ReturnValueToken } from './token';
@@ -9,7 +8,7 @@ import { ReturnValueToken } from './token';
 import metadataParse from '../metadata-parser';
 import valueParse from '../value-parser';
 
-function returnParser(parser: Parser, _colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: ReturnValueToken) => void) {
+function returnParser(parser: Parser, options: InternalConnectionOptions, callback: (token: ReturnValueToken) => void) {
   parser.readUInt16LE((paramOrdinal) => {
     parser.readBVarChar((paramName) => {
       if (paramName.charAt(0) === '@') {

--- a/src/token/row-token-parser.ts
+++ b/src/token/row-token-parser.ts
@@ -13,7 +13,8 @@ type Column = {
   metadata: ColumnMetadata;
 };
 
-function rowParser(parser: Parser, colMetadata: ColumnMetadata[], options: InternalConnectionOptions, callback: (token: RowToken) => void) {
+function rowParser(parser: Parser, options: InternalConnectionOptions, callback: (token: RowToken) => void) {
+  const colMetadata = parser.colMetadata;
   const columns: Column[] = [];
 
   const len = colMetadata.length;

--- a/src/token/sspi-token-parser.ts
+++ b/src/token/sspi-token-parser.ts
@@ -1,5 +1,4 @@
 import Parser from './stream-parser';
-import { ColumnMetadata } from './colmetadata-token-parser';
 import { InternalConnectionOptions } from '../connection';
 
 import { SSPIToken } from './token';
@@ -42,7 +41,7 @@ function parseChallenge(buffer: Buffer) {
   return challenge as Data;
 }
 
-function sspiParser(parser: Parser, _colMetadata: ColumnMetadata[], _options: InternalConnectionOptions, callback: (token: SSPIToken) => void) {
+function sspiParser(parser: Parser, _options: InternalConnectionOptions, callback: (token: SSPIToken) => void) {
   parser.readUsVarByte((buffer) => {
     callback(new SSPIToken(parseChallenge(buffer), buffer));
   });

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -51,11 +51,11 @@ class Parser extends Transform {
   suspended: boolean;
   next?: () => void;
 
-  constructor(debug: Debug, colMetadata: ColumnMetadata[], options: InternalConnectionOptions) {
+  constructor(debug: Debug, options: InternalConnectionOptions) {
     super({ objectMode: true });
 
     this.debug = debug;
-    this.colMetadata = colMetadata;
+    this.colMetadata = [];
     this.options = options;
     this.endOfMessageMarker = new EndOfMessageMarker();
 
@@ -111,7 +111,7 @@ class Parser extends Transform {
       this.position += 1;
 
       if (tokenParsers[type]) {
-        tokenParsers[type](this, this.colMetadata, this.options, doneParsing);
+        tokenParsers[type](this, this.options, doneParsing);
       } else {
         this.emit('error', new Error('Unknown type: ' + type));
       }

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -42,18 +42,16 @@ import {
  */
 export class Parser extends EventEmitter {
   debug: Debug;
-  colMetadata: any;
   options: InternalConnectionOptions;
   parser: StreamParser;
 
-  constructor(debug: Debug, colMetadata: any, options: InternalConnectionOptions) {
+  constructor(debug: Debug, options: InternalConnectionOptions) {
     super();
 
     this.debug = debug;
-    this.colMetadata = colMetadata;
     this.options = options;
 
-    this.parser = new StreamParser(this.debug, this.colMetadata, this.options);
+    this.parser = new StreamParser(this.debug, this.options);
     this.parser.on('data', (token: Token) => {
       if (token.event) {
         this.emit(token.event, token);

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -17,24 +17,26 @@ const options = {
 
 describe('Row Token Parser', () => {
   it('should write int', () => {
-    const colMetaData = [{ type: dataTypeByName.Int }];
+    const colMetadata = [{ type: dataTypeByName.Int }];
     const value = 3;
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
     buffer.writeUInt8(0xd1);
     buffer.writeUInt32LE(value);
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
+
     parser.write(buffer.data);
     const token = parser.read();
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write bigint', () => {
-    const colMetaData = [
+    const colMetadata = [
       { type: dataTypeByName.BigInt },
       { type: dataTypeByName.BigInt }
     ];
@@ -45,7 +47,9 @@ describe('Row Token Parser', () => {
       Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 127])
     );
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
+
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -56,25 +60,26 @@ describe('Row Token Parser', () => {
   });
 
   it('should write real', () => {
-    const colMetaData = [{ type: dataTypeByName.Real }];
+    const colMetadata = [{ type: dataTypeByName.Real }];
     const value = 9.5;
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x18, 0x41]));
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write float', () => {
-    const colMetaData = [{ type: dataTypeByName.Float }];
+    const colMetadata = [{ type: dataTypeByName.Float }];
     const value = 9.5;
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -83,18 +88,19 @@ describe('Row Token Parser', () => {
       Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x23, 0x40])
     );
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write Money', () => {
-    const colMetaData = [
+    const colMetadata = [
       { type: SmallMoney },
       { type: Money },
       { type: MoneyN },
@@ -120,7 +126,8 @@ describe('Row Token Parser', () => {
       Buffer.from([0x08, 0xf4, 0x10, 0x22, 0x11, 0xdc, 0x6a, 0xe9, 0x7d])
     );
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -135,7 +142,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write varchar without code page', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         collation: {
@@ -150,18 +157,19 @@ describe('Row Token Parser', () => {
     buffer.writeUsVarchar(value);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varchar with code page', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         collation: {
@@ -176,18 +184,19 @@ describe('Row Token Parser', () => {
     buffer.writeUsVarchar(value);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write nvarchar', () => {
-    const colMetaData = [{ type: dataTypeByName.NVarChar }];
+    const colMetadata = [{ type: dataTypeByName.NVarChar }];
     const value = 'abc';
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -196,18 +205,19 @@ describe('Row Token Parser', () => {
     buffer.writeString(value);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varBinary', () => {
-    const colMetaData = [{ type: dataTypeByName.VarBinary }];
+    const colMetadata = [{ type: dataTypeByName.VarBinary }];
     const value = Buffer.from([0x12, 0x34]);
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -216,18 +226,19 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value));
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.deepEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write binary', () => {
-    const colMetaData = [{ type: dataTypeByName.Binary }];
+    const colMetadata = [{ type: dataTypeByName.Binary }];
     const value = Buffer.from([0x12, 0x34]);
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -236,18 +247,19 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value));
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.deepEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxNull', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         dataLength: 65535,
@@ -264,18 +276,19 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxUnkownLength', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         dataLength: 65535,
@@ -298,18 +311,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxKnownLength', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         dataLength: 65535,
@@ -330,18 +344,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharmaxWithCodePage', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         dataLength: 65535,
@@ -362,18 +377,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxKnownLengthWrong', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarChar,
         dataLength: 65535
@@ -392,7 +408,8 @@ describe('Row Token Parser', () => {
     // console.log(buffer.data)
 
     try {
-      const parser = new Parser({ token() { } }, colMetaData, options);
+      const parser = new Parser({ token() { } }, options);
+      parser.colMetadata = colMetadata;
       parser.write(buffer.data);
       parser.read();
       assert.isOk(false);
@@ -402,7 +419,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write varBinaryMaxNull', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarBinary,
         dataLength: 65535
@@ -416,18 +433,19 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varBinaryMaxUnknownLength', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: dataTypeByName.VarBinary,
         dataLength: 65535
@@ -447,18 +465,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
 
     assert.strictEqual(token.columns.length, 1);
     assert.deepEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetaData[0]);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write intN', () => {
-    const colMetaData = [
+    const colMetadata = [
       { type: IntN },
       { type: IntN },
       { type: IntN },
@@ -581,7 +600,8 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -602,7 +622,7 @@ describe('Row Token Parser', () => {
   });
 
   it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `false`', () => {
-    const colMetaData = [
+    const colMetadata = [
       { type: dataTypeByName.UniqueIdentifier },
       { type: dataTypeByName.UniqueIdentifier }
     ];
@@ -633,7 +653,8 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() {} }, colMetaData, Object.assign({ lowerCaseGuids: false }, options));
+    const parser = new Parser({ token() {} }, Object.assign({ lowerCaseGuids: false }, options));
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     var token = parser.read();
     // console.log(token)
@@ -647,7 +668,7 @@ describe('Row Token Parser', () => {
   });
 
   it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `true`', () => {
-    var colMetaData = [
+    var colMetadata = [
       { type: dataTypeByName.UniqueIdentifier },
       { type: dataTypeByName.UniqueIdentifier }
     ];
@@ -677,7 +698,8 @@ describe('Row Token Parser', () => {
       ])
     );
     // console.log(buffer.data)
-    const parser = new Parser({ token() {} }, colMetaData, Object.assign({ lowerCaseGuids: true }, options));
+    const parser = new Parser({ token() {} }, Object.assign({ lowerCaseGuids: true }, options));
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -691,7 +713,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write floatN', () => {
-    const colMetaData = [
+    const colMetadata = [
       { type: FloatN },
       { type: FloatN },
       { type: FloatN }
@@ -720,7 +742,8 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -732,7 +755,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write datetime', () => {
-    const colMetaData = [{ type: dataTypeByName.DateTime }];
+    const colMetadata = [{ type: dataTypeByName.DateTime }];
 
     const days = 2; // 3rd January 1900
     const threeHundredthsOfSecond = 45 * 300; // 45 seconds
@@ -744,7 +767,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(threeHundredthsOfSecond);
     // console.log(buffer)
 
-    let parser = new Parser({ token() { } }, colMetaData, { useUTC: false });
+    let parser = new Parser({ token() { } }, { useUTC: false });
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     let token = parser.read();
     // console.log(token)
@@ -755,7 +779,8 @@ describe('Row Token Parser', () => {
       new Date('January 3, 1900 00:00:45').getTime()
     );
 
-    parser = new Parser({ token() { } }, colMetaData, { useUTC: true });
+    parser = new Parser({ token() { } }, { useUTC: true });
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     token = parser.read();
     // console.log(token)
@@ -768,7 +793,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write datetimeN', () => {
-    const colMetaData = [{ type: DateTimeN }];
+    const colMetadata = [{ type: DateTimeN }];
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
     buffer.writeUInt8(0xd1);
@@ -776,7 +801,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -786,7 +812,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write numeric4Bytes', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: NumericN,
         precision: 3,
@@ -804,7 +830,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(93);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -814,7 +841,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write numeric4BytesNegative', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: NumericN,
         precision: 3,
@@ -832,7 +859,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(93);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -842,7 +870,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write numeric8Bytes', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: NumericN,
         precision: 13,
@@ -861,7 +889,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -871,7 +900,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write numeric12Bytes', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: NumericN,
         precision: 23,
@@ -891,7 +920,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -901,7 +931,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write numeric16Bytes', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: NumericN,
         precision: 33,
@@ -927,7 +957,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)
@@ -937,7 +968,7 @@ describe('Row Token Parser', () => {
   });
 
   it('should write numericNull', () => {
-    const colMetaData = [
+    const colMetadata = [
       {
         type: NumericN,
         precision: 3,
@@ -951,7 +982,8 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, colMetaData, options);
+    const parser = new Parser({ token() { } }, options);
+    parser.colMetadata = colMetadata;
     parser.write(buffer.data);
     const token = parser.read();
     // console.log(token)


### PR DESCRIPTION
This removes the `colMetadata` parameter on the Parser classes and the individual token parser functions.

The rationale behind removing it from the Parser classes is that it was always set to `undefined` in the `tedious` codebase, except for in the tests, where we can also just set the property directly to whatever we want it to be.

The rationale behind removing it from the token parser function is that it was only used by the `ROW` and `NBCROW` token parser functions, and the column information can also be accessed simply via the property on the parser instance that is also passed to those functions.