### PR TITLE
fix: correctly handle invalid packet headers

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1703,7 +1703,18 @@ class Connection extends EventEmitter {
     }
 
     if (connectListener) {
-      this.once('connect', connectListener);
+      const onConnect = () => {
+        this.removeListener('error', onError);
+        connectListener();
+      };
+
+      const onError = (err: Error) => {
+        this.removeListener('connect', onConnect);
+        connectListener(err);
+      };
+
+      this.once('connect', onConnect);
+      this.once('error', onError);
     }
 
     this.transitionTo(this.STATE.CONNECTING);
@@ -2217,6 +2228,9 @@ class Connection extends EventEmitter {
       this.messageIo.on('data', (data) => { this.dispatchEvent('data', data); });
       this.messageIo.on('message', () => { this.dispatchEvent('message'); });
       this.messageIo.on('secure', (cleartext) => { this.emit('secure', cleartext); });
+      this.messageIo.on('error', (error) => {
+        this.socketError(error);
+      });
 
       this.socket = socket;
       this.socketConnect();

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -42,6 +42,10 @@ class MessageIO extends EventEmitter {
       message.on('end', () => { this.emit('message'); });
     });
 
+    this.incomingMessageStream.on('error', (message) => {
+      this.emit('error', message);
+    });
+
     this.outgoingMessageStream = new OutgoingMessageStream(this.debug, { packetSize: packetSize });
 
     this.socket.pipe(this.incomingMessageStream as unknown as NodeJS.WritableStream);

--- a/test/integration/invalid-packet-stream-test.js
+++ b/test/integration/invalid-packet-stream-test.js
@@ -1,0 +1,58 @@
+const { assert } = require('chai');
+const net = require('net');
+const Connection = require('../../src/tedious').Connection;
+const ConnectionError = require('../../src/errors').ConnectionError;
+
+describe('Connecting to a server that sends invalid packet data', function() {
+  let server, sockets;
+
+  beforeEach(function(done) {
+    sockets = [];
+    server = net.createServer();
+    server.listen(0, '127.0.0.1', done);
+    server.on('connection', (socket) => {
+      sockets.push(socket);
+    });
+  });
+
+  afterEach(function(done) {
+    // Clean up all leftover sockets
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    server.close(done);
+  });
+
+  it('should throw Connection Error ', function(done) {
+    server.once('connection', (socket) => {
+      const packetData = Buffer.from('test1234');
+
+      const packetHeader = Buffer.alloc(8);
+      let offset = 0;
+      offset = packetHeader.writeUInt8(0x11, offset);
+      offset = packetHeader.writeUInt8(0x01, offset);
+      offset = packetHeader.writeUInt16BE(5, offset);
+      offset = packetHeader.writeUInt16BE(0x0000, offset);
+      offset = packetHeader.writeUInt8(1, offset);
+      packetHeader.writeUInt8(0x00, offset);
+
+      const packet = Buffer.concat([packetHeader, packetData]);
+      socket.write(packet);
+    });
+
+    const addressInfo = server.address();
+    const connection = new Connection({
+      server: addressInfo.address,
+      options: {
+        port: addressInfo.port,
+      }
+    });
+
+    connection.connect((err) => {
+      assert.instanceOf(err, ConnectionError);
+      assert.equal(err.message, 'Connection lost - Unable to process incoming packet');
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
When the server sends invalid packet header data, we will now correctly pass a `ConnectionError` to the `callback` given to `TranformStream._transform`.

Fixes: #1074
References: #1101