### PR TITLE
fix: improve Azure AD authentication performance

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -224,6 +224,29 @@ jobs:
     - name: run integration tests
       run: npx nyc --reporter=lcov npm run test-integration && npx codecov
 
+    - name: Set up CI configuration (AD Service Principal Authentication)
+      run: |
+        echo '{
+          "config": {
+            "server": "${{ secrets.AZURE_SERVER }}",
+            "authentication": {
+              "type": "azure-active-directory-service-principal-secret",
+              "options": {
+                "clientId": "${{ secrets.AZURE_AD_SP_CLIENT_ID }}",
+                "tenantId": "${{ secrets.AZURE_AD_SP_TENANT_ID }}",
+                "clientSecret": "${{ secrets.AZURE_AD_SP_CLIENT_SECRET }}"
+              }
+            },
+            "options": {
+              "port": 1433,
+              "database": "tedious"
+            }
+          }
+        }' > ~/.tedious/test-connection.json
+
+    - name: run integration tests
+      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+
   pre-release:
     name: Pre-Release
     needs: [test, azure]

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,29 @@
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-js": "^2.0.4",
         "adal-node": "^0.1.28"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+        },
+        "adal-node": {
+          "version": "0.1.28",
+          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
+          "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+          "requires": {
+            "@types/node": "^8.0.47",
+            "async": ">=0.6.0",
+            "date-utils": "*",
+            "jws": "3.x.x",
+            "request": ">= 2.52.0",
+            "underscore": ">= 1.3.1",
+            "uuid": "^3.1.0",
+            "xmldom": ">= 0.1.x",
+            "xpath.js": "~1.1.0"
+          }
+        }
       }
     },
     "@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@azure/ms-rest-nodeauth": "^3.0.6",
     "@js-joda/core": "^3.1.0",
+    "adal-node": "^0.1.28",
     "bl": "^3.0.0",
     "depd": "^2.0.0",
     "iconv-lite": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -136,9 +136,21 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
-      "body-max-line-length": [1, "always", 100],
-      "footer-max-line-length": [1, "always", 100],
-      "header-max-length": [1, "always", 100]
+      "body-max-line-length": [
+        1,
+        "always",
+        100
+      ],
+      "footer-max-line-length": [
+        1,
+        "always",
+        100
+      ],
+      "header-max-length": [
+        1,
+        "always",
+        100
+      ]
     }
   },
   "nyc": {

--- a/test/integration/connection-retry-test.js
+++ b/test/integration/connection-retry-test.js
@@ -33,7 +33,7 @@ describe('Connection Retry Test', function() {
   it('should retry specified number of times on transient errors', function(done) {
     const config = getConfig();
 
-    if (config.authentication && config.authentication.type === 'azure-active-directory-password') {
+    if (config.authentication && config.authentication.type !== 'default') {
       return done();
     }
 
@@ -59,7 +59,7 @@ describe('Connection Retry Test', function() {
   it('should no retries on non-transient errors', function(done) {
     const config = getConfig();
 
-    if (config.authentication && config.authentication.type === 'azure-active-directory-password') {
+    if (config.authentication && config.authentication.type !== 'default') {
       return done();
     }
 
@@ -85,7 +85,7 @@ describe('Connection Retry Test', function() {
   it('should no retries if connection timeout fires', function(done) {
     const config = getConfig();
 
-    if (config.authentication && config.authentication.type === 'azure-active-directory-password') {
+    if (config.authentication && config.authentication.type !== 'default') {
       return done();
     }
 

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -77,6 +77,10 @@ describe('Initiate Connect Test', function() {
   it('should be bad credentials', function(done) {
     const config = getConfig();
 
+    if (config.authentication && config.authentication.type !== 'default') {
+      return done();
+    }
+
     config.authentication.options.userName = 'bad-user';
     config.authentication.options.password = 'bad-password';
 


### PR DESCRIPTION
We use the `@azure/ms-rest-nodeauth` package to perform all Azure ActiveDirectory related authentication steps. That library builds on top of `node-adal` and provides a higher level API and authentication methods that `node-adal` does not provide (like MSI VM and Service authentication).

Because requesting an authentication token is pretty slow (it can take 500ms or much more), `node-adal` exposes a in-memory token caching mechanism. Each request can specify a token cache, or a global token cache will be used instead. Unfortunately, the high level API that `@azure/ms-rest-nodeauth` exposes and that we use, provides a new token cache for each authentication request. In theory, it allows passing in a custom token cache, but that logic is not working correctly (see https://github.com/Azure/ms-rest-nodeauth/pull/107 for a fix).

So, for the time being, this switches us over to a lower level API exposed by `@azure/ms-rest-nodeauth`, where specifying a custom token cache works correctly. This should greatly improve the performance of the `azure-active-directory-password` authentication method by only requesting a token if no token was cached before.
