### PR TITLE
fix: use proper servername for TLS after redirect

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2201,7 +2201,7 @@ Connection.prototype.STATE = {
             return this.close();
           }
 
-          this.messageIo.startTls(this.secureContext, this.config.server, this.config.options.trustServerCertificate);
+          this.messageIo.startTls(this.secureContext, this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
           this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
         } else {
           this.sendLogin7Packet();


### PR DESCRIPTION
This fixes an issue where after a server redirect, we would continue to use the original servername when trying to establish a TLS connection. This issue is only visible when `trustServerCertificate` was explicitly set to `false`, as otherwise the hostname returned by the certificate was never verified.

Fixes: https://github.com/tediousjs/tedious/issues/1081
