### PR TITLE
feat: allow parameters to have collation options

### DIFF
--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -58,6 +58,13 @@ export interface Parameter {
     sortId: number;
   };
 
+  collation?: {
+    lcid: number;
+    flags: number;
+    version: number;
+    sortId: number;
+  };
+
   nullable?: boolean;
 
   forceEncrypt?: boolean;
@@ -70,6 +77,13 @@ export interface ParameterData<T = any> {
   length?: number;
   scale?: number;
   precision?: number;
+
+  collation?: {
+    lcid: number;
+    flags: number;
+    version: number;
+    sortId: number;
+  };
 
   value: T;
 }

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -50,6 +50,18 @@ const Char: { maximumLength: number } & DataType = {
     const buffer = Buffer.alloc(8);
     buffer.writeUInt8(this.id, 0);
     buffer.writeUInt16LE(parameter.length!, 1);
+
+    if (parameter.collation) {
+      const { lcid, flags, version, sortId } = parameter.collation;
+      buffer.writeUInt8((lcid) & 0xFF, 3);
+      buffer.writeUInt8((lcid >> 8) & 0xFF, 4);
+      // byte index 5 contains data for both lcid and flags
+      buffer.writeUInt8(((lcid >> 16) & 0x0F) | (((flags) & 0x0F) << 4), 5);
+      // byte index 6 contains data for both flags and version
+      buffer.writeUInt8(((flags) & 0xF0) | ((version) & 0x0F), 6);
+      buffer.writeUInt8((sortId) & 0xFF, 7);
+    }
+
     return buffer;
   },
 

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -60,6 +60,17 @@ const VarChar: { maximumLength: number } & DataType = {
       buffer.writeUInt16LE(MAX, 1);
     }
 
+    if (parameter.collation) {
+      const { lcid, flags, version, sortId } = parameter.collation;
+      buffer.writeUInt8((lcid) & 0xFF, 3);
+      buffer.writeUInt8((lcid >> 8) & 0xFF, 4);
+      // byte index 5 contains data for both lcid and flags
+      buffer.writeUInt8(((lcid >> 16) & 0x0F) | (((flags) & 0x0F) << 4), 5);
+      // byte index 6 contains data for both flags and version
+      buffer.writeUInt8(((flags) & 0xF0) | ((version) & 0x0F), 6);
+      buffer.writeUInt8((sortId) & 0xFF, 7);
+    }
+
     return buffer;
   },
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -36,6 +36,12 @@ export interface ParameterOptions {
   length?: number;
   precision?: number;
   scale?: number;
+  collation?: {
+    lcid: number;
+    flags: number;
+    version: number;
+    sortId: number;
+  };
 }
 
 interface RequestOptions {
@@ -402,7 +408,7 @@ class Request extends EventEmitter {
       options = {};
     }
 
-    const { output = false, length, precision, scale } = options;
+    const { output = false, length, precision, scale, collation } = options;
 
     const parameter: Parameter = {
       type: type,
@@ -411,6 +417,7 @@ class Request extends EventEmitter {
       output: output,
       length: length,
       precision: precision,
+      collation: collation,
       scale: scale
     };
     this.parameters.push(parameter);

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -99,6 +99,10 @@ class RpcRequestPayload implements Iterable<Buffer> {
       param.scale = type.resolveScale(parameter);
     }
 
+    if (parameter.collation) {
+      param.collation = parameter.collation;
+    }
+
     yield type.generateTypeInfo(param, this.options);
     yield type.generateParameterLength(param, this.options);
     yield * type.generateParameterData(param, this.options);

--- a/test/integration/datatypes-in-results-test.ts
+++ b/test/integration/datatypes-in-results-test.ts
@@ -613,7 +613,7 @@ describe('Collation LCID test', function() {
     }
   });
 
-  it('should recieve correct column collation after sending different collation char and varchar', function(done) {
+  it('should receive correct column collation after sending different collation char and varchar', function(done) {
     const remove_table_request = new Request('IF OBJECT_ID(\'dbo.temp_collation\', \'U\') IS NOT NULL DROP TABLE dbo.temp_collation;', (err) => {
       if (err) {
         return done(err);


### PR DESCRIPTION
This was extracted from https://github.com/tediousjs/tedious/pull/1020

I've no idea how this could be tested. I tried sending `varchar` parameter values with different collations set, but it's not clear to me how to check what the collation of the parameter is on the server side.

@MichaelSun90 @IanChokS Any ideas how this could be tested?

---

@fredwes Would you mind taking a look?