### PR TITLE
chore: try to fix npm release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ jobs:
       with:
         node-version: 12
 
-    - run: echo "//registry.npmjs.org/:_authToken=\${{ secrets.NPM_TOKEN }}" > .npmrc
-    - run: |
+    - name: Tag latest release
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
         read next latest <<< $(npm info tedious --json | jq -r '."dist-tags".next, ."dist-tags".latest')
         if [ "$(printf '%s\n' "$latest" "$next" | sort -V | tail -n 1)" != "$latest" ]; then
           date_format="%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
I think this was broken when I moved our CI from Travis over to GitHub Actions.