### PR TITLE
refactor: prefer TypeScript's `interface` over `type`

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -34,12 +34,12 @@ const DONE_STATUS = {
   SRVERROR: 0x100
 };
 
-type InternalOptions = {
+interface InternalOptions {
   checkConstraints: boolean;
   fireTriggers: boolean;
   keepNulls: boolean;
   lockTable: boolean;
-};
+}
 
 export interface Options {
   checkConstraints?: InternalOptions['checkConstraints'];
@@ -50,18 +50,18 @@ export interface Options {
 
 export type Callback = (err: Error | undefined | null, rowCount?: number) => void;
 
-type Column = Parameter & {
+interface Column extends Parameter {
   objName: string;
-};
+}
 
-type ColumnOptions = {
+interface ColumnOptions {
   output?: boolean;
   length?: number;
   precision?: number;
   scale?: number;
   objName?: string;
   nullable?: boolean;
-};
+}
 
 // A transform that converts rows to packets.
 class RowTransform extends Transform {

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -40,7 +40,7 @@ import Variant from './data-types/sql-variant';
 
 import { InternalConnectionOptions } from './connection';
 
-export type Parameter = {
+export interface Parameter {
   type: DataType;
   name: string;
 
@@ -52,15 +52,15 @@ export type Parameter = {
   scale?: number;
 
   nullable?: boolean;
-};
+}
 
-export type ParameterData<T = any> = {
+export interface ParameterData<T = any> {
   length?: number;
   scale?: number;
   precision?: number;
 
   value: T;
-};
+}
 
 export interface DataType {
   id: number;

--- a/src/login7-payload.ts
+++ b/src/login7-payload.ts
@@ -63,7 +63,7 @@ const FEDAUTH_OPTIONS = {
 
 const FEATURE_EXT_TERMINATOR = 0xFF;
 
-type Options = {
+interface Options {
   tdsVersion: number;
   packetSize: number;
   clientProgVer: number;
@@ -71,7 +71,7 @@ type Options = {
   connectionId: number;
   clientTimeZone: number;
   clientLcid: number;
-};
+}
 
 /*
   s2.2.6.3

--- a/src/metadata-parser.ts
+++ b/src/metadata-parser.ts
@@ -5,29 +5,29 @@ import { TYPE, DataType } from './data-type';
 
 import { sprintf } from 'sprintf-js';
 
-type Collation = {
+interface Collation {
   lcid: number;
   flags: number;
   version: number;
   sortId: number;
   codepage: string;
-};
+}
 
-type XmlSchema = {
+interface XmlSchema {
   dbname: string;
   owningSchema: string;
   xmlSchemaCollection: string;
-};
+}
 
-type UdtInfo = {
+interface UdtInfo {
   maxByteSize: number;
   dbname: string;
   owningSchema: string;
   typeName: string;
   assemblyName: string;
-};
+}
 
-export type Metadata = {
+export interface Metadata {
   userType: number;
   flags: number;
   type: DataType;
@@ -37,7 +37,7 @@ export type Metadata = {
   dataLength: number | undefined;
   schema: XmlSchema | undefined;
   udtInfo: UdtInfo | undefined;
-};
+}
 
 function readCollation(parser: Parser, callback: (collation: Collation | undefined) => void) {
   // s2.2.5.1.2

--- a/src/ntlm-payload.ts
+++ b/src/ntlm-payload.ts
@@ -2,7 +2,7 @@ import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import * as crypto from 'crypto';
 import JSBI from 'jsbi';
 
-type Options = {
+interface Options {
   domain: string;
   userName: string;
   password: string;
@@ -10,7 +10,7 @@ type Options = {
     target: Buffer;
     nonce: Buffer;
   };
-};
+}
 
 class NTLMResponsePayload {
   data: Buffer;

--- a/src/prelogin-payload.ts
+++ b/src/prelogin-payload.ts
@@ -45,9 +45,9 @@ for (const name in MARS) {
 }
 
 
-type Options = {
+interface Options {
   encrypt: boolean;
-};
+}
 
 /*
   s2.2.6.4

--- a/src/request.ts
+++ b/src/request.ts
@@ -7,7 +7,7 @@ import Connection from './connection';
 // TODO: Figure out how to type the `rows` parameter here.
 type CompletionCallback = (error: Error | null | undefined, rowCount?: number, rows?: any) => void;
 
-type ParameterOptions = {
+interface ParameterOptions {
   output?: boolean;
   length?: number;
   precision?: number;

--- a/src/token/colmetadata-token-parser.ts
+++ b/src/token/colmetadata-token-parser.ts
@@ -4,10 +4,10 @@ import Parser from './stream-parser';
 import { InternalConnectionOptions } from '../connection';
 import { ColMetadataToken } from './token';
 
-export type ColumnMetadata = Metadata & {
+export interface ColumnMetadata extends Metadata {
   colName: string;
   tableName?: string | string[];
-};
+}
 
 function readTableName(parser: Parser, options: InternalConnectionOptions, metadata: Metadata, callback: (tableName?: string | string[]) => void) {
   if (metadata.type.hasTableName) {

--- a/src/token/done-token-parser.ts
+++ b/src/token/done-token-parser.ts
@@ -16,14 +16,14 @@ const STATUS = {
   SRVERROR: 0x0100
 };
 
-type TokenData = {
+interface TokenData {
   more: boolean;
   sqlError: boolean;
   attention: boolean;
   serverError: boolean;
   rowCount: number | undefined;
   curCmd: number;
-};
+}
 
 function parseToken(parser: Parser, options: InternalConnectionOptions, callback: (data: TokenData) => void) {
   parser.readUInt16LE((status) => {

--- a/src/token/infoerror-token-parser.ts
+++ b/src/token/infoerror-token-parser.ts
@@ -3,7 +3,7 @@ import { InternalConnectionOptions } from '../connection';
 
 import { InfoMessageToken, ErrorMessageToken } from './token';
 
-type TokenData = {
+interface TokenData {
   number: number;
   state: number;
   class: number;
@@ -11,7 +11,7 @@ type TokenData = {
   serverName: string;
   procName: string;
   lineNumber: number;
-};
+}
 
 function parseToken(parser: Parser, options: InternalConnectionOptions, callback: (data: TokenData) => void) {
   // length

--- a/src/token/nbcrow-token-parser.ts
+++ b/src/token/nbcrow-token-parser.ts
@@ -12,10 +12,10 @@ function nullHandler(_parser: Parser, _columnMetadata: ColumnMetadata, _options:
   callback(null);
 }
 
-type Column = {
+interface Column {
   value: unknown;
   metadata: ColumnMetadata;
-};
+}
 
 function nbcRowParser(parser: Parser, options: InternalConnectionOptions, callback: (token: NBCRowToken) => void) {
   const columnsMetaData = parser.colMetadata;

--- a/src/token/row-token-parser.ts
+++ b/src/token/row-token-parser.ts
@@ -8,10 +8,10 @@ import { RowToken } from './token';
 
 import valueParse from '../value-parser';
 
-type Column = {
+interface Column {
   value: unknown;
   metadata: ColumnMetadata;
-};
+}
 
 function rowParser(parser: Parser, options: InternalConnectionOptions, callback: (token: RowToken) => void) {
   const colMetadata = parser.colMetadata;

--- a/src/token/sspi-token-parser.ts
+++ b/src/token/sspi-token-parser.ts
@@ -3,7 +3,7 @@ import { InternalConnectionOptions } from '../connection';
 
 import { SSPIToken } from './token';
 
-type Data = {
+interface Data {
   magic: string;
   type: number;
   domainLen: number;
@@ -18,7 +18,7 @@ type Data = {
   oddData: Buffer;
   domain: string;
   target: Buffer;
-};
+}
 
 function parseChallenge(buffer: Buffer) {
   const challenge: Partial<Data> = {};


### PR DESCRIPTION
This is a cleanup extracted from https://github.com/tediousjs/tedious/pull/995, and just switches `type` assignments with `interface` declarations.

There is not really much of a difference between those two. See https://medium.com/@martin_hotell/interface-vs-type-alias-in-typescript-2-7-2a8f1777af4c for a blog post highlighting the difference more closely.

The main intent for switching from one to the other is to just be a bit more consistent.