### PR TITLE
Remove deprecated functionality

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1705,18 +1705,6 @@ class Connection extends EventEmitter {
     this.transientErrorLookup = new TransientErrorLookup();
 
     this.state = this.STATE.INITIALIZED;
-
-    process.nextTick(() => {
-      if (this.state === this.STATE.INITIALIZED) {
-        const message = 'In the next major version of `tedious`, creating a new ' +
-          '`Connection` instance will no longer establish a connection to the ' +
-          'server automatically. Please use the new `connect` helper function or ' +
-          'call the `.connect` method on the newly created `Connection` object to ' +
-          'silence this message.';
-        deprecate(message);
-        this.connect();
-      }
-    });
   }
 
   connect(connectListener?: (err?: Error) => void) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1249,7 +1249,7 @@ class Connection extends EventEmitter {
         trustServerCertificate: false,
         useColumnNames: false,
         useUTC: true,
-        validateBulkLoadParameters: false,
+        validateBulkLoadParameters: true,
         workstationId: undefined,
         lowerCaseGuids: false
       }
@@ -1650,8 +1650,6 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.validateBulkLoadParameters = config.options.validateBulkLoadParameters;
-      } else {
-        deprecate('The default value for "config.options.validateBulkLoadParameters" will change from `false` to `true` in the next major version of `tedious`. Set the value to `true` or `false` explicitly to silence this message.');
       }
 
       if (config.options.workstationId !== undefined) {


### PR DESCRIPTION
This removes all functionality that is currently deprecated, and will cause a new major release. This will most likely be the last release before we drop any support for Node 6.x and 8.x.