### PR TITLE
Add `AbortSignal` support to `Connector` and `InstanceLookup`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -44,6 +44,8 @@ import { ColumnMetadata } from './token/colmetadata-token-parser';
 import depd from 'depd';
 import { MemoryCache } from 'adal-node';
 
+import AbortController from 'node-abort-controller';
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const deprecate = depd('tedious');
 
@@ -1878,10 +1880,13 @@ class Connection extends EventEmitter {
     if (this.config.options.port) {
       return this.connectOnPort(this.config.options.port, this.config.options.multiSubnetFailover);
     } else {
+      const controller = new AbortController();
+
       return new InstanceLookup().instanceLookup({
         server: this.config.server,
         instanceName: this.config.options.instanceName!,
-        timeout: this.config.options.connectTimeout
+        timeout: this.config.options.connectTimeout,
+        signal: controller.signal
       }, (err, port) => {
         if (this.state === this.STATE.FINAL) {
           return;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2225,7 +2225,8 @@ class Connection extends EventEmitter {
       localAddress: this.config.options.localAddress
     };
 
-    new Connector(connectOpts, multiSubnetFailover).execute((err, socket) => {
+    const controller = new AbortController();
+    new Connector(connectOpts, controller.signal, multiSubnetFailover).execute((err, socket) => {
       if (err) {
         return this.socketError(err);
       }

--- a/test/integration/instance-lookup-test.js
+++ b/test/integration/instance-lookup-test.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
 const homedir = require('os').homedir();
 const assert = require('chai').assert;
+const AbortController = require('node-abort-controller');
 
 var RESERVED_IP_ADDRESS = '192.0.2.0'; // Can never be used, so guaranteed to fail.
 
@@ -31,7 +32,12 @@ describe('Instance Lookup Test', function() {
       return this.skip();
     }
 
-    new InstanceLookup().instanceLookup({ server: config.server, instanceName: config.instanceName }, function(err, port) {
+    const controller = new AbortController();
+    new InstanceLookup().instanceLookup({
+      server: config.server,
+      instanceName: config.instanceName,
+      signal: controller.signal
+    }, function(err, port) {
       if (err) {
         return done(err);
       }
@@ -45,11 +51,13 @@ describe('Instance Lookup Test', function() {
   it('should test bad Instance', function(done) {
     var config = getConfig();
 
+    const controller = new AbortController();
     new InstanceLookup().instanceLookup({
       server: config.server,
       instanceName: 'badInstanceName',
       timeout: 100,
-      retries: 1
+      retries: 1,
+      signal: controller.signal
     }, function(err, port) {
       assert.ok(err);
       assert.ok(!port);
@@ -59,11 +67,13 @@ describe('Instance Lookup Test', function() {
   });
 
   it('should test bad Server', function(done) {
+    const controller = new AbortController();
     new InstanceLookup().instanceLookup({
       server: RESERVED_IP_ADDRESS,
       instanceName: 'badInstanceName',
       timeout: 100,
-      retries: 1
+      retries: 1,
+      signal: controller.signal
     }, function(err, port) {
       assert.ok(err);
       assert.ok(!port);

--- a/test/unit/connector-test.js
+++ b/test/unit/connector-test.js
@@ -2,6 +2,7 @@ const Mitm = require('mitm');
 const sinon = require('sinon');
 const punycode = require('punycode');
 const assert = require('chai').assert;
+const AbortController = require('node-abort-controller');
 
 const {
   ParallelConnectionStrategy,
@@ -22,6 +23,10 @@ describe('Connector', function() {
       mitm.disable();
     });
 
+    afterEach(function() {
+      sinon.restore();
+    });
+
     it('connects directly if given an IP v4 address', function(done) {
       const hostIp = '127.0.0.1';
       const localIp = '192.168.0.1';
@@ -31,7 +36,9 @@ describe('Connector', function() {
         port: 12345,
         localAddress: localIp
       };
-      const connector = new Connector(connectionOptions, true);
+
+      const controller = new AbortController();
+      const connector = new Connector(connectionOptions, controller.signal, true);
 
       let expectedSocket;
 
@@ -66,7 +73,9 @@ describe('Connector', function() {
         port: 12345,
         localAddress: localIp
       };
-      const connector = new Connector(connectionOptions, true);
+
+      const controller = new AbortController();
+      const connector = new Connector(connectionOptions, controller.signal, true);
 
       let expectedSocket;
 
@@ -93,7 +102,8 @@ describe('Connector', function() {
     });
 
     it('uses a parallel connection strategy', function(done) {
-      const connector = new Connector({ host: 'localhost', port: 12345 }, true);
+      const controller = new AbortController();
+      const connector = new Connector({ host: 'localhost', port: 12345 }, controller.signal, true);
 
       const spy = sinon.spy(ParallelConnectionStrategy.prototype, 'connect');
 
@@ -103,6 +113,52 @@ describe('Connector', function() {
         }
 
         assert.strictEqual(spy.callCount, 1);
+
+        done();
+      });
+    });
+
+    it('will immediately abort when called with an aborted signal', function(done) {
+      const controller = new AbortController();
+      const connector = new Connector({ host: 'localhost', port: 12345 }, controller.signal, true);
+
+      const spy = sinon.spy(ParallelConnectionStrategy.prototype, 'connect');
+
+      controller.abort();
+
+      connector.execute(function(err, socket) {
+        assert.instanceOf(err, Error);
+        assert.strictEqual(err.name, 'AbortError');
+
+        sinon.assert.callCount(spy, 0);
+
+        done();
+      });
+    });
+
+    it('can be aborted during DNS lookup', function(done) {
+      const lookup = sinon.spy(function lookup(hostname, options, callback) {
+        controller.abort();
+
+        process.nextTick(callback, null, [
+          { address: '127.0.0.1', family: 4 }
+        ]);
+      });
+
+      const controller = new AbortController();
+      const connector = new Connector({
+        host: 'localhost',
+        port: 12345,
+        lookup: lookup
+      }, controller.signal, true);
+
+      const spy = sinon.spy(ParallelConnectionStrategy.prototype, 'connect');
+
+      connector.execute((err) => {
+        assert.instanceOf(err, Error);
+        assert.strictEqual(err.name, 'AbortError');
+
+        sinon.assert.callCount(spy, 0);
 
         done();
       });
@@ -131,7 +187,9 @@ describe('Connector', function() {
         port: 12345,
         localAddress: '192.168.0.1'
       };
-      const connector = new Connector(connectionOptions, false);
+
+      const controller = new AbortController();
+      const connector = new Connector(connectionOptions, controller.signal, false);
 
       let expectedSocket;
       mitm.once('connect', function(socket, options) {
@@ -157,7 +215,8 @@ describe('Connector', function() {
     });
 
     it('uses a sequential connection strategy', function(done) {
-      const connector = new Connector({ host: 'localhost', port: 12345 }, false);
+      const controller = new AbortController();
+      const connector = new Connector({ host: 'localhost', port: 12345 }, controller.signal, false);
 
       const spy = sinon.spy(
         SequentialConnectionStrategy.prototype,
@@ -183,7 +242,8 @@ describe('Connector', function() {
       });
 
       const server = '本地主机.ad';
-      const connector = new Connector({ host: server, port: 12345, lookup: lookup }, true);
+      const controller = new AbortController();
+      const connector = new Connector({ host: server, port: 12345, lookup: lookup }, controller.signal, true);
 
       connector.execute(() => {
         assert.isOk(lookup.called, 'Failed to call `lookup` function for hostname');
@@ -199,7 +259,8 @@ describe('Connector', function() {
       });
 
       const server = 'localhost';
-      const connector = new Connector({ host: server, port: 12345, lookup: lookup }, true);
+      const controller = new AbortController();
+      const connector = new Connector({ host: server, port: 12345, lookup: lookup }, controller.signal, true);
 
       connector.execute(() => {
         assert.isOk(lookup.called, 'Failed to call `lookup` function for hostname');
@@ -224,12 +285,14 @@ describe('SequentialConnectionStrategy', function() {
   });
 
   it('tries to connect to all addresses in sequence', function(done) {
+    const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -279,12 +342,14 @@ describe('SequentialConnectionStrategy', function() {
   });
 
   it('passes the first succesfully connected socket to the callback', function(done) {
+    const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -305,12 +370,14 @@ describe('SequentialConnectionStrategy', function() {
   });
 
   it('only attempts new connections until the first successful connection', function(done) {
+    const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -336,12 +403,14 @@ describe('SequentialConnectionStrategy', function() {
   });
 
   it('fails if all sequential connections fail', function(done) {
+    const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -359,12 +428,14 @@ describe('SequentialConnectionStrategy', function() {
   });
 
   it('destroys all sockets except for the first succesfully connected socket', function(done) {
+    const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -392,6 +463,64 @@ describe('SequentialConnectionStrategy', function() {
       done();
     });
   });
+
+  it('will immediately abort when called with an aborted signal', function(done) {
+    const controller = new AbortController();
+    controller.abort();
+
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      controller.signal,
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    mitm.on('connect', () => {
+      assert.fail('no connections expected');
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      done();
+    });
+  });
+
+  it('can be aborted while trying to connect', function(done) {
+    const controller = new AbortController();
+    const strategy = new SequentialConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      controller.signal,
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedSockets = [];
+    mitm.on('connect', function(socket) {
+      attemptedSockets.push(socket);
+
+      process.nextTick(() => {
+        controller.abort();
+      });
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      assert.lengthOf(attemptedSockets, 1);
+      assert.isOk(attemptedSockets[0].destroyed);
+
+      done();
+    });
+  });
 });
 
 describe('ParallelConnectionStrategy', function() {
@@ -407,12 +536,14 @@ describe('ParallelConnectionStrategy', function() {
   });
 
   it('tries to connect to all addresses in parallel', function(done) {
+    const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -448,12 +579,14 @@ describe('ParallelConnectionStrategy', function() {
   });
 
   it('fails if all parallel connections fail', function(done) {
+    const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -471,12 +604,14 @@ describe('ParallelConnectionStrategy', function() {
   });
 
   it('passes the first succesfully connected socket to the callback', function(done) {
+    const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -503,12 +638,14 @@ describe('ParallelConnectionStrategy', function() {
   });
 
   it('destroys all sockets except for the first succesfully connected socket', function(done) {
+    const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
       [
         { address: '127.0.0.2' },
         { address: '2002:20:0:0:0:0:1:3' },
         { address: '127.0.0.4' }
       ],
+      controller.signal,
       { port: 12345, localAddress: '192.168.0.1' }
     );
 
@@ -524,6 +661,66 @@ describe('ParallelConnectionStrategy', function() {
       }
 
       assert.isOk(!attemptedSockets[0].destroyed);
+      assert.isOk(attemptedSockets[1].destroyed);
+      assert.isOk(attemptedSockets[2].destroyed);
+
+      done();
+    });
+  });
+
+  it('will immediately abort when called with an aborted signal', function(done) {
+    const controller = new AbortController();
+    controller.abort();
+
+    const strategy = new ParallelConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      controller.signal,
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    mitm.on('connect', () => {
+      assert.fail('no connections expected');
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      done();
+    });
+  });
+
+  it('can be aborted while trying to connect', function(done) {
+    const controller = new AbortController();
+    const strategy = new ParallelConnectionStrategy(
+      [
+        { address: '127.0.0.2' },
+        { address: '2002:20:0:0:0:0:1:3' },
+        { address: '127.0.0.4' }
+      ],
+      controller.signal,
+      { port: 12345, localAddress: '192.168.0.1' }
+    );
+
+    const attemptedSockets = [];
+    mitm.on('connect', function(socket) {
+      attemptedSockets.push(socket);
+
+      process.nextTick(() => {
+        controller.abort();
+      });
+    });
+
+    strategy.connect(function(err, socket) {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      assert.lengthOf(attemptedSockets, 3);
+      assert.isOk(attemptedSockets[0].destroyed);
       assert.isOk(attemptedSockets[1].destroyed);
       assert.isOk(attemptedSockets[2].destroyed);
 

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const punycode = require('punycode');
 const assert = require('chai').assert;
 const dgram = require('dgram');
+const AbortController = require('node-abort-controller');
 
 describe('instanceLookup invalid args', function() {
   let instanceLookup;
@@ -57,6 +58,9 @@ describe('instanceLookup invalid args', function() {
 });
 
 describe('InstanceLookup', function() {
+  /**
+   * @type {dgram.Socket}
+   */
   let server;
 
   beforeEach(function(done) {
@@ -75,14 +79,93 @@ describe('InstanceLookup', function() {
       done();
     });
 
+    const controller = new AbortController();
     new InstanceLookup().instanceLookup({
       server: server.address().address,
       port: server.address().port,
       instanceName: 'second',
       timeout: 500,
       retries: 1,
+      signal: controller.signal
     }, () => {
       // Ignore
+    });
+  });
+
+  it('can be aborted immediately', function(done) {
+    server.on('message', (msg, rinfo) => {
+      assert.fail('expected no message to be received');
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    new InstanceLookup().instanceLookup({
+      server: server.address().address,
+      port: server.address().port,
+      instanceName: 'first',
+      timeout: 500,
+      retries: 1,
+      signal: controller.signal
+    }, (err) => {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      done();
+    });
+  });
+
+  it('can be aborted after sending the first request', function(done) {
+    server.on('message', (msg, rinfo) => {
+      if (controller.signal.aborted) {
+        assert.fail('expected no message to be received');
+      }
+
+      controller.abort();
+    });
+
+    const controller = new AbortController();
+
+    new InstanceLookup().instanceLookup({
+      server: server.address().address,
+      port: server.address().port,
+      instanceName: 'first',
+      timeout: 500,
+      retries: 1,
+      signal: controller.signal
+    }, (err) => {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      done();
+    });
+  });
+
+  it('can be aborted after retrying to send a request', function(done) {
+    server.once('message', () => {
+      server.on('message', (msg, rinfo) => {
+        if (controller.signal.aborted) {
+          assert.fail('expected no message to be received');
+        }
+
+        controller.abort();
+      });
+    });
+
+    const controller = new AbortController();
+
+    new InstanceLookup().instanceLookup({
+      server: server.address().address,
+      port: server.address().port,
+      instanceName: 'first',
+      timeout: 500,
+      retries: 1,
+      signal: controller.signal
+    }, (err) => {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err.name, 'AbortError');
+
+      done();
     });
   });
 
@@ -100,12 +183,15 @@ describe('InstanceLookup', function() {
         done();
       }, 600);
 
+      const controller = new AbortController();
+
       new InstanceLookup().instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'instance',
         timeout: 500,
-        retries: 1,
+        retries: 0,
+        signal: controller.signal
       }, (err) => {
         assert.instanceOf(err, Error);
         assert.match(err.message, /^Failed to get response from SQL Server Browser/);
@@ -128,12 +214,15 @@ describe('InstanceLookup', function() {
         server.send(response, rinfo.port, rinfo.address);
       });
 
+      const controller = new AbortController();
+
       new InstanceLookup().instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'second',
         timeout: 500,
         retries: 1,
+        signal: controller.signal
       }, (err, result) => {
         assert.ifError(err);
 
@@ -156,12 +245,15 @@ describe('InstanceLookup', function() {
         server.send(response, rinfo.port, rinfo.address);
       });
 
+      const controller = new AbortController();
+
       new InstanceLookup().instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'other',
         timeout: 500,
         retries: 1,
+        signal: controller.signal
       }, (err) => {
         assert.instanceOf(err, Error);
         assert.match(err.message, /^Port for other not found/);
@@ -177,12 +269,15 @@ describe('InstanceLookup', function() {
         server.send('foo bar baz', rinfo.port, rinfo.address);
       });
 
+      const controller = new AbortController();
+
       new InstanceLookup().instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'other',
         timeout: 500,
         retries: 1,
+        signal: controller.signal
       }, (err) => {
         assert.instanceOf(err, Error);
         assert.match(err.message, /^Port for other not found/);
@@ -238,12 +333,15 @@ describe('parseBrowserResponse', function() {
       callback([{ address: '127.0.0.1', family: 4 }]);
     });
 
+    const controller = new AbortController();
+
     const options = {
       server: '本地主机.ad',
       instanceName: 'instance',
       timeout: 500,
       retries: 1,
-      lookup: lookup
+      lookup: lookup,
+      signal: controller.signal
     };
 
     new InstanceLookup().instanceLookup(options, () => {
@@ -259,12 +357,15 @@ describe('parseBrowserResponse', function() {
       callback([{ address: '127.0.0.1', family: 4 }]);
     });
 
+    const controller = new AbortController();
+
     const options = {
       server: 'localhost',
       instanceName: 'instance',
       timeout: 500,
       retries: 1,
-      lookup: lookup
+      lookup: lookup,
+      signal: controller.signal
     };
 
     new InstanceLookup().instanceLookup(options, (err) => {


### PR DESCRIPTION
This adds `AbortSignal` support to the `Connector` and `InstanceLookup` classes.

None of this is really used so far, but it's laying the foundation to properly resolve the issue described in https://github.com/tediousjs/tedious/issues/782, and similar issues, where after the connection attempt times out, errors can still happen.