### PR TITLE
Fix running tests on SQLServer 2019

### DIFF
--- a/test/integration/transactions-test.js
+++ b/test/integration/transactions-test.js
@@ -297,17 +297,11 @@ describe('Transactions Test', function() {
               assert.ok(true);
             });
 
-            req = new Request(
-              "insert into #temp values ('asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasd')",
-              function(err) {
-                assert.strictEqual(
-                  err.message,
-                  'String or binary data would be truncated.'
-                );
+            req = new Request("insert into #temp values ('asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasd')", function(err) {
+              assert.match(err.message, /^String or binary data would be truncated/);
 
-                connection.close();
-              }
-            );
+              connection.close();
+            });
             connection.execSqlBatch(req);
           });
         });


### PR DESCRIPTION
On SQLServer 2019, this test would sometimes fail, because the error message would change from just

```
String or binary data would be truncated.
```

to

```
String or binary data would be truncated in table 'tempdb.dbo.#temp_______________________________________________________________________________________________________________000000000002', column 'value'. Truncated value: 'asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfas'.
```

As we don't actually care about the exact error message, we can change the assertion to match just the beginning of the error message and thus make this test pass on both newer and older SQLServer versions.