### PR TITLE
chore: relax `commitlint` configuration a bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,12 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "body-max-line-length": [1, "always", 100],
+      "footer-max-line-length": [1, "always", 100],
+      "header-max-length": [1, "always", 100]
+    }
   },
   "nyc": {
     "sourceMap": false,


### PR DESCRIPTION
This makes some of the `commitlint` checks a bit less strict. This should keep dependabot PRs like https://github.com/tediousjs/tedious/pull/1176 from failing.