### PR TITLE
refactor: use `AbortController` to implement cancellation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9246,6 +9246,11 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.1.0.tgz",
+      "integrity": "sha512-dEYmUqjtbivotqjraOe8UvhT/poFfog1BQRNsZm/MSEDDESk2cQ1tvD8kGyuN07TM/zoW+n42odL8zTeJupYdQ=="
+    },
     "node-emoji": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "iconv-lite": "^0.6.2",
     "jsbi": "^3.1.4",
     "native-duplexpair": "^1.0.0",
+    "node-abort-controller": "^1.1.0",
     "punycode": "^2.1.0",
     "readable-stream": "^3.6.0",
     "sprintf-js": "^1.1.2"

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1882,13 +1882,13 @@ class Connection extends EventEmitter {
         server: this.config.server,
         instanceName: this.config.options.instanceName!,
         timeout: this.config.options.connectTimeout
-      }, (message, port) => {
+      }, (err, port) => {
         if (this.state === this.STATE.FINAL) {
           return;
         }
 
-        if (message) {
-          this.emit('connect', ConnectionError(message, 'EINSTLOOKUP'));
+        if (err) {
+          this.emit('connect', ConnectionError(err.message, 'EINSTLOOKUP'));
         } else {
           this.connectOnPort(port!, this.config.options.multiSubnetFailover);
         }

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -70,6 +70,11 @@ export class InstanceLookup {
         timer = setTimeout(onTimeout, timeout);
         sender.execute((err, response) => {
           clearTimeout(timer);
+
+          if (err?.name === 'AbortError') {
+            return;
+          }
+
           if (err) {
             callback('Failed to lookup instance on ' + server + ' - ' + err.message);
 

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -1,5 +1,7 @@
-import { Sender } from './sender';
 import dns from 'dns';
+import AbortController from 'node-abort-controller';
+
+import { Sender } from './sender';
 
 const SQL_SERVER_BROWSER_PORT = 1434;
 const TIMEOUT = 2 * 1000;
@@ -11,11 +13,6 @@ type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
 export class InstanceLookup {
-  // Wrapper allows for stubbing Sender when unit testing instance-lookup.
-  createSender(host: string, port: number, lookup: LookupFunction, request: Buffer) {
-    return new Sender(host, port, lookup, request);
-  }
-
   instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction }, callback: (err: Error | undefined, port?: number) => void) {
     const server = options.server;
     if (typeof server !== 'string') {
@@ -57,8 +54,10 @@ export class InstanceLookup {
       let sender: Sender;
       let timer: NodeJS.Timeout;
 
+      const controller = new AbortController();
+
       const onTimeout = () => {
-        sender.cancel();
+        controller.abort();
         makeAttempt();
       };
 
@@ -66,7 +65,7 @@ export class InstanceLookup {
         retriesLeft--;
 
         const request = Buffer.from([0x02]);
-        sender = this.createSender(options.server, port, lookup, request);
+        sender = new Sender(options.server, port, lookup, controller.signal, request);
         timer = setTimeout(onTimeout, timeout);
         sender.execute((err, response) => {
           clearTimeout(timer);

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -16,7 +16,7 @@ export class InstanceLookup {
     return new Sender(host, port, lookup, request);
   }
 
-  instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction }, callback: (message: string | undefined, port?: number) => void) {
+  instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction }, callback: (err: Error | undefined, port?: number) => void) {
     const server = options.server;
     if (typeof server !== 'string') {
       throw new TypeError('Invalid arguments: "server" must be a string');
@@ -76,8 +76,7 @@ export class InstanceLookup {
           }
 
           if (err) {
-            callback('Failed to lookup instance on ' + server + ' - ' + err.message);
-
+            callback(new Error('Failed to lookup instance on ' + server + ' - ' + err.message));
           } else {
             const message = response!.toString('ascii', MYSTERY_HEADER_LENGTH);
             const port = this.parseBrowserResponse(message, instanceName);
@@ -85,12 +84,12 @@ export class InstanceLookup {
             if (port) {
               callback(undefined, port);
             } else {
-              callback('Port for ' + instanceName + ' not found in ' + options.server);
+              callback(new Error('Port for ' + instanceName + ' not found in ' + options.server));
             }
           }
         });
       } else {
-        callback('Failed to get response from SQL Server Browser on ' + server);
+        callback(new Error('Failed to get response from SQL Server Browser on ' + server));
       }
     };
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -23,48 +23,23 @@ export class ParallelSendStrategy {
   port: number;
   request: Buffer;
 
-  socketV4: dgram.Socket | null;
-  socketV6: dgram.Socket | null;
-
-  onMessage: ((message: Buffer) => void) | null;
-  onError: ((err: Error) => void) | null;
   signal: AbortSignal;
 
   constructor(addresses: dns.LookupAddress[], port: number, signal: AbortSignal, request: Buffer) {
     this.addresses = addresses;
     this.port = port;
     this.request = request;
-
-    this.socketV4 = null;
-    this.socketV6 = null;
-    this.onError = null;
-    this.onMessage = null;
-
     this.signal = signal;
   }
 
-  clearSockets() {
-    const clearSocket = (socket: dgram.Socket, onError: (err: Error) => void, onMessage: (message: Buffer) => void) => {
-      socket.removeListener('error', onError);
-      socket.removeListener('message', onMessage);
-      socket.close();
-    };
-
-    if (this.socketV4) {
-      clearSocket(this.socketV4, this.onError!, this.onMessage!);
-      this.socketV4 = null;
-    }
-
-    if (this.socketV6) {
-      clearSocket(this.socketV6, this.onError!, this.onMessage!);
-      this.socketV6 = null;
-    }
-  }
-
   send(cb: (error: Error | null, message?: Buffer) => void) {
-    if (this.signal.aborted) {
+    const signal = this.signal;
+
+    if (signal.aborted) {
       return cb(new AbortError());
     }
+
+    const sockets: dgram.Socket[] = [];
 
     let errorCount = 0;
 
@@ -72,62 +47,45 @@ export class ParallelSendStrategy {
       errorCount++;
 
       if (errorCount === this.addresses.length) {
-        this.signal.removeEventListener('abort', onAbort);
-        this.clearSockets();
+        signal.removeEventListener('abort', onAbort);
+        clearSockets();
 
         cb(err);
       }
     };
 
     const onMessage = (message: Buffer) => {
-      this.signal.removeEventListener('abort', onAbort);
-      this.clearSockets();
+      signal.removeEventListener('abort', onAbort);
+      clearSockets();
 
       cb(null, message);
     };
 
     const onAbort = () => {
-      this.clearSockets();
+      clearSockets();
 
       cb(new AbortError());
     };
 
-    this.signal.addEventListener('abort', onAbort, { once: true });
-
-    const createDgramSocket = (udpType: 'udp4' | 'udp6', onError: (err: Error) => void, onMessage: (message: Buffer) => void) => {
-      const socket = dgram.createSocket(udpType);
-
-      socket.on('error', onError);
-      socket.on('message', onMessage);
-      return socket;
+    const clearSockets = () => {
+      for (const socket of sockets) {
+        socket.removeListener('error', onError);
+        socket.removeListener('message', onMessage);
+        socket.close();
+      }
     };
 
+    signal.addEventListener('abort', onAbort, { once: true });
+
     for (let j = 0; j < this.addresses.length; j++) {
-      const udpTypeV4 = 'udp4';
-      const udpTypeV6 = 'udp6';
+      const udpType = this.addresses[j].family === 6 ? 'udp6' : 'udp4';
 
-      const udpType = this.addresses[j].family === 6 ? udpTypeV6 : udpTypeV4;
-      let socket;
-
-      if (udpType === udpTypeV4) {
-        if (!this.socketV4) {
-          this.socketV4 = createDgramSocket(udpTypeV4, onError, onMessage);
-        }
-
-        socket = this.socketV4;
-      } else {
-        if (!this.socketV6) {
-          this.socketV6 = createDgramSocket(udpTypeV6, onError, onMessage);
-        }
-
-        socket = this.socketV6;
-      }
-
+      const socket = dgram.createSocket(udpType);
+      sockets.push(socket);
+      socket.on('error', onError);
+      socket.on('message', onMessage);
       socket.send(this.request, 0, this.request.length, this.port, this.addresses[j].address);
     }
-
-    this.onError = onError;
-    this.onMessage = onMessage;
   }
 }
 

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -107,8 +107,8 @@ describe('InstanceLookup', function() {
         timeout: 500,
         retries: 1,
       }, (err) => {
-        assert.isOk(err);
-        assert.match(err, /^Failed to get response from SQL Server Browser/);
+        assert.instanceOf(err, Error);
+        assert.match(err.message, /^Failed to get response from SQL Server Browser/);
         assert.isTrue(timedOut);
 
         errored = true;
@@ -163,8 +163,8 @@ describe('InstanceLookup', function() {
         timeout: 500,
         retries: 1,
       }, (err) => {
-        assert.isOk(err);
-        assert.match(err, /^Port for other not found/);
+        assert.instanceOf(err, Error);
+        assert.match(err.message, /^Port for other not found/);
 
         done();
       });
@@ -184,8 +184,8 @@ describe('InstanceLookup', function() {
         timeout: 500,
         retries: 1,
       }, (err) => {
-        assert.isOk(err);
-        assert.match(err, /^Port for other not found/);
+        assert.instanceOf(err, Error);
+        assert.match(err.message, /^Port for other not found/);
 
         done();
       });

--- a/test/unit/sender-test.js
+++ b/test/unit/sender-test.js
@@ -1,6 +1,7 @@
 const dgram = require('dgram');
 const { assert } = require('chai');
 const dns = require('dns');
+const AbortController = require('node-abort-controller');
 
 const { Sender } = require('../../src/sender');
 
@@ -60,7 +61,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       sender.execute(done);
     });
 
@@ -75,7 +77,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       sender.execute((err) => {
         assert.strictEqual(err, expectedError);
 
@@ -92,7 +95,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender(address, port, dns.lookup, expectedRequest);
+      const controller = new AbortController();
+      const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
       sender.execute(done);
     });
 
@@ -103,7 +107,8 @@ describe('Sender', function() {
         server.send(expectedResponse, rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender(address, port, dns.lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
       sender.execute((err, message) => {
         if (err) {
           return done(err);
@@ -115,9 +120,9 @@ describe('Sender', function() {
       });
     });
 
-    it('can be canceled during the DNS lookup', function(done) {
+    it('can be aborted during the DNS lookup', function(done) {
       function lookup(hostname, options, callback) {
-        sender.cancel();
+        controller.abort();
 
         callback(undefined, [
           { address: address, family: 4 }
@@ -128,7 +133,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       sender.execute((err) => {
         assert.instanceOf(err, Error);
         assert.strictEqual(err.name, 'AbortError');
@@ -137,10 +143,10 @@ describe('Sender', function() {
       });
     });
 
-    it('can be canceled after the DNS lookup', function(done) {
+    it('can be aborted after the DNS lookup', function(done) {
       function lookup(hostname, options, callback) {
         process.nextTick(() => {
-          sender.cancel();
+          controller.abort();
         });
 
         callback(undefined, [
@@ -152,7 +158,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       sender.execute((err) => {
         assert.instanceOf(err, Error);
         assert.strictEqual(err.name, 'AbortError');
@@ -161,14 +168,15 @@ describe('Sender', function() {
       });
     });
 
-    it('can be canceled before receiving a response', function(done) {
+    it('can be aborted before receiving a response', function(done) {
       const expectedRequest = Buffer.from([0x02]);
 
       server.once('message', (message, rinfo) => {
-        sender.cancel();
+        controller.abort();
       });
 
-      const sender = new Sender(address, port, dns.lookup, expectedRequest);
+      const controller = new AbortController();
+      const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
       sender.execute((err) => {
         assert.instanceOf(err, Error);
         assert.strictEqual(err.name, 'AbortError');
@@ -233,7 +241,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       sender.execute(done);
     });
 
@@ -248,7 +257,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       sender.execute((err) => {
         assert.strictEqual(err, expectedError);
 
@@ -265,7 +275,8 @@ describe('Sender', function() {
         server.send(Buffer.from('response'), rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender(address, port, dns.lookup, expectedRequest);
+      const controller = new AbortController();
+      const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
       sender.execute(done);
     });
 
@@ -276,7 +287,8 @@ describe('Sender', function() {
         server.send(expectedResponse, rinfo.port, rinfo.address);
       });
 
-      const sender = new Sender(address, port, dns.lookup, Buffer.from([0x02]));
+      const controller = new AbortController();
+      const sender = new Sender(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
       sender.execute((err, message) => {
         if (err) {
           return done(err);
@@ -354,7 +366,8 @@ describe('Sender', function() {
         });
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, expectedRequest);
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
       sender.execute((err) => {
         if (err) {
           return done(err);
@@ -391,7 +404,8 @@ describe('Sender', function() {
         });
       });
 
-      const sender = new Sender('foo.bar.baz', port, lookup, expectedRequest);
+      const controller = new AbortController();
+      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
       sender.execute((err, response) => {
         if (err) {
           return done(err);


### PR DESCRIPTION
This refactors the `Sender` helper class (used for instance lookup) to implement cancellation behavior on top of the `AbortController` (and `AbortSignal`) interfaces.

This also adds test cases that cover cancellation behavior and increases the overall test coverage.

This is mostly in preparation to convert this part of the code over to `async`/`await` and with the eventual goal of fixing issues like https://github.com/tediousjs/tedious/issues/782.