### PR TITLE
Update nodejs.yml to drop node.js 6 & 8 environment

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
       fail-fast: false
 
     services:


### PR DESCRIPTION
Proposal to remove node.js env 6.x and 8.x
