### PR TITLE
`connect` callback could miss `err` argument

### DIFF
--- a/benchmarks/common.js
+++ b/benchmarks/common.js
@@ -280,7 +280,7 @@ function createConnection(cb) {
   var config = JSON.parse(fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')).config;
 
   var connection = new Connection(config);
-  connection.on('connect', function() {
+  connection.connect(function() {
     cb(connection);
   });
 }

--- a/examples/bulkLoad-sample.js
+++ b/examples/bulkLoad-sample.js
@@ -47,7 +47,7 @@ function loadBulkData() {
   connection.execBulkLoad(bulkLoad);
 }
 
-connection.on('connect', function(err) {
+connection.connect(function(err) {
   if (err) {
     console.log('Connection Failed');
     throw err;

--- a/examples/minimal.js
+++ b/examples/minimal.js
@@ -27,7 +27,7 @@ var config = {
 
 var connection = new Connection(config);
 
-connection.on('connect', function(err) {
+connection.connect(function(err) {
     // If no error, then good to go...
     executeStatement();
   }

--- a/examples/parameters.js
+++ b/examples/parameters.js
@@ -13,7 +13,7 @@ var connection = new Connection({
   }
 });
 
-connection.on('connect', function(err){
+connection.connect(function(err){
 	var request = new Request("INSERT INTO MyTable (uniqueIdCol, intCol, nVarCharCol) VALUES (@uniqueIdVal, @intVal, @nVarCharVal)",
 	function(err){
 		if(err){

--- a/examples/simple-client.js
+++ b/examples/simple-client.js
@@ -15,7 +15,7 @@ config.options.debug = {
 
 var connection = new Connection(config);
 
-connection.on('connect', connected);
+connection.connect(connected);
 connection.on('infoMessage', infoError);
 connection.on('errorMessage', infoError);
 connection.on('end', end);

--- a/examples/storedProcedureWithParameters.js
+++ b/examples/storedProcedureWithParameters.js
@@ -24,7 +24,7 @@ var connection = new Connection({
   }
 });
 
-connection.on('connect', function(err) {
+connection.connect(function(err) {
   var request = new Request('countChar',
     function(err) {
       if (err) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1722,9 +1722,9 @@ class Connection extends EventEmitter {
     }
 
     if (connectListener) {
-      const onConnect = () => {
+      const onConnect = (err?: Error) => {
         this.removeListener('error', onError);
-        connectListener();
+        connectListener(err);
       };
 
       const onError = (err: Error) => {

--- a/test/integration/binary-insert-test.js
+++ b/test/integration/binary-insert-test.js
@@ -24,7 +24,7 @@ describe('inserting binary data', function() {
 
   beforeEach(function(done) {
     this.connection = new Connection(config);
-    this.connection.on('connect', done);
+    this.connection.connect(done);
   });
 
   afterEach(function(done) {

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -33,7 +33,7 @@ describe('Bulk Load Tests', function() {
 
   beforeEach(function(done) {
     connection = new Connection(getConfig());
-    connection.on('connect', done);
+    connection.connect(done);
 
     if (debugMode) {
       connection.on('debug', (message) => console.log(message));
@@ -530,7 +530,7 @@ describe('Bulk Loads when `config.options.validateBulkLoadParameters` is `true`'
     const config = getConfig();
     config.options = { ...config.options, validateBulkLoadParameters: true };
     connection = new Connection(config);
-    connection.on('connect', done);
+    connection.connect(done);
 
     if (debugMode) {
       connection.on('debug', (message) => console.log(message));

--- a/test/integration/connection-retry-test.js
+++ b/test/integration/connection-retry-test.js
@@ -47,12 +47,12 @@ describe('Connection Retry Test', function() {
       assert.ok(true);
     });
 
-    connection.on('connect', (err) => {
-      assert.ok(err);
-    });
-
     connection.on('end', (info) => {
       done();
+    });
+
+    connection.connect((err) => {
+      assert.ok(err);
     });
   });
 
@@ -73,12 +73,12 @@ describe('Connection Retry Test', function() {
       assert.ok(false);
     });
 
-    connection.on('connect', (err) => {
-      assert.ok(err);
-    });
-
     connection.on('end', (info) => {
       done();
+    });
+
+    connection.connect((err) => {
+      assert.ok(err);
     });
   });
 
@@ -108,13 +108,13 @@ describe('Connection Retry Test', function() {
       clock.tick(config.options.connectTimeout + 1);
     });
 
-    connection.on('connect', (err) => {
-      assert.ok(err);
-    });
-
     connection.on('end', (info) => {
       clock.restore();
       done();
+    });
+
+    connection.connect((err) => {
+      assert.ok(err);
     });
   });
 });

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -49,16 +49,16 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
-      assert.ok(err);
-    });
-
     connection.on('end', function(info) {
       done();
     });
 
-    return connection.on('debug', function(text) {
+    connection.on('debug', function(text) {
       // console.log(text)
+    });
+
+    connection.connect(function(err) {
+      assert.ok(err);
     });
   });
 
@@ -82,12 +82,6 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
-      assert.ok(err);
-
-      connection.close();
-    });
-
     connection.on('end', function(info) {
       done();
     });
@@ -101,11 +95,15 @@ describe('Initiate Connect Test', function() {
       return assert.ok(~error.message.indexOf('failed') || ~error.message.indexOf('登录失败'));
     });
 
-    return connection.on(
-      'debug',
-      function(text) { }
+    connection.on('debug', function(text) {
       // console.log(text)
-    );
+    });
+
+    connection.connect(function(err) {
+      assert.ok(err);
+
+      connection.close();
+    });
   });
 
   it('should connect by port', function(done) {
@@ -118,7 +116,7 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
 
       connection.close();
@@ -153,7 +151,7 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
 
       connection.close();
@@ -188,7 +186,7 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ok(err);
 
       connection.close();
@@ -287,7 +285,7 @@ describe('Initiate Connect Test', function() {
     };
 
     const connection = new Connection(config);
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ok(err);
       assert.strictEqual(err.code, 'ESOCKET');
     });
@@ -359,7 +357,7 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
     connection.on('error', (error) => { assert.ifError(error); });
-    connection.on('connect', (err) => { });
+    connection.connect((err) => { });
 
     setTimeout(() => { done(); }, 500);
   });
@@ -396,7 +394,7 @@ describe('Ntlm Test', function() {
 
     const connection = new Connection(ntlmConfig);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
 
       connection.close();
@@ -435,7 +433,7 @@ describe('Encrypt Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
 
       connection.close();
@@ -470,7 +468,7 @@ describe('BeginTransaction Tests', function() {
   beforeEach(function(done) {
     const config = getConfig();
     connection = new Connection(config);
-    connection.on('connect', done);
+    connection.connect(done);
   });
 
   afterEach(function(done) {
@@ -533,7 +531,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -572,7 +570,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -616,7 +614,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -671,7 +669,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       execSql();
     });
 
@@ -721,7 +719,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -753,7 +751,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -781,7 +779,7 @@ describe('Insertion Tests', function() {
 
     const connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSql(request);
 
@@ -831,7 +829,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -867,7 +865,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -905,7 +903,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -953,7 +951,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -995,7 +993,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -1050,7 +1048,7 @@ describe('Insertion Tests', function() {
       assert.ok(true);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       async.series([
         testAnsiNullsOptionOn,
         setAnsiNullsOptionOff,
@@ -1120,7 +1118,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
       setTimeout(connection.cancel.bind(connection), 2000);
     });
@@ -1173,7 +1171,7 @@ describe('Insertion Tests', function() {
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.execSql(request);
     });
 
@@ -1200,7 +1198,7 @@ describe('Advanced Input Test', function() {
       connection.close();
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSqlBatch(request);
     });
@@ -1259,7 +1257,7 @@ describe('Date Insert Test', function() {
       assert.strictEqual(dateFirstActual, datefirst);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSql(request);
     });
@@ -1310,7 +1308,7 @@ describe('Language Insert Test', function() {
       assert.strictEqual(languageActual, language);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSql(request);
     });
@@ -1351,7 +1349,7 @@ describe('should test date format', function() {
       assert.strictEqual(dateFormatActual, dateFormat);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSql(request);
     });
@@ -1404,7 +1402,7 @@ describe('Boolean Config Options Test', function() {
       assert.strictEqual(columns[0].value, expectedValue);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
 
       connection.execSql(request);

--- a/test/integration/errors-test.js
+++ b/test/integration/errors-test.js
@@ -31,7 +31,7 @@ function execSql(done, sql, requestCallback) {
     connection.close();
   });
 
-  connection.on('connect', function(err) {
+  connection.connect(function(err) {
     if (err) {
       return done(err);
     }
@@ -130,7 +130,7 @@ describe('Errors Test', function() {
       }
     );
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       if (err) {
         return done(err);
       }
@@ -159,7 +159,7 @@ describe('Errors Test', function() {
       connection.close();
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       if (err) {
         return done(err);
       }

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -70,7 +70,7 @@ function execSql(done, type, value, tdsVersion, options, expectedValue, cast, co
   const connectionConfig = Object.assign({}, config, { options: Object.assign({}, config.options, connectionOptions) });
   var connection = new Connection(connectionConfig);
 
-  connection.on('connect', function(err) {
+  connection.connect(function(err) {
     assert.ifError(err);
     connection.execSql(request);
   });
@@ -128,7 +128,7 @@ function execSqlOutput(done, type, value, expectedValue, connectionOptions) {
   const connectionConfig = Object.assign({}, config, { options: Object.assign({}, config.options, connectionOptions) });
   var connection = new Connection(connectionConfig);
 
-  connection.on('connect', function(err) {
+  connection.connect(function(err) {
     assert.ifError(err);
     connection.execSql(request);
   });
@@ -967,7 +967,7 @@ describe('Parameterised Statements Test', function() {
 
     var connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSql(request);
     });
@@ -1050,7 +1050,7 @@ end')\
 
     var connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.execSqlBatch(request);
     });

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -17,7 +17,7 @@ describe('Pause-Resume Test', function() {
 
   beforeEach(function(done) {
     connection = new Connection(getConfig());
-    connection.on('connect', done);
+    connection.connect(done);
   });
 
   afterEach(function(done) {

--- a/test/integration/prepare-execute-statements-test.js
+++ b/test/integration/prepare-execute-statements-test.js
@@ -46,7 +46,7 @@ describe('Prepare Execute Statement', function() {
       assert.strictEqual(columns[0].value, value);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.prepare(request);
     });
@@ -74,7 +74,7 @@ describe('Prepare Execute Statement', function() {
       connection.unprepare(request);
     });
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       assert.ifError(err);
       connection.prepare(request);
     });

--- a/test/integration/rpc-test.js
+++ b/test/integration/rpc-test.js
@@ -28,7 +28,7 @@ describe('RPC test', function() {
   beforeEach(function(done) {
     const config = getConfig();
     connection = new Connection(config);
-    connection.on('connect', done);
+    connection.connect(done);
 
     connection.on('infoMessage', (info) => {
       // console.log("#{info.number} : #{info.message}")
@@ -317,7 +317,7 @@ set @paramOut = @paramIn\
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.callProcedure(request);
     });
 
@@ -361,7 +361,7 @@ set @paramOut = @paramIn\
 
     let connection = new Connection(config);
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       execSqlBatch(
         connection,
         '\

--- a/test/integration/socket-error-test.js
+++ b/test/integration/socket-error-test.js
@@ -30,7 +30,7 @@ describe('A `error` on the network socket', function() {
 
     connection = new Connection(getConfig());
     connection.on('error', done);
-    connection.on('connect', (err) => {
+    connection.connect((err) => {
       connection.removeListener('error', done);
       done(err);
     });

--- a/test/integration/transactions-test.js
+++ b/test/integration/transactions-test.js
@@ -180,7 +180,7 @@ GO`,
   }
 
   run(actions) {
-    this.connection.on('connect', (err) => {
+    this.connection.connect((err) => {
       async.series(actions);
     });
   }
@@ -280,7 +280,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       let req = new Request('create table #temp (value varchar(50))', function(
         err
       ) {
@@ -317,7 +317,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.transaction(function(err, outerDone) {
         assert.ifError(err);
 
@@ -339,7 +339,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       let request = new Request('create table #temp (id int)', function(err) {
         assert.ifError(err);
 
@@ -397,7 +397,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       let request = new Request('create table #temp (id int)', function(err) {
         assert.ifError(err);
 
@@ -450,7 +450,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.transaction(function(err, outerDone) {
         assert.ifError(err);
 
@@ -490,7 +490,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.transaction(function(err, outerDone) {
         assert.ifError(err);
 
@@ -518,7 +518,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.transaction(function(err, outerDone) {
         assert.ifError(err);
 
@@ -587,7 +587,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.transaction(function(err) {
         assert.ifError(err);
 
@@ -607,7 +607,7 @@ describe('Transactions Test', function() {
     //  connection.on('errorMessage', (error) => console.log("#{error.number} : #{error.message}"))
     //  connection.on('debug', (message) => console.log(message) if (debug))
 
-    connection.on('connect', function(err) {
+    connection.connect(function(err) {
       connection.beginTransaction(function(err) {
         assert.ifError(err);
 

--- a/test/integration/tvp-test.js
+++ b/test/integration/tvp-test.js
@@ -50,7 +50,7 @@ describe('calling a procedure that takes and returns a TVP', function() {
       // console.log(text)
     );
 
-    connection.on('connect', done);
+    connection.connect(done);
   });
 
   afterEach(function() {

--- a/test/performance/big-select.js
+++ b/test/performance/big-select.js
@@ -98,7 +98,7 @@ end\
     connection.execSqlBatch(request);
   }
 
-  connection.on('connect', function(err) {
+  connection.connect(function(err) {
     test.ok(!err);
 
     async.series([


### PR DESCRIPTION
The callback passed to `Connection.prototype.connect` could in some error cases be called without an error argument.

This issue was introduced in https://github.com/tediousjs/tedious/pull/1102.