### PR TITLE
ci: fix running`commitlint` on GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -44,7 +44,9 @@ jobs:
 
     - name: Prepare Commitlint (push)
       if: ${{ github.event_name == 'push' }}
-      run: echo "::set-env name=TRAVIS_COMMIT_RANGE::${{ github.event.before }}..${{ github.event.after }}"
+      run:  |
+        echo "::set-env name=TRAVIS_PULL_REQUEST_SLUG::"
+        echo "::set-env name=TRAVIS_COMMIT_RANGE::${{ github.event.before }}..${{ github.event.after }}"
 
     - run: npx commitlint-travis
       env:


### PR DESCRIPTION
This fixes the `Error: Expected TRAVIS_PULL_REQUEST_SLUG to be defined globally, it was not.` failure when GitHub Actions executes the commit message linter after a push to the `master` branch. (https://github.com/tediousjs/tedious/runs/773821309)