### PR TITLE
Stop stubbing `dns` module

### DIFF
--- a/test/unit/connector-test.js
+++ b/test/unit/connector-test.js
@@ -1,44 +1,16 @@
 const Mitm = require('mitm');
 const sinon = require('sinon');
-const dns = require('dns');
 const punycode = require('punycode');
 const assert = require('chai').assert;
 
-const ParallelConnectionStrategy = require('../../src/connector')
-  .ParallelConnectionStrategy;
-const SequentialConnectionStrategy = require('../../src/connector')
-  .SequentialConnectionStrategy;
-const Connector = require('../../src/connector').Connector;
+const {
+  ParallelConnectionStrategy,
+  SequentialConnectionStrategy,
+  Connector
+} = require('../../src/connector');
 
-function connectToIpTestImpl(hostIp, localIp, mitm, done) {
-  const connectionOptions = {
-    host: hostIp,
-    port: 12345,
-    localAddress: localIp
-  };
-  const connector = new Connector(connectionOptions, true);
-
-  let expectedSocket;
-
-  mitm.once('connect', function(socket, options) {
-    expectedSocket = socket;
-
-    assert.strictEqual(options, connectionOptions);
-  });
-
-  connector.execute(function(err, socket) {
-    if (err) {
-      return done(err);
-    }
-
-    assert.strictEqual(socket, expectedSocket);
-
-    done();
-  });
-}
-
-describe('connector tests', function() {
-  describe('Connector with MultiSubnetFailover', function() {
+describe('Connector', function() {
+  describe('with MultiSubnetFailover', function() {
     let mitm;
 
     beforeEach(function() {
@@ -50,15 +22,77 @@ describe('connector tests', function() {
       mitm.disable();
     });
 
-    it('should connects directly if given an IP v4 address', function(done) {
-      connectToIpTestImpl('127.0.0.1', '192.168.0.1', mitm, done);
+    it('connects directly if given an IP v4 address', function(done) {
+      const hostIp = '127.0.0.1';
+      const localIp = '192.168.0.1';
+
+      const connectionOptions = {
+        host: hostIp,
+        port: 12345,
+        localAddress: localIp
+      };
+      const connector = new Connector(connectionOptions, true);
+
+      let expectedSocket;
+
+      mitm.once('connect', function(socket, options) {
+        expectedSocket = socket;
+
+        assert.deepEqual(options, {
+          host: hostIp,
+          port: 12345,
+          localAddress: localIp,
+          family: 4
+        });
+      });
+
+      connector.execute(function(err, socket) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.strictEqual(socket, expectedSocket);
+
+        done();
+      });
     });
 
-    it('should connects directly if given an IP v6 address', function(done) {
-      connectToIpTestImpl('::1', '2002:20:0:0:0:0:1:2', mitm, done);
+    it('connects directly if given an IP v6 address', function(done) {
+      const hostIp = '::1';
+      const localIp = '2002:20:0:0:0:0:1:2';
+
+      const connectionOptions = {
+        host: hostIp,
+        port: 12345,
+        localAddress: localIp
+      };
+      const connector = new Connector(connectionOptions, true);
+
+      let expectedSocket;
+
+      mitm.once('connect', function(socket, options) {
+        expectedSocket = socket;
+
+        assert.deepEqual(options, {
+          host: hostIp,
+          port: 12345,
+          localAddress: localIp,
+          family: 6
+        });
+      });
+
+      connector.execute(function(err, socket) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.strictEqual(socket, expectedSocket);
+
+        done();
+      });
     });
 
-    it('should uses a parallel connection strategy', function(done) {
+    it('uses a parallel connection strategy', function(done) {
       const connector = new Connector({ host: 'localhost', port: 12345 }, true);
 
       const spy = sinon.spy(ParallelConnectionStrategy.prototype, 'connect');
@@ -75,7 +109,7 @@ describe('connector tests', function() {
     });
   });
 
-  describe('Connector without MultiSubnetFailover', function() {
+  describe('without MultiSubnetFailover', function() {
     let mitm;
 
     beforeEach(function() {
@@ -91,7 +125,7 @@ describe('connector tests', function() {
       sinon.restore();
     });
 
-    it('should connect directly if given an IP address', function(done) {
+    it('connects directly if given an IP address', function(done) {
       const connectionOptions = {
         host: '127.0.0.1',
         port: 12345,
@@ -103,7 +137,12 @@ describe('connector tests', function() {
       mitm.once('connect', function(socket, options) {
         expectedSocket = socket;
 
-        assert.strictEqual(options, connectionOptions);
+        assert.deepEqual(options, {
+          host: '127.0.0.1',
+          port: 12345,
+          localAddress: '192.168.0.1',
+          family: 4
+        });
       });
 
       connector.execute(function(err, socket) {
@@ -117,7 +156,7 @@ describe('connector tests', function() {
       });
     });
 
-    it('should uses a sequential connection strategy', function(done) {
+    it('uses a sequential connection strategy', function(done) {
       const connector = new Connector({ host: 'localhost', port: 12345 }, false);
 
       const spy = sinon.spy(
@@ -137,357 +176,358 @@ describe('connector tests', function() {
     });
   });
 
-  describe('SequentialConnectionStrategy', function() {
-    let mitm;
-
-    beforeEach(function() {
-      mitm = new Mitm();
-      mitm.enable();
-    });
-
-    afterEach(function() {
-      mitm.disable();
-    });
-
-    it('should tries to connect to all addresses in sequence', function(done) {
-      const strategy = new SequentialConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      const attemptedConnections = [];
-      mitm.on('connect', function(socket, options) {
-        attemptedConnections.push(options);
-
-        const expectedConnectionCount = attemptedConnections.length;
-        const handler = () => {
-          socket.removeListener('connect', handler);
-          socket.removeListener('error', handler);
-
-          assert.strictEqual(attemptedConnections.length, expectedConnectionCount);
-        };
-
-        socket.on('connect', handler);
-        socket.on('error', handler);
-
-        if (options.host !== '127.0.0.4') {
-          process.nextTick(() => {
-            socket.emit('error', new Error());
-          });
-        }
-      });
-
-      strategy.connect(function(err) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.strictEqual(attemptedConnections.length, 3);
-
-        assert.strictEqual(attemptedConnections[0].host, '127.0.0.2');
-        assert.strictEqual(attemptedConnections[0].port, 12345);
-        assert.strictEqual(attemptedConnections[0].localAddress, '192.168.0.1');
-
-        assert.strictEqual(attemptedConnections[1].host, '2002:20:0:0:0:0:1:3');
-        assert.strictEqual(attemptedConnections[1].port, 12345);
-        assert.strictEqual(attemptedConnections[1].localAddress, '192.168.0.1');
-
-        assert.strictEqual(attemptedConnections[2].host, '127.0.0.4');
-        assert.strictEqual(attemptedConnections[2].port, 12345);
-        assert.strictEqual(attemptedConnections[2].localAddress, '192.168.0.1');
-
-        done();
-      });
-    });
-
-    it('should passes the first succesfully connected socket to the callback', function(done) {
-      const strategy = new SequentialConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      let expectedSocket;
-      mitm.on('connect', function(socket, opts) {
-        if (opts.host !== '127.0.0.4') {
-          socket.destroy(new Error());
-        } else {
-          expectedSocket = socket;
-        }
-      });
-
-      strategy.connect(function(err, socket) {
-        assert.strictEqual(expectedSocket, socket);
-
-        done();
-      });
-    });
-
-    it('should only attempts new connections until the first successful connection', function(done) {
-      const strategy = new SequentialConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      const attemptedConnections = [];
-
-      mitm.on('connect', function(socket, options) {
-        attemptedConnections.push(options);
-      });
-
-      strategy.connect(function(err) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.strictEqual(attemptedConnections.length, 1);
-
-        assert.strictEqual(attemptedConnections[0].host, '127.0.0.2');
-        assert.strictEqual(attemptedConnections[0].port, 12345);
-        assert.strictEqual(attemptedConnections[0].localAddress, '192.168.0.1');
-
-        done();
-      });
-    });
-
-    it('should fails if all sequential connections fail', function(done) {
-      const strategy = new SequentialConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      mitm.on('connect', function(socket) {
-        process.nextTick(() => {
-          socket.emit('error', new Error());
-        });
-      });
-
-      strategy.connect(function(err, socket) {
-        assert.equal('Could not connect (sequence)', err.message);
-
-        done();
-      });
-    });
-
-    it('should destroys all sockets except for the first succesfully connected socket', function(done) {
-      const strategy = new SequentialConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      const attemptedSockets = [];
-
-      mitm.on('connect', function(socket, options) {
-        attemptedSockets.push(socket);
-
-        if (options.host !== '127.0.0.4') {
-          process.nextTick(() => {
-            socket.emit('error', new Error());
-          });
-        }
-      });
-
-      strategy.connect(function(err, socket) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.isOk(attemptedSockets[0].destroyed);
-        assert.isOk(attemptedSockets[1].destroyed);
-        assert.isOk(!attemptedSockets[2].destroyed);
-
-        done();
-      });
-    });
-  });
-
-  describe('ParallelConnectionStrategy', function() {
-    let mitm;
-
-    beforeEach(function() {
-      mitm = new Mitm();
-      mitm.enable();
-    });
-
-    afterEach(function() {
-      mitm.disable();
-    });
-
-    it('should tries to connect to all addresses in parallel', function(done) {
-      const strategy = new ParallelConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      const attemptedConnections = [];
-
-      mitm.on('connect', function(socket, options) {
-        attemptedConnections.push(options);
-
-        socket.once('connect', function() {
-          assert.strictEqual(attemptedConnections.length, 3);
-        });
-      });
-
-      strategy.connect(function(err, socket) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.strictEqual(attemptedConnections[0].host, '127.0.0.2');
-        assert.strictEqual(attemptedConnections[0].port, 12345);
-        assert.strictEqual(attemptedConnections[0].localAddress, '192.168.0.1');
-
-        assert.strictEqual(attemptedConnections[1].host, '2002:20:0:0:0:0:1:3');
-        assert.strictEqual(attemptedConnections[1].port, 12345);
-        assert.strictEqual(attemptedConnections[1].localAddress, '192.168.0.1');
-
-        assert.strictEqual(attemptedConnections[2].host, '127.0.0.4');
-        assert.strictEqual(attemptedConnections[2].port, 12345);
-        assert.strictEqual(attemptedConnections[2].localAddress, '192.168.0.1');
-
-        done();
-      });
-    });
-
-    it('should fails if all parallel connections fail', function(done) {
-      const strategy = new ParallelConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      mitm.on('connect', function(socket) {
-        process.nextTick(() => {
-          socket.emit('error', new Error());
-        });
-      });
-
-      strategy.connect(function(err, socket) {
-        assert.equal('Could not connect (parallel)', err.message);
-
-        done();
-      });
-    });
-
-    it('should passes the first succesfully connected socket to the callback', function(done) {
-      const strategy = new ParallelConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      let expectedSocket;
-      mitm.on('connect', function(socket, opts) {
-        if (opts.host !== '127.0.0.4') {
-          process.nextTick(() => {
-            socket.emit('error', new Error());
-          });
-        } else {
-          expectedSocket = socket;
-        }
-      });
-
-      strategy.connect(function(err, socket) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.strictEqual(expectedSocket, socket);
-
-        done();
-      });
-    });
-
-    it('should destroys all sockets except for the first succesfully connected socket', function(done) {
-      const strategy = new ParallelConnectionStrategy(
-        [
-          { address: '127.0.0.2' },
-          { address: '2002:20:0:0:0:0:1:3' },
-          { address: '127.0.0.4' }
-        ],
-        { port: 12345, localAddress: '192.168.0.1' }
-      );
-
-      const attemptedSockets = [];
-
-      mitm.on('connect', function(socket) {
-        attemptedSockets.push(socket);
-      });
-
-      strategy.connect(function(err, socket) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.isOk(!attemptedSockets[0].destroyed);
-        assert.isOk(attemptedSockets[1].destroyed);
-        assert.isOk(attemptedSockets[2].destroyed);
-
-        done();
-      });
-    });
-  });
-
   describe('Test unicode SQL Server name', function() {
-    let spy;
+    it('test IDN Server name', function(done) {
+      const lookup = sinon.spy(function lookup(hostname, options, callback) {
+        callback([{ address: '127.0.0.1', family: 4 }]);
+      });
 
-    beforeEach(function() {
-      // Spy the dns.lookup so we can verify if it receives punycode value for IDN Server names
-      spy = sinon.spy(dns, 'lookup');
-    });
-
-    afterEach(function() {
-      sinon.restore();
-    });
-
-    it('should test IDN Server name', function() {
       const server = '本地主机.ad';
-      const connector = new Connector({ host: server, port: 12345 }, true);
+      const connector = new Connector({ host: server, port: 12345, lookup: lookup }, true);
 
-      connector.execute(() => { });
+      connector.execute(() => {
+        assert.isOk(lookup.called, 'Failed to call `lookup` function for hostname');
+        assert.isOk(lookup.calledWithMatch(punycode.toASCII(server)), 'Unexpected hostname passed to `lookup`');
 
-      assert.isOk(spy.called, 'Failed to call dns.lookup on hostname');
-      assert.isOk(spy.calledWithMatch(punycode.toASCII(server)), 'Unexpcted hostname passed to dns.lookup');
+        done();
+      });
     });
 
-    it('should test ASCII Server name', function() {
+    it('test ASCII Server name', function(done) {
+      const lookup = sinon.spy(function lookup(hostname, options, callback) {
+        callback([{ address: '127.0.0.1', family: 4 }]);
+      });
+
       const server = 'localhost';
-      const connector = new Connector({ host: server, port: 12345 }, true);
+      const connector = new Connector({ host: server, port: 12345, lookup: lookup }, true);
 
-      connector.execute(() => { });
+      connector.execute(() => {
+        assert.isOk(lookup.called, 'Failed to call `lookup` function for hostname');
+        assert.isOk(lookup.calledWithMatch(server), 'Unexpected hostname passed to `lookup`');
 
-      assert.isOk(spy.called, 'Failed to call dns.lookup on hostname');
-      assert.isOk(spy.calledWithMatch(server), 'Unexpcted hostname passed to dns.lookup');
+        done();
+      });
+    });
+  });
+});
+
+describe('SequentialConnectionStrategy', function() {
+  let mitm;
+
+  beforeEach(function() {
+    mitm = new Mitm();
+    mitm.enable();
+  });
+
+  afterEach(function() {
+    mitm.disable();
+  });
+
+  it('tries to connect to all addresses in sequence', function(done) {
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedConnections = [];
+    mitm.on('connect', function(socket, options) {
+      attemptedConnections.push(options);
+
+      const expectedConnectionCount = attemptedConnections.length;
+      const handler = () => {
+        socket.removeListener('connect', handler);
+        socket.removeListener('error', handler);
+
+        assert.strictEqual(attemptedConnections.length, expectedConnectionCount);
+      };
+
+      socket.on('connect', handler);
+      socket.on('error', handler);
+
+      if (options.host !== '127.0.0.4') {
+        process.nextTick(() => {
+          socket.emit('error', new Error());
+        });
+      }
+    });
+
+    strategy.connect(function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(attemptedConnections.length, 3);
+
+      assert.strictEqual(attemptedConnections[0].host, '127.0.0.2');
+      assert.strictEqual(attemptedConnections[0].port, 12345);
+      assert.strictEqual(attemptedConnections[0].localAddress, '192.168.0.1');
+
+      assert.strictEqual(attemptedConnections[1].host, '2002:20:0:0:0:0:1:3');
+      assert.strictEqual(attemptedConnections[1].port, 12345);
+      assert.strictEqual(attemptedConnections[1].localAddress, '192.168.0.1');
+
+      assert.strictEqual(attemptedConnections[2].host, '127.0.0.4');
+      assert.strictEqual(attemptedConnections[2].port, 12345);
+      assert.strictEqual(attemptedConnections[2].localAddress, '192.168.0.1');
+
+      done();
+    });
+  });
+
+  it('passes the first succesfully connected socket to the callback', function(done) {
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    let expectedSocket;
+    mitm.on('connect', function(socket, opts) {
+      if (opts.host !== '127.0.0.4') {
+        socket.destroy(new Error());
+      } else {
+        expectedSocket = socket;
+      }
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.strictEqual(expectedSocket, socket);
+
+      done();
+    });
+  });
+
+  it('only attempts new connections until the first successful connection', function(done) {
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedConnections = [];
+
+    mitm.on('connect', function(socket, options) {
+      attemptedConnections.push(options);
+    });
+
+    strategy.connect(function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(attemptedConnections.length, 1);
+
+      assert.strictEqual(attemptedConnections[0].host, '127.0.0.2');
+      assert.strictEqual(attemptedConnections[0].port, 12345);
+      assert.strictEqual(attemptedConnections[0].localAddress, '192.168.0.1');
+
+      done();
+    });
+  });
+
+  it('fails if all sequential connections fail', function(done) {
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    mitm.on('connect', function(socket) {
+      process.nextTick(() => {
+        socket.emit('error', new Error());
+      });
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.equal('Could not connect (sequence)', err.message);
+
+      done();
+    });
+  });
+
+  it('destroys all sockets except for the first succesfully connected socket', function(done) {
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedSockets = [];
+
+    mitm.on('connect', function(socket, options) {
+      attemptedSockets.push(socket);
+
+      if (options.host !== '127.0.0.4') {
+        process.nextTick(() => {
+          socket.emit('error', new Error());
+        });
+      }
+    });
+
+    strategy.connect(function(err, socket) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.isOk(attemptedSockets[0].destroyed);
+      assert.isOk(attemptedSockets[1].destroyed);
+      assert.isOk(!attemptedSockets[2].destroyed);
+
+      done();
+    });
+  });
+});
+
+describe('ParallelConnectionStrategy', function() {
+  let mitm;
+
+  beforeEach(function() {
+    mitm = new Mitm();
+    mitm.enable();
+  });
+
+  afterEach(function() {
+    mitm.disable();
+  });
+
+  it('tries to connect to all addresses in parallel', function(done) {
+    const strategy = new ParallelConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedConnections = [];
+
+    mitm.on('connect', function(socket, options) {
+      attemptedConnections.push(options);
+
+      socket.once('connect', function() {
+        assert.strictEqual(attemptedConnections.length, 3);
+      });
+    });
+
+    strategy.connect(function(err, socket) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(attemptedConnections[0].host, '127.0.0.2');
+      assert.strictEqual(attemptedConnections[0].port, 12345);
+      assert.strictEqual(attemptedConnections[0].localAddress, '192.168.0.1');
+
+      assert.strictEqual(attemptedConnections[1].host, '2002:20:0:0:0:0:1:3');
+      assert.strictEqual(attemptedConnections[1].port, 12345);
+      assert.strictEqual(attemptedConnections[1].localAddress, '192.168.0.1');
+
+      assert.strictEqual(attemptedConnections[2].host, '127.0.0.4');
+      assert.strictEqual(attemptedConnections[2].port, 12345);
+      assert.strictEqual(attemptedConnections[2].localAddress, '192.168.0.1');
+
+      done();
+    });
+  });
+
+  it('fails if all parallel connections fail', function(done) {
+    const strategy = new ParallelConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    mitm.on('connect', function(socket) {
+      process.nextTick(() => {
+        socket.emit('error', new Error());
+      });
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.equal('Could not connect (parallel)', err.message);
+
+      done();
+    });
+  });
+
+  it('passes the first succesfully connected socket to the callback', function(done) {
+    const strategy = new ParallelConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    let expectedSocket;
+    mitm.on('connect', function(socket, opts) {
+      if (opts.host !== '127.0.0.4') {
+        process.nextTick(() => {
+          socket.emit('error', new Error());
+        });
+      } else {
+        expectedSocket = socket;
+      }
+    });
+
+    strategy.connect(function(err, socket) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(expectedSocket, socket);
+
+      done();
+    });
+  });
+
+  it('destroys all sockets except for the first succesfully connected socket', function(done) {
+    const strategy = new ParallelConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedSockets = [];
+
+    mitm.on('connect', function(socket) {
+      attemptedSockets.push(socket);
+    });
+
+    strategy.connect(function(err, socket) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.isOk(!attemptedSockets[0].destroyed);
+      assert.isOk(attemptedSockets[1].destroyed);
+      assert.isOk(attemptedSockets[2].destroyed);
+
+      done();
     });
   });
 });

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -1,8 +1,8 @@
 const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
 const sinon = require('sinon');
-const dns = require('dns');
 const punycode = require('punycode');
 const assert = require('chai').assert;
+const dgram = require('dgram');
 
 describe('instanceLookup invalid args', function() {
   let instanceLookup;
@@ -56,218 +56,139 @@ describe('instanceLookup invalid args', function() {
   });
 });
 
-describe('instanceLookup functional unit tests', function() {
+describe('InstanceLookup', function() {
+  let server;
 
-  let options;
-  let anyPort;
-  let anyRequest;
-  let anyMessage;
-  let anyError;
-  let anySqlPort;
-  let instanceLookup;
-  let testSender;
-  let createSenderStub;
-  let senderExecuteStub;
-  let parseStub;
-
-
-  beforeEach(function() {
-    options = {
-      server: 'server',
-      instanceName: 'instance',
-      timeout: 1000,
-      retries: 3
-    };
-
-    anyPort = 1234;
-    anyRequest = Buffer.alloc(0x02);
-    anyMessage = 'any message';
-    anyError = new Error('any error');
-    anySqlPort = 2345;
-
-    instanceLookup = new InstanceLookup();
-
-    // Stub out createSender method to return the Sender we create. This allows us
-    // to override the execute method on Sender so we can test instance lookup code
-    // without triggering network activity.
-    testSender = instanceLookup.createSender(
-      options.server,
-      anyPort,
-      anyRequest
-    );
-    createSenderStub = sinon.stub(
-      instanceLookup,
-      'createSender'
-    );
-    createSenderStub.returns(testSender);
-    senderExecuteStub = sinon.stub(testSender, 'execute');
-
-    // Stub parseBrowserResponse so we can mimic success and failure without creating
-    // elaborate responses. parseBrowserResponse itself has unit tests to ensure that
-    // it functions correctly.
-    parseStub = sinon.stub(
-      instanceLookup,
-      'parseBrowserResponse'
-    );
+  beforeEach(function(done) {
+    server = dgram.createSocket('udp4');
+    server.bind(0, '127.0.0.1', done);
   });
 
-  afterEach(function() {
-    sinon.restore();
-  }),
+  afterEach(function(done) {
+    server.close(done);
+  });
 
-  it('success', (done) => {
-    senderExecuteStub.callsArgWithAsync(0, null, anyMessage);
-    parseStub
-      .withArgs(anyMessage, options.instanceName)
-      .returns(anySqlPort);
-
-    instanceLookup.instanceLookup(options, (error, port) => {
-      assert.strictEqual(error, undefined);
-      assert.strictEqual(port, anySqlPort);
-
-      assert.ok(createSenderStub.calledOnce);
-      assert.strictEqual(createSenderStub.args[0][0], options.server);
-      assert.strictEqual(createSenderStub.args[0][3]);
-
-      assert.ok(senderExecuteStub.calledOnce);
-      assert.ok(parseStub.calledOnce);
-
-      done();
-    });
-  }),
-
-  it('sender fail', (done) => {
-    senderExecuteStub.callsArgWithAsync(0, anyError, undefined);
-
-    instanceLookup.instanceLookup(options, (error, port) => {
-      assert.ok(error.indexOf(anyError.message) !== -1);
-      assert.strictEqual(port, undefined);
-
-      assert.ok(createSenderStub.calledOnce);
-      assert.strictEqual(createSenderStub.args[0][0], options.server);
-      assert.strictEqual(createSenderStub.args[0][3]);
-
-      assert.ok(senderExecuteStub.calledOnce);
-      assert.strictEqual(parseStub.callCount, 0);
-
-      done();
-    });
-  }),
-
-  it('parse fail', (done) => {
-    senderExecuteStub.callsArgWithAsync(0, null, anyMessage);
-    parseStub
-      .withArgs(anyMessage, options.instanceName)
-      .returns(null);
-
-    instanceLookup.instanceLookup(options, (error, port) => {
-      assert.ok(error.indexOf('not found') !== -1);
-      assert.strictEqual(port, undefined);
-
-      assert.ok(createSenderStub.calledOnce);
-      assert.strictEqual(createSenderStub.args[0][0], options.server);
-      assert.strictEqual(createSenderStub.args[0][3]);
-
-      assert.ok(senderExecuteStub.calledOnce);
-      assert.ok(parseStub.calledOnce);
-
-      done();
-    });
-  }),
-
-  it('retry success', (done) => {
-    // First invocation of execute will not invoke callback. This will cause a timeout
-    // and trigger a retry. Setup to invoke callback on second invocation.
-    senderExecuteStub
-      .onCall(1)
-      .callsArgWithAsync(0, null, anyMessage);
-    parseStub
-      .withArgs(anyMessage, options.instanceName)
-      .returns(anySqlPort);
-
-    const clock = sinon.useFakeTimers();
-
-    instanceLookup.instanceLookup(options, (error, port) => {
-      assert.strictEqual(error, undefined);
-      assert.strictEqual(port, anySqlPort);
-
-      assert.ok(createSenderStub.callCount, 2);
-      for (let j = 0; j < createSenderStub.callCount; j++) {
-        assert.strictEqual(createSenderStub.args[j][0], options.server);
-        assert.strictEqual(createSenderStub.args[j][3]);
-      }
-
-      // Execute called twice but parse only called once as the first call to execute times out.
-      assert.strictEqual(senderExecuteStub.callCount, 2);
-      assert.ok(parseStub.calledOnce);
-
-      clock.restore();
+  it('sends a request to the given server browser endpoint', function(done) {
+    server.on('message', (msg) => {
+      assert.deepEqual(msg, Buffer.from([0x02]));
 
       done();
     });
 
-    // Forward clock to trigger timeout.
-    clock.tick(options.timeout * 1.1);
-  }),
-
-  it('retry fail', (done) => {
-    const clock = sinon.useFakeTimers();
-
-    const forwardClock = () => {
-      clock.tick(options.timeout * 1.1);
-    };
-
-    function scheduleForwardClock() {
-      // This function is called in place of sender.execute(). We don't want to
-      // rely on when the timeout is set in relation to execute() in the calling
-      // context. So we setup to forward clock on next tick.
-      process.nextTick(forwardClock);
-    }
-
-    senderExecuteStub.restore();
-    senderExecuteStub = sinon.stub(
-      testSender,
-      'execute',
-    ).callsFake(scheduleForwardClock);
-
-    instanceLookup.instanceLookup(options, (error, port) => {
-      assert.ok(error.indexOf('Failed to get response') !== -1);
-      assert.strictEqual(port, undefined);
-
-      assert.strictEqual(createSenderStub.callCount, options.retries);
-      for (let j = 0; j < createSenderStub.callCount; j++) {
-        assert.strictEqual(createSenderStub.args[j][0], options.server);
-        assert.strictEqual(createSenderStub.args[j][3]);
-      }
-
-      // Execute called 'retries' number of times but parse is never called because
-      // all the execute calls timeout.
-      assert.strictEqual(senderExecuteStub.callCount, options.retries);
-      assert.strictEqual(parseStub.callCount, 0);
-
-      clock.restore();
-
-      done();
+    new InstanceLookup().instanceLookup({
+      server: server.address().address,
+      port: server.address().port,
+      instanceName: 'second',
+      timeout: 500,
+      retries: 1,
+    }, () => {
+      // Ignore
     });
-  }),
+  });
 
-  it('incorrect instanceName', (done) => {
-    const message = 'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
-      'ServerName;WINDOWS2;InstanceName;YYYYYYYYYY;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
-    senderExecuteStub.callsArgWithAsync(0, null, message);
-    parseStub
-      .withArgs(message, options.instanceName);
+  describe('when not receiving a response', function(done) {
+    it('times out after the given timeout period', function(done) {
+      let timedOut = false;
+      let errored = false;
 
-    instanceLookup.instanceLookup(options, (error, port) => {
-      assert.ok(error.indexOf('XXXXXXXXXX') === -1);
-      assert.ok(error.indexOf('YYYYYYYYYY') === -1);
-      assert.strictEqual(port, undefined);
+      setTimeout(() => {
+        timedOut = true;
+      }, 500);
 
-      assert.ok(createSenderStub.calledOnce);
-      assert.ok(senderExecuteStub.calledOnce);
-      assert.ok(parseStub.calledOnce);
+      setTimeout(() => {
+        assert.isTrue(errored);
+        done();
+      }, 600);
 
-      done();
+      new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'instance',
+        timeout: 500,
+        retries: 1,
+      }, (err) => {
+        assert.isOk(err);
+        assert.match(err, /^Failed to get response from SQL Server Browser/);
+        assert.isTrue(timedOut);
+
+        errored = true;
+      });
+    });
+  });
+
+  describe('when receiving a response before timing out', function() {
+    it('returns the port for the instance with a matching name', function(done) {
+      server.on('message', (msg, rinfo) => {
+        const response = [
+          'ServerName;WINDOWS2;InstanceName;first;IsClustered;No;Version;10.50.2500.0;tcp;1444;;',
+          'ServerName;WINDOWS2;InstanceName;second;IsClustered;No;Version;10.50.2500.0;tcp;1433;;',
+          'ServerName;WINDOWS2;InstanceName;third;IsClustered;No;Version;10.50.2500.0;tcp;1445;;'
+        ].join('');
+
+        server.send(response, rinfo.port, rinfo.address);
+      });
+
+      new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'second',
+        timeout: 500,
+        retries: 1,
+      }, (err, result) => {
+        assert.ifError(err);
+
+        assert.strictEqual(result, 1433);
+
+        done();
+      });
+    });
+  });
+
+  describe('when receiving a response that does not contain the requested instance name', function() {
+    it('returns an error', function(done) {
+      server.on('message', (msg, rinfo) => {
+        const response = [
+          'ServerName;WINDOWS2;InstanceName;first;IsClustered;No;Version;10.50.2500.0;tcp;1444;;',
+          'ServerName;WINDOWS2;InstanceName;second;IsClustered;No;Version;10.50.2500.0;tcp;1433;;',
+          'ServerName;WINDOWS2;InstanceName;third;IsClustered;No;Version;10.50.2500.0;tcp;1445;;'
+        ].join('');
+
+        server.send(response, rinfo.port, rinfo.address);
+      });
+
+      new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'other',
+        timeout: 500,
+        retries: 1,
+      }, (err) => {
+        assert.isOk(err);
+        assert.match(err, /^Port for other not found/);
+
+        done();
+      });
+    });
+  });
+
+  describe('when receiving an invalid response', function() {
+    it('returns an error', function(done) {
+      server.on('message', (msg, rinfo) => {
+        server.send('foo bar baz', rinfo.port, rinfo.address);
+      });
+
+      new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'other',
+        timeout: 500,
+        retries: 1,
+      }, (err) => {
+        assert.isOk(err);
+        assert.match(err, /^Port for other not found/);
+
+        done();
+      });
     });
   });
 });
@@ -312,43 +233,43 @@ describe('parseBrowserResponse', function() {
 });
 
 describe('parseBrowserResponse', function() {
-  let spy;
-
-  beforeEach(function() {
-    spy = sinon.spy(dns, 'lookup');
-  });
-
-  afterEach(function() {
-    sinon.restore();
-  });
-
   it('test IDN Server name', (done) => {
+    const lookup = sinon.spy(function lookup(hostname, options, callback) {
+      callback([{ address: '127.0.0.1', family: 4 }]);
+    });
+
     const options = {
       server: '本地主机.ad',
       instanceName: 'instance',
       timeout: 500,
-      retries: 1
+      retries: 1,
+      lookup: lookup
     };
 
     new InstanceLookup().instanceLookup(options, () => {
-      assert.ok(spy.called, 'Failed to call dns.lookup on hostname');
-      assert.ok(spy.calledWithMatch(punycode.toASCII(options.server)), 'Unexpected hostname passed to dns.lookup');
+      sinon.assert.calledOnce(lookup);
+      sinon.assert.calledWithMatch(lookup, punycode.toASCII(options.server));
 
       done();
     });
   });
 
   it('test ASCII Server name', (done) => {
+    const lookup = sinon.spy(function lookup(hostname, options, callback) {
+      callback([{ address: '127.0.0.1', family: 4 }]);
+    });
+
     const options = {
       server: 'localhost',
       instanceName: 'instance',
       timeout: 500,
-      retries: 1
+      retries: 1,
+      lookup: lookup
     };
 
-    new InstanceLookup().instanceLookup(options, () => {
-      assert.ok(spy.called, 'Failed to call dns.lookup on hostname');
-      assert.ok(spy.calledWithMatch(options.server), 'Unexpected hostname passed to dns.lookup');
+    new InstanceLookup().instanceLookup(options, (err) => {
+      sinon.assert.calledOnce(lookup);
+      sinon.assert.calledWithMatch(lookup, options.server);
 
       done();
     });


### PR DESCRIPTION
This removes the stubbing of `dns.lookup` we had in place in some of our test cases.

This stubbing was error prone and lead to a whole bunch of flaky test failures on CI.

Instead of stubbing functions, this changes relevant code to allow passing in a custom `lookup` function, but falling back to `dns.lookup` if that function is `undefined`.

Closes: https://github.com/tediousjs/tedious/pull/988