### PR TITLE
feat: added error state details into connection-error

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1982,6 +1982,9 @@ class Connection extends EventEmitter {
         }
       } else {
         const error = ConnectionError(token.message, 'ELOGIN');
+        error.number = token.number;
+        error.state = token.state;
+        error.class = token.class;
 
         const isLoginErrorTransient = this.transientErrorLookup.isTransientError(token.number);
         if (isLoginErrorTransient && this.curTransientRetryCount !== this.config.options.maxRetriesOnTransientErrors) {

--- a/src/errors.d.ts
+++ b/src/errors.d.ts
@@ -2,6 +2,9 @@ export interface ConnectionError extends Error {
   message: string;
   code?: string;
   isTransient?: boolean;
+  number?: number;
+  state?: number;
+  class?: number;
 }
 
 export declare var ConnectionError: {

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -76,6 +76,7 @@ describe('Initiate Connect Test', function() {
 
   it('should be bad credentials', function(done) {
     const config = getConfig();
+    const invalidLoginError = 18456;
 
     config.authentication.options.userName = 'bad-user';
     config.authentication.options.password = 'bad-password';
@@ -100,7 +101,7 @@ describe('Initiate Connect Test', function() {
     });
 
     connection.connect(function(err) {
-      assert.ok(err);
+      assert.ok(err && err.number === invalidLoginError);
 
       connection.close();
     });


### PR DESCRIPTION
I am facing an [issue](https://github.com/tediousjs/node-mssql/issues/1120) where I am wondering if it's possible to distinguish the root cause of an `ELOGIN` error during the connection event. Although I know that in most cases SQL server doesn't send a state other than 1 [(ref)](https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error?view=sql-server-ver15#additional-error-information) but I hope that's configurable.

Assuming the same, does it makes sense to pass those information along with `ConnectionError`? The PR simply adds three properties (number, state, class) to the Error instance.
