### PR TITLE
Add `devcontainer` configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "tediousjs/tedious",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	"extensions": [
+		"ms-mssql.mssql",
+		"dbaeumer.vscode-eslint"
+	],
+
+	"postCreateCommand": "npm install",
+
+	"containerEnv": {
+		"EDITOR": "code --wait"
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  app:
+    image: "mcr.microsoft.com/vscode/devcontainers/javascript-node:14"
+
+    volumes:
+      - "..:/workspace:cached"
+      - "./test-connection.json:/root/.tedious/test-connection.json"
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: "sleep infinity"
+
+    depends_on:
+      - mssql
+
+  mssql:
+    image: "mcr.microsoft.com/mssql/server:2019-latest"
+
+    restart: unless-stopped
+
+    environment:
+      - "ACCEPT_EULA=Y"
+      - "SA_PASSWORD=yourStrong(!)Password"

--- a/.devcontainer/test-connection.json
+++ b/.devcontainer/test-connection.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "server": "mssql",
+    "authentication": {
+      "type": "default",
+      "options": {
+        "userName": "sa",
+        "password": "yourStrong(!)Password"
+      }
+    },
+    "options": {
+      "port": 1433,
+      "database": "master",
+      "trustServerCertificate": true
+    }
+  }
+}


### PR DESCRIPTION
This adds configuration files for a `devcontainer` setup, as supported in VS Code.

This enables a relatively quick and painful way to set up a fully functional development environment for `tedious`, which works even in the browser via [GitHub Codespaces](https://github.com/features/codespaces/) or [Visual Studio Codespaces](https://visualstudio.microsoft.com/services/visual-studio-codespaces/).

The environment that will be spun up consists of one "JavaScript Development Container", and an additional container running  SQLServer 2019 for Linux. A `test-connection.json` file for running unit and integration tests will also be set up automatically. 