### PR TITLE
refactor: update `connect` helper type signature

### DIFF
--- a/src/tedious.ts
+++ b/src/tedious.ts
@@ -11,7 +11,7 @@ import { versions as TDS_VERSION } from './tds-versions';
 
 const library = { name: name };
 
-export function connect(config: ConnectionConfiguration, connectListener?: (err?: Error) => {}) {
+export function connect(config: ConnectionConfiguration, connectListener?: (err?: Error) => void) {
   const connection = new Connection(config);
   connection.connect(connectListener);
   return connection;


### PR DESCRIPTION
This fixes the type signature of the `connect` helper that was added in https://github.com/tediousjs/tedious/pull/1069.

Note: this is marked as `refactor` because we don't yet publish type signatures and this has thus no impact on users.