### PR TITLE
ci: fix condition for running tests against Azure

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only run these tests if we have access to the secrets
-    if: ${{ github.repository == 'tediousjs/tedious' }}
+    if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
As Pull Requests that are opened from a forked repository don't have access to secrets that contain the Azure username and password, so we want to skip running that job.

This fixes a mistake I made that prevented the Azure job from being skipped.