### PR TITLE
chore: add typing to cryptoCredentialDetails

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -543,7 +543,7 @@ interface ConnectionOptions {
    *
    * (default: `{}`)
    */
-  cryptoCredentialsDetails?: {};
+  cryptoCredentialsDetails?: SecureContextOptions;
 
   /**
    * Database to connect to (default: dependent on server configuration).


### PR DESCRIPTION
The typing is defined for the internal interface, but not for the external interface.

Since newer node versions contains changes to the default TLS settings (e.g. minimum TLS version), more users would need to set the `cryptoCredentialDetails`.

Adding the typing would make that easier.