### PR TITLE
refactor: convert `InstanceLookup` and `Sender` to use `async`/`await` and support `AbortSignal`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2022,13 +2022,11 @@ class Connection extends EventEmitter {
         this.transitionTo(this.STATE.SENT_PRELOGIN);
       });
     }, (err) => {
-      process.nextTick(() => {
-        if (err.name === 'AbortError') {
-          return;
-        }
+      if (err.name === 'AbortError') {
+        return;
+      }
 
-        return this.socketError(err);
-      });
+      process.nextTick(() => { this.socketError(err); });
     });
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1935,11 +1935,12 @@ class Connection extends EventEmitter {
           this.connectOnPort(port, this.config.options.multiSubnetFailover, signal);
         });
       }, (err) => {
-        process.nextTick(() => {
-          if (err.name === 'AbortError') {
-            return;
-          }
+        if (err.name === 'AbortError') {
+          // Ignore the AbortError for now, this is still handled by the connectTimer firing
+          return;
+        }
 
+        process.nextTick(() => {
           this.emit('connect', new ConnectionError(err.message, 'EINSTLOOKUP'));
         });
       });

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1929,16 +1929,18 @@ class Connection extends EventEmitter {
         instanceName: this.config.options.instanceName!,
         timeout: this.config.options.connectTimeout,
         signal: signal
-      }, (err, port) => {
-        if (err) {
+      }).then((port) => {
+        process.nextTick(() => {
+          this.connectOnPort(port, this.config.options.multiSubnetFailover, signal);
+        });
+      }, (err) => {
+        process.nextTick(() => {
           if (err.name === 'AbortError') {
             return;
           }
 
           this.emit('connect', new ConnectionError(err.message, 'EINSTLOOKUP'));
-        } else {
-          this.connectOnPort(port!, this.config.options.multiSubnetFailover, signal);
-        }
+        });
       });
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -18,7 +18,7 @@ import {
 import BulkLoad, { Options as BulkLoadOptions, Callback as BulkLoadCallback } from './bulk-load';
 import Debug from './debug';
 import { EventEmitter, once } from 'events';
-import { InstanceLookup } from './instance-lookup';
+import { instanceLookup } from './instance-lookup';
 import { TransientErrorLookup } from './transient-error-lookup';
 import { TYPE } from './packet';
 import PreloginPayload from './prelogin-payload';
@@ -1925,7 +1925,7 @@ class Connection extends EventEmitter {
     if (this.config.options.port) {
       return this.connectOnPort(this.config.options.port, this.config.options.multiSubnetFailover, signal);
     } else {
-      return new InstanceLookup().instanceLookup({
+      return instanceLookup({
         server: this.config.server,
         instanceName: this.config.options.instanceName!,
         timeout: this.config.options.connectTimeout,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1999,31 +1999,32 @@ class Connection extends EventEmitter {
       localAddress: this.config.options.localAddress
     };
 
-    new Connector(connectOpts, signal, multiSubnetFailover).execute((err, socket) => {
-      if (err) {
+    new Connector(connectOpts, signal, multiSubnetFailover).execute().then((socket) => {
+      process.nextTick(() => {
+        socket.on('error', (error) => { this.socketError(error); });
+        socket.on('close', () => { this.socketClose(); });
+        socket.on('end', () => { this.socketEnd(); });
+        socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY);
+
+        this.messageIo = new MessageIO(socket, this.config.options.packetSize, this.debug);
+        this.messageIo.on('secure', (cleartext) => { this.emit('secure', cleartext); });
+
+        this.socket = socket;
+
+        this.closed = false;
+        this.debug.log('connected to ' + this.config.server + ':' + this.config.options.port);
+
+        this.sendPreLogin();
+        this.transitionTo(this.STATE.SENT_PRELOGIN);
+      });
+    }, (err) => {
+      process.nextTick(() => {
         if (err.name === 'AbortError') {
           return;
         }
 
         return this.socketError(err);
-      }
-
-      socket = socket!;
-      socket.on('error', (error) => { this.socketError(error); });
-      socket.on('close', () => { this.socketClose(); });
-      socket.on('end', () => { this.socketEnd(); });
-      socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY);
-
-      this.messageIo = new MessageIO(socket, this.config.options.packetSize, this.debug);
-      this.messageIo.on('secure', (cleartext) => { this.emit('secure', cleartext); });
-
-      this.socket = socket;
-
-      this.closed = false;
-      this.debug.log('connected to ' + this.config.server + ':' + this.config.options.port);
-
-      this.sendPreLogin();
-      this.transitionTo(this.STATE.SENT_PRELOGIN);
+      });
     });
   }
 

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -13,7 +13,7 @@ type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback
 export async function connectInParallel(options: { host: string, port: number, localAddress?: string | undefined }, lookup: LookupFunction, signal: AbortSignal) {
   const addresses = await lookupAllAddresses(options.host, lookup, signal);
 
-  return new Promise<net.Socket>((resolve, reject) => {
+  return await new Promise<net.Socket>((resolve, reject) => {
     if (signal.aborted) {
       return reject(new AbortError());
     }
@@ -158,7 +158,7 @@ export async function lookupAllAddresses(host: string, lookup: LookupFunction, s
     return [{ address: host, family: 4 }];
   } else {
     // dns.lookup does not have support for AbortSignal yet
-    return Promise.race([
+    return await Promise.race([
       new Promise<LookupAddress[]>((resolve, reject) => {
         lookup(punycode.toASCII(host), { all: true }, (err, addresses) => {
           err ? reject(err) : resolve(addresses);

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -3,17 +3,7 @@ import dns from 'dns';
 
 import * as punycode from 'punycode';
 import { AbortSignal } from 'node-abort-controller';
-
-class AbortError extends Error {
-  code: string;
-
-  constructor() {
-    super('The operation was aborted');
-
-    this.code = 'ABORT_ERR';
-    this.name = 'AbortError';
-  }
-}
+import AbortError from './errors/abort-error';
 
 export class ParallelConnectionStrategy {
   addresses: dns.LookupAddress[];

--- a/src/errors/abort-error.ts
+++ b/src/errors/abort-error.ts
@@ -1,0 +1,10 @@
+export default class AbortError extends Error {
+  code: string;
+
+  constructor() {
+    super('The operation was aborted');
+
+    this.code = 'ABORT_ERR';
+    this.name = 'AbortError';
+  }
+}

--- a/src/errors/timeout-error.ts
+++ b/src/errors/timeout-error.ts
@@ -1,0 +1,10 @@
+export default class TimeoutError extends Error {
+  code: string;
+
+  constructor() {
+    super('The operation was aborted due to timeout');
+
+    this.code = 'TIMEOUT_ERR';
+    this.name = 'TimeoutError';
+  }
+}

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -70,10 +70,10 @@ export class InstanceLookup {
       let response;
       try {
         response = await sender.execute();
-      } catch (err) {
+      } catch (err: unknown) {
         clearTimeout(timer);
 
-        if (err?.name === 'AbortError') {
+        if (err instanceof Error && err.name === 'AbortError') {
           // If the overall instance lookup was aborted,
           // do not perform any further attempts.
           if (signal.aborted) {

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -1,6 +1,7 @@
 import dns from 'dns';
 import { AbortController, AbortSignal } from 'node-abort-controller';
 
+import AbortError from './errors/abort-error';
 import { Sender } from './sender';
 
 const SQL_SERVER_BROWSER_PORT = 1434;
@@ -10,17 +11,6 @@ const RETRIES = 3;
 const MYSTERY_HEADER_LENGTH = 3;
 
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
-
-class AbortError extends Error {
-  code: string;
-
-  constructor() {
-    super('The operation was aborted');
-
-    this.code = 'ABORT_ERR';
-    this.name = 'AbortError';
-  }
-}
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
 export class InstanceLookup {

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -83,7 +83,7 @@ export class InstanceLookup {
           continue;
         }
 
-        throw new Error('Failed to lookup instance on ' + server + ' - ' + err.message);
+        throw err;
       }
 
       const message = response.toString('ascii', MYSTERY_HEADER_LENGTH);

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -13,115 +13,113 @@ const MYSTERY_HEADER_LENGTH = 3;
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
-export class InstanceLookup {
-  async instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction, signal: AbortSignal }): Promise<number> {
-    const server = options.server;
-    if (typeof server !== 'string') {
-      throw new TypeError('Invalid arguments: "server" must be a string');
-    }
-
-    const instanceName = options.instanceName;
-    if (typeof instanceName !== 'string') {
-      throw new TypeError('Invalid arguments: "instanceName" must be a string');
-    }
-
-    const timeout = options.timeout === undefined ? TIMEOUT : options.timeout;
-    if (typeof timeout !== 'number') {
-      throw new TypeError('Invalid arguments: "timeout" must be a number');
-    }
-
-    let retries = options.retries === undefined ? RETRIES : options.retries;
-    if (typeof retries !== 'number') {
-      throw new TypeError('Invalid arguments: "retries" must be a number');
-    }
-
-    if (options.lookup !== undefined && typeof options.lookup !== 'function') {
-      throw new TypeError('Invalid arguments: "lookup" must be a function');
-    }
-    const lookup = options.lookup ?? dns.lookup;
-
-    if (options.port !== undefined && typeof options.port !== 'number') {
-      throw new TypeError('Invalid arguments: "port" must be a number');
-    }
-    const port = options.port ?? SQL_SERVER_BROWSER_PORT;
-
-    const signal = options.signal;
-
-    if (signal.aborted) {
-      throw new AbortError();
-    }
-
-    while (retries >= 0) {
-      retries--;
-
-      const controller = new AbortController();
-
-      const abortCurrentAttempt = () => { controller.abort(); };
-
-      // If the overall instance lookup is aborted,
-      // forward the abort to the controller of the current
-      // lookup attempt.
-      signal.addEventListener('abort', abortCurrentAttempt, { once: true });
-
-      const request = Buffer.from([0x02]);
-      const sender = new Sender(options.server, port, lookup, controller.signal, request);
-      const timer = setTimeout(abortCurrentAttempt, timeout);
-
-      let response;
-      try {
-        response = await sender.execute();
-      } catch (err: unknown) {
-        clearTimeout(timer);
-
-        if (err instanceof Error && err.name === 'AbortError') {
-          // If the overall instance lookup was aborted,
-          // do not perform any further attempts.
-          if (signal.aborted) {
-            throw new AbortError();
-          }
-
-          continue;
-        }
-
-        throw err;
-      }
-
-      const message = response.toString('ascii', MYSTERY_HEADER_LENGTH);
-      const foundPort = this.parseBrowserResponse(message, instanceName);
-
-      if (foundPort) {
-        return foundPort;
-      }
-
-      throw new Error('Port for ' + instanceName + ' not found in ' + options.server);
-    }
-
-    throw new Error('Failed to get response from SQL Server Browser on ' + server);
+export async function instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction, signal: AbortSignal }): Promise<number> {
+  const server = options.server;
+  if (typeof server !== 'string') {
+    throw new TypeError('Invalid arguments: "server" must be a string');
   }
 
-  parseBrowserResponse(response: string, instanceName: string) {
-    let getPort;
+  const instanceName = options.instanceName;
+  if (typeof instanceName !== 'string') {
+    throw new TypeError('Invalid arguments: "instanceName" must be a string');
+  }
 
-    const instances = response.split(';;');
-    for (let i = 0, len = instances.length; i < len; i++) {
-      const instance = instances[i];
-      const parts = instance.split(';');
+  const timeout = options.timeout === undefined ? TIMEOUT : options.timeout;
+  if (typeof timeout !== 'number') {
+    throw new TypeError('Invalid arguments: "timeout" must be a number');
+  }
 
-      for (let p = 0, partsLen = parts.length; p < partsLen; p += 2) {
-        const name = parts[p];
-        const value = parts[p + 1];
+  let retries = options.retries === undefined ? RETRIES : options.retries;
+  if (typeof retries !== 'number') {
+    throw new TypeError('Invalid arguments: "retries" must be a number');
+  }
 
-        if (name === 'tcp' && getPort) {
-          const port = parseInt(value, 10);
-          return port;
+  if (options.lookup !== undefined && typeof options.lookup !== 'function') {
+    throw new TypeError('Invalid arguments: "lookup" must be a function');
+  }
+  const lookup = options.lookup ?? dns.lookup;
+
+  if (options.port !== undefined && typeof options.port !== 'number') {
+    throw new TypeError('Invalid arguments: "port" must be a number');
+  }
+  const port = options.port ?? SQL_SERVER_BROWSER_PORT;
+
+  const signal = options.signal;
+
+  if (signal.aborted) {
+    throw new AbortError();
+  }
+
+  while (retries >= 0) {
+    retries--;
+
+    const controller = new AbortController();
+
+    const abortCurrentAttempt = () => { controller.abort(); };
+
+    // If the overall instance lookup is aborted,
+    // forward the abort to the controller of the current
+    // lookup attempt.
+    signal.addEventListener('abort', abortCurrentAttempt, { once: true });
+
+    const request = Buffer.from([0x02]);
+    const sender = new Sender(options.server, port, lookup, controller.signal, request);
+    const timer = setTimeout(abortCurrentAttempt, timeout);
+
+    let response;
+    try {
+      response = await sender.execute();
+    } catch (err: unknown) {
+      clearTimeout(timer);
+
+      if (err instanceof Error && err.name === 'AbortError') {
+        // If the overall instance lookup was aborted,
+        // do not perform any further attempts.
+        if (signal.aborted) {
+          throw new AbortError();
         }
 
-        if (name === 'InstanceName') {
-          if (value.toUpperCase() === instanceName.toUpperCase()) {
-            getPort = true;
-          } else {
-            getPort = false;
-          }
+        continue;
+      }
+
+      throw err;
+    }
+
+    const message = response.toString('ascii', MYSTERY_HEADER_LENGTH);
+    const foundPort = parseBrowserResponse(message, instanceName);
+
+    if (foundPort) {
+      return foundPort;
+    }
+
+    throw new Error('Port for ' + instanceName + ' not found in ' + options.server);
+  }
+
+  throw new Error('Failed to get response from SQL Server Browser on ' + server);
+}
+
+export function parseBrowserResponse(response: string, instanceName: string) {
+  let getPort;
+
+  const instances = response.split(';;');
+  for (let i = 0, len = instances.length; i < len; i++) {
+    const instance = instances[i];
+    const parts = instance.split(';');
+
+    for (let p = 0, partsLen = parts.length; p < partsLen; p += 2) {
+      const name = parts[p];
+      const value = parts[p + 1];
+
+      if (name === 'tcp' && getPort) {
+        const port = parseInt(value, 10);
+        return port;
+      }
+
+      if (name === 'InstanceName') {
+        if (value.toUpperCase() === instanceName.toUpperCase()) {
+          getPort = true;
+        } else {
+          getPort = false;
         }
       }
     }

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -2,7 +2,7 @@ import dns from 'dns';
 import { AbortSignal } from 'node-abort-controller';
 
 import AbortError from './errors/abort-error';
-import { Sender } from './sender';
+import { sendMessage } from './sender';
 import { withTimeout } from './utils/with-timeout';
 
 const SQL_SERVER_BROWSER_PORT = 1434;
@@ -57,7 +57,7 @@ export async function instanceLookup(options: { server: string, instanceName: st
     try {
       response = await withTimeout(timeout, async (signal) => {
         const request = Buffer.from([0x02]);
-        return await new Sender(options.server, port, lookup, signal, request).execute();
+        return await sendMessage(options.server, port, lookup, signal, request);
       }, signal);
     } catch (err) {
       // If the current attempt timed out, continue with the next

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -14,7 +14,7 @@ const MYSTERY_HEADER_LENGTH = 3;
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
-export async function instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction, signal: AbortSignal }): Promise<number> {
+export async function instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction, signal: AbortSignal }) {
   const server = options.server;
   if (typeof server !== 'string') {
     throw new TypeError('Invalid arguments: "server" must be a string');
@@ -57,7 +57,7 @@ export async function instanceLookup(options: { server: string, instanceName: st
     try {
       response = await withTimeout(timeout, async (signal) => {
         const request = Buffer.from([0x02]);
-        return new Sender(options.server, port, lookup, signal, request).execute();
+        return await new Sender(options.server, port, lookup, signal, request).execute();
       }, signal);
     } catch (err) {
       // If the current attempt timed out, continue with the next

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -4,18 +4,10 @@ import net from 'net';
 import * as punycode from 'punycode';
 import { AbortSignal } from 'node-abort-controller';
 
+import AbortError from './errors/abort-error';
+
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
 
-class AbortError extends Error {
-  code: string;
-
-  constructor() {
-    super('The operation was aborted');
-
-    this.code = 'ABORT_ERR';
-    this.name = 'AbortError';
-  }
-}
 
 export class ParallelSendStrategy {
   addresses: dns.LookupAddress[];

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -23,8 +23,8 @@ export class ParallelSendStrategy {
     this.signal = signal;
   }
 
-  send(): Promise<Buffer> {
-    return new Promise((resolve, reject) => {
+  async send() {
+    return await new Promise<Buffer>((resolve, reject) => {
       const signal = this.signal;
 
       if (signal.aborted) {
@@ -97,36 +97,36 @@ export class Sender {
     this.signal = signal;
   }
 
-  execute(): Promise<Buffer> {
+  async execute() {
     if (net.isIP(this.host)) {
-      return this.executeForIP();
+      return await this.executeForIP();
     } else {
-      return this.executeForHostname();
+      return await this.executeForHostname();
     }
   }
 
-  executeForIP(): Promise<Buffer> {
-    return this.executeForAddresses([
+  async executeForIP() {
+    return await this.executeForAddresses([
       { address: this.host, family: net.isIPv6(this.host) ? 6 : 4 }
     ]);
   }
 
   // Wrapper for stubbing. Sinon does not have support for stubbing module functions.
-  invokeLookupAll(host: string): Promise<dns.LookupAddress[]> {
-    return new Promise((resolve, reject) => {
+  async invokeLookupAll(host: string) {
+    return await new Promise<dns.LookupAddress[]>((resolve, reject) => {
       this.lookup.call(null, punycode.toASCII(host), { all: true }, (err, addresses) => {
         err ? reject(err) : resolve(addresses);
       });
     });
   }
 
-  async executeForHostname(): Promise<Buffer> {
+  async executeForHostname() {
     const addresses = await this.invokeLookupAll(this.host);
-    return this.executeForAddresses(addresses);
+    return await this.executeForAddresses(addresses);
   }
 
-  executeForAddresses(addresses: dns.LookupAddress[]): Promise<Buffer> {
+  async executeForAddresses(addresses: dns.LookupAddress[]) {
     const parallelSendStrategy = new ParallelSendStrategy(addresses, this.port, this.signal, this.request);
-    return parallelSendStrategy.send();
+    return await parallelSendStrategy.send();
   }
 }

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -8,125 +8,76 @@ import AbortError from './errors/abort-error';
 
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
 
+export async function sendInParallel(addresses: dns.LookupAddress[], port: number, request: Buffer, signal: AbortSignal) {
+  return await new Promise<Buffer>((resolve, reject) => {
+    if (signal.aborted) {
+      return reject(new AbortError());
+    }
 
-export class ParallelSendStrategy {
-  addresses: dns.LookupAddress[];
-  port: number;
-  request: Buffer;
+    const sockets: dgram.Socket[] = [];
 
-  signal: AbortSignal;
+    let errorCount = 0;
 
-  constructor(addresses: dns.LookupAddress[], port: number, signal: AbortSignal, request: Buffer) {
-    this.addresses = addresses;
-    this.port = port;
-    this.request = request;
-    this.signal = signal;
-  }
+    const onError = (err: Error) => {
+      errorCount++;
 
-  async send() {
-    return await new Promise<Buffer>((resolve, reject) => {
-      const signal = this.signal;
-
-      if (signal.aborted) {
-        return reject(new AbortError());
-      }
-
-      const sockets: dgram.Socket[] = [];
-
-      let errorCount = 0;
-
-      const onError = (err: Error) => {
-        errorCount++;
-
-        if (errorCount === this.addresses.length) {
-          signal.removeEventListener('abort', onAbort);
-          clearSockets();
-
-          reject(err);
-        }
-      };
-
-      const onMessage = (message: Buffer) => {
+      if (errorCount === addresses.length) {
         signal.removeEventListener('abort', onAbort);
         clearSockets();
 
-        resolve(message);
-      };
-
-      const onAbort = () => {
-        clearSockets();
-
-        reject(new AbortError());
-      };
-
-      const clearSockets = () => {
-        for (const socket of sockets) {
-          socket.removeListener('error', onError);
-          socket.removeListener('message', onMessage);
-          socket.close();
-        }
-      };
-
-      signal.addEventListener('abort', onAbort, { once: true });
-
-      for (let j = 0; j < this.addresses.length; j++) {
-        const udpType = this.addresses[j].family === 6 ? 'udp6' : 'udp4';
-
-        const socket = dgram.createSocket(udpType);
-        sockets.push(socket);
-        socket.on('error', onError);
-        socket.on('message', onMessage);
-        socket.send(this.request, 0, this.request.length, this.port, this.addresses[j].address);
+        reject(err);
       }
-    });
-  }
+    };
+
+    const onMessage = (message: Buffer) => {
+      signal.removeEventListener('abort', onAbort);
+      clearSockets();
+
+      resolve(message);
+    };
+
+    const onAbort = () => {
+      clearSockets();
+
+      reject(new AbortError());
+    };
+
+    const clearSockets = () => {
+      for (const socket of sockets) {
+        socket.removeListener('error', onError);
+        socket.removeListener('message', onMessage);
+        socket.close();
+      }
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    for (let j = 0; j < addresses.length; j++) {
+      const udpType = addresses[j].family === 6 ? 'udp6' : 'udp4';
+
+      const socket = dgram.createSocket(udpType);
+      sockets.push(socket);
+      socket.on('error', onError);
+      socket.on('message', onMessage);
+      socket.send(request, 0, request.length, port, addresses[j].address);
+    }
+  });
 }
 
-export class Sender {
-  host: string;
-  port: number;
-  request: Buffer;
-  lookup: LookupFunction;
-  signal: AbortSignal;
+export async function sendMessage(host: string, port: number, lookup: LookupFunction, signal: AbortSignal, request: Buffer) {
+  let addresses: dns.LookupAddress[];
 
-  constructor(host: string, port: number, lookup: LookupFunction, signal: AbortSignal, request: Buffer) {
-    this.host = host;
-    this.port = port;
-    this.request = request;
-    this.lookup = lookup;
-    this.signal = signal;
-  }
-
-  async execute() {
-    if (net.isIP(this.host)) {
-      return await this.executeForIP();
-    } else {
-      return await this.executeForHostname();
-    }
-  }
-
-  async executeForIP() {
-    return await this.executeForAddresses([
-      { address: this.host, family: net.isIPv6(this.host) ? 6 : 4 }
-    ]);
-  }
-
-  // Wrapper for stubbing. Sinon does not have support for stubbing module functions.
-  async invokeLookupAll(host: string) {
-    return await new Promise<dns.LookupAddress[]>((resolve, reject) => {
-      this.lookup.call(null, punycode.toASCII(host), { all: true }, (err, addresses) => {
+  if (net.isIP(host)) {
+    addresses = [
+      { address: host, family: net.isIPv6(host) ? 6 : 4 }
+    ];
+  } else {
+    addresses = await new Promise<dns.LookupAddress[]>((resolve, reject) => {
+      lookup(punycode.toASCII(host), { all: true }, (err, addresses) => {
         err ? reject(err) : resolve(addresses);
       });
     });
   }
 
-  async executeForHostname() {
-    const addresses = await this.invokeLookupAll(this.host);
-    return await this.executeForAddresses(addresses);
-  }
-
-  async executeForAddresses(addresses: dns.LookupAddress[]) {
-    const parallelSendStrategy = new ParallelSendStrategy(addresses, this.port, this.signal, this.request);
-    return await parallelSendStrategy.send();
-  }
+  return await sendInParallel(addresses, port, request, signal);
 }

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,0 +1,29 @@
+import { AbortController, AbortSignal } from 'node-abort-controller';
+import TimeoutError from '../errors/timeout-error';
+
+/**
+ * Run the function `func` with an `AbortSignal` that will automatically abort after the time specified
+ * by `timeout` or when the given `signal` is aborted.
+ *
+ * On timeout, the `timeoutSignal` will be aborted and a `TimeoutError` will be thrown.
+ */
+export async function withTimeout<T>(timeout: number, func: (timeoutSignal: AbortSignal) => Promise<T>, signal?: AbortSignal): Promise<T> {
+  const timeoutController = new AbortController();
+  const abortCurrentAttempt = () => { timeoutController.abort(); };
+
+  const timer = setTimeout(abortCurrentAttempt, timeout);
+  signal?.addEventListener('abort', abortCurrentAttempt, { once: true });
+
+  try {
+    return await func(timeoutController.signal);
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError' && !(signal && signal.aborted)) {
+      throw new TimeoutError();
+    }
+
+    throw err;
+  } finally {
+    signal?.removeEventListener('abort', abortCurrentAttempt);
+    clearTimeout(timer);
+  }
+}

--- a/test/integration/instance-lookup-test.js
+++ b/test/integration/instance-lookup-test.js
@@ -27,7 +27,7 @@ function getConfig() {
 }
 
 describe('Instance Lookup Test', function() {
-  it('should test good instance', function(done) {
+  it('should test good instance', async function() {
     var config = getConfig();
 
     if (!config.instanceName) {
@@ -36,52 +36,52 @@ describe('Instance Lookup Test', function() {
     }
 
     const controller = new AbortController();
-    new InstanceLookup().instanceLookup({
+    const port = await new InstanceLookup().instanceLookup({
       server: config.server,
       instanceName: config.instanceName,
       signal: controller.signal
-    }, function(err, port) {
-      if (err) {
-        return done(err);
-      }
-
-      assert.ok(port);
-
-      done();
     });
+
+    assert.ok(port);
   });
 
-  it('should test bad Instance', function(done) {
+  it('should test bad Instance', async function() {
     var config = getConfig();
 
     const controller = new AbortController();
-    new InstanceLookup().instanceLookup({
-      server: config.server,
-      instanceName: 'badInstanceName',
-      timeout: 100,
-      retries: 1,
-      signal: controller.signal
-    }, function(err, port) {
-      assert.ok(err);
-      assert.ok(!port);
 
-      done();
-    });
+    let error;
+    try {
+      await new InstanceLookup().instanceLookup({
+        server: config.server,
+        instanceName: 'badInstanceName',
+        timeout: 100,
+        retries: 1,
+        signal: controller.signal
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
   });
 
-  it('should test bad Server', function(done) {
+  it('should test bad Server', async function() {
     const controller = new AbortController();
-    new InstanceLookup().instanceLookup({
-      server: RESERVED_IP_ADDRESS,
-      instanceName: 'badInstanceName',
-      timeout: 100,
-      retries: 1,
-      signal: controller.signal
-    }, function(err, port) {
-      assert.ok(err);
-      assert.ok(!port);
 
-      done();
-    });
+    let error;
+    try {
+      await new InstanceLookup().instanceLookup({
+        server: RESERVED_IP_ADDRESS,
+        instanceName: 'badInstanceName',
+        timeout: 100,
+        retries: 1,
+        signal: controller.signal
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
   });
 });

--- a/test/integration/instance-lookup-test.js
+++ b/test/integration/instance-lookup-test.js
@@ -5,7 +5,7 @@ const homedir = require('os').homedir();
 const assert = require('chai').assert;
 import { AbortController } from 'node-abort-controller';
 
-const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
+const { instanceLookup } = require('../../src/instance-lookup');
 
 var RESERVED_IP_ADDRESS = '192.0.2.0'; // Can never be used, so guaranteed to fail.
 
@@ -36,7 +36,7 @@ describe('Instance Lookup Test', function() {
     }
 
     const controller = new AbortController();
-    const port = await new InstanceLookup().instanceLookup({
+    const port = await instanceLookup({
       server: config.server,
       instanceName: config.instanceName,
       signal: controller.signal
@@ -52,7 +52,7 @@ describe('Instance Lookup Test', function() {
 
     let error;
     try {
-      await new InstanceLookup().instanceLookup({
+      await instanceLookup({
         server: config.server,
         instanceName: 'badInstanceName',
         timeout: 100,
@@ -71,7 +71,7 @@ describe('Instance Lookup Test', function() {
 
     let error;
     try {
-      await new InstanceLookup().instanceLookup({
+      await instanceLookup({
         server: RESERVED_IP_ADDRESS,
         instanceName: 'badInstanceName',
         timeout: 100,

--- a/test/unit/connector-test.js
+++ b/test/unit/connector-test.js
@@ -134,8 +134,6 @@ describe('Connector', function() {
         lookup: lookup
       }, controller.signal, true);
 
-      const spy = sinon.spy(ParallelConnectionStrategy.prototype, 'connect');
-
       let error;
       try {
         await connector.execute();
@@ -145,8 +143,6 @@ describe('Connector', function() {
 
       assert.instanceOf(error, Error);
       assert.strictEqual(error.name, 'AbortError');
-
-      sinon.assert.callCount(spy, 0);
     });
   });
 
@@ -262,13 +258,15 @@ describe('SequentialConnectionStrategy', function() {
   it('tries to connect to all addresses in sequence', async function() {
     const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedConnections = [];
@@ -313,13 +311,15 @@ describe('SequentialConnectionStrategy', function() {
   it('passes the first succesfully connected socket to the callback', async function() {
     const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     let expectedSocket;
@@ -339,13 +339,15 @@ describe('SequentialConnectionStrategy', function() {
   it('only attempts new connections until the first successful connection', async function() {
     const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedConnections = [];
@@ -366,13 +368,15 @@ describe('SequentialConnectionStrategy', function() {
   it('fails if all sequential connections fail', async function() {
     const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     mitm.on('connect', function(socket) {
@@ -395,13 +399,15 @@ describe('SequentialConnectionStrategy', function() {
   it('destroys all sockets except for the first succesfully connected socket', async function() {
     const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedSockets = [];
@@ -428,13 +434,15 @@ describe('SequentialConnectionStrategy', function() {
     controller.abort();
 
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     mitm.on('connect', () => {
@@ -455,13 +463,15 @@ describe('SequentialConnectionStrategy', function() {
   it('can be aborted while trying to connect', async function() {
     const controller = new AbortController();
     const strategy = new SequentialConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedSockets = [];
@@ -503,13 +513,15 @@ describe('ParallelConnectionStrategy', function() {
   it('tries to connect to all addresses in parallel', async function() {
     const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedConnections = [];
@@ -540,13 +552,15 @@ describe('ParallelConnectionStrategy', function() {
   it('fails if all parallel connections fail', async function() {
     const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     mitm.on('connect', function(socket) {
@@ -569,13 +583,15 @@ describe('ParallelConnectionStrategy', function() {
   it('passes the first succesfully connected socket to the callback', async function() {
     const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     let expectedSocket;
@@ -596,13 +612,15 @@ describe('ParallelConnectionStrategy', function() {
   it('destroys all sockets except for the first succesfully connected socket', async function() {
     const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedSockets = [];
@@ -623,13 +641,15 @@ describe('ParallelConnectionStrategy', function() {
     controller.abort();
 
     const strategy = new ParallelConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     mitm.on('connect', () => {
@@ -650,13 +670,15 @@ describe('ParallelConnectionStrategy', function() {
   it('can be aborted while trying to connect', async function() {
     const controller = new AbortController();
     const strategy = new ParallelConnectionStrategy(
-      [
-        { address: '127.0.0.2' },
-        { address: '2002:20:0:0:0:0:1:3' },
-        { address: '127.0.0.4' }
-      ],
+      { host: 'localhost', port: 12345, localAddress: '192.168.0.1' },
+      function lookup(hostname, options, callback) {
+        callback(null, [
+          { address: '127.0.0.2', family: 4 },
+          { address: '2002:20:0:0:0:0:1:3', family: 6 },
+          { address: '127.0.0.4', family: 4 }
+        ]);
+      },
       controller.signal,
-      { port: 12345, localAddress: '192.168.0.1' }
     );
 
     const attemptedSockets = [];

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -12,48 +12,61 @@ describe('instanceLookup invalid args', function() {
     instanceLookup = new InstanceLookup();
   });
 
-  it('invalid server', () => {
-    assert.throws(() => {
-      instanceLookup.instanceLookup({ server: 4 });
-    }, 'Invalid arguments: "server" must be a string');
+  it('invalid server', async function() {
+    let error;
+    try {
+      await instanceLookup.instanceLookup({ server: 4 });
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Invalid arguments: "server" must be a string');
   });
 
-  it('invalid instanceName', () => {
-    assert.throws(() => {
-      instanceLookup.instanceLookup({ server: 'serverName', instanceName: 4 });
-    }, 'Invalid arguments: "instanceName" must be a string');
+  it('invalid instanceName', async function() {
+    let error;
+    try {
+      await instanceLookup.instanceLookup({ server: 'serverName', instanceName: 4 });
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Invalid arguments: "instanceName" must be a string');
   });
 
-  it('invalid timeout', () => {
-    assert.throws(() => {
-      instanceLookup.instanceLookup({
+  it('invalid timeout', async function() {
+    let error;
+    try {
+      await instanceLookup.instanceLookup({
         server: 'server',
         instanceName: 'instance',
         timeout: 'some string'
       });
-    }, 'Invalid arguments: "timeout" must be a number');
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Invalid arguments: "timeout" must be a number');
   });
 
-  it('invalid retries', () => {
-    assert.throws(() => {
-      instanceLookup.instanceLookup({
+  it('invalid retries', async function() {
+    let error;
+    try {
+      await instanceLookup.instanceLookup({
         server: 'server',
         instanceName: 'instance',
         timeout: 1000,
         retries: 'some string'
       });
-    }, 'Invalid arguments: "retries" must be a number');
-  });
+    } catch (err) {
+      error = err;
+    }
 
-  it('invalid callback', () => {
-    assert.throws(() => {
-      instanceLookup.instanceLookup({
-        server: 'server',
-        instanceName: 'instance',
-        timeout: 1000,
-        retries: 3
-      }, 4);
-    }, 'Invalid arguments: "callback" must be a function');
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Invalid arguments: "retries" must be a number');
   });
 });
 
@@ -72,27 +85,28 @@ describe('InstanceLookup', function() {
     server.close(done);
   });
 
-  it('sends a request to the given server browser endpoint', function(done) {
+  it('sends a request to the given server browser endpoint', async function() {
     server.on('message', (msg) => {
       assert.deepEqual(msg, Buffer.from([0x02]));
-
-      done();
     });
 
     const controller = new AbortController();
-    new InstanceLookup().instanceLookup({
-      server: server.address().address,
-      port: server.address().port,
-      instanceName: 'second',
-      timeout: 500,
-      retries: 1,
-      signal: controller.signal
-    }, () => {
+
+    try {
+      await new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'second',
+        timeout: 500,
+        retries: 1,
+        signal: controller.signal
+      });
+    } catch (err) {
       // Ignore
-    });
+    }
   });
 
-  it('can be aborted immediately', function(done) {
+  it('can be aborted immediately', async function() {
     server.on('message', (msg, rinfo) => {
       assert.fail('expected no message to be received');
     });
@@ -100,22 +114,25 @@ describe('InstanceLookup', function() {
     const controller = new AbortController();
     controller.abort();
 
-    new InstanceLookup().instanceLookup({
-      server: server.address().address,
-      port: server.address().port,
-      instanceName: 'first',
-      timeout: 500,
-      retries: 1,
-      signal: controller.signal
-    }, (err) => {
-      assert.instanceOf(err, Error);
-      assert.strictEqual(err.name, 'AbortError');
+    let error;
+    try {
+      await new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'first',
+        timeout: 500,
+        retries: 1,
+        signal: controller.signal
+      });
+    } catch (err) {
+      error = err;
+    }
 
-      done();
-    });
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.name, 'AbortError');
   });
 
-  it('can be aborted after sending the first request', function(done) {
+  it('can be aborted after sending the first request', async function() {
     server.on('message', (msg, rinfo) => {
       if (controller.signal.aborted) {
         assert.fail('expected no message to be received');
@@ -126,22 +143,25 @@ describe('InstanceLookup', function() {
 
     const controller = new AbortController();
 
-    new InstanceLookup().instanceLookup({
-      server: server.address().address,
-      port: server.address().port,
-      instanceName: 'first',
-      timeout: 500,
-      retries: 1,
-      signal: controller.signal
-    }, (err) => {
-      assert.instanceOf(err, Error);
-      assert.strictEqual(err.name, 'AbortError');
+    let error;
+    try {
+      await new InstanceLookup().instanceLookup({
+        server: server.address().address,
+        port: server.address().port,
+        instanceName: 'first',
+        timeout: 500,
+        retries: 1,
+        signal: controller.signal
+      });
+    } catch (err) {
+      error = err;
+    }
 
-      done();
-    });
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.name, 'AbortError');
   });
 
-  it('can be aborted after retrying to send a request', function(done) {
+  it('can be aborted after retrying to send a request', async function() {
     server.once('message', () => {
       server.on('message', (msg, rinfo) => {
         if (controller.signal.aborted) {
@@ -154,56 +174,55 @@ describe('InstanceLookup', function() {
 
     const controller = new AbortController();
 
-    new InstanceLookup().instanceLookup({
-      server: server.address().address,
-      port: server.address().port,
-      instanceName: 'first',
-      timeout: 500,
-      retries: 1,
-      signal: controller.signal
-    }, (err) => {
-      assert.instanceOf(err, Error);
-      assert.strictEqual(err.name, 'AbortError');
-
-      done();
-    });
-  });
-
-  describe('when not receiving a response', function(done) {
-    it('times out after the given timeout period', function(done) {
-      let timedOut = false;
-      let errored = false;
-
-      setTimeout(() => {
-        timedOut = true;
-      }, 500);
-
-      setTimeout(() => {
-        assert.isTrue(errored);
-        done();
-      }, 600);
-
-      const controller = new AbortController();
-
-      new InstanceLookup().instanceLookup({
+    let error;
+    try {
+      await new InstanceLookup().instanceLookup({
         server: server.address().address,
         port: server.address().port,
-        instanceName: 'instance',
+        instanceName: 'first',
         timeout: 500,
-        retries: 0,
+        retries: 1,
         signal: controller.signal
-      }, (err) => {
-        assert.instanceOf(err, Error);
-        assert.match(err.message, /^Failed to get response from SQL Server Browser/);
-        assert.isTrue(timedOut);
-
-        errored = true;
       });
+    } catch (err) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.name, 'AbortError');
+  });
+
+  describe('when not receiving a response', function() {
+    it('times out after the given timeout period', async function() {
+      const controller = new AbortController();
+
+      const timeBefore = process.hrtime();
+
+      let error;
+      try {
+        await new InstanceLookup().instanceLookup({
+          server: server.address().address,
+          port: server.address().port,
+          instanceName: 'instance',
+          timeout: 500,
+          retries: 0,
+          signal: controller.signal
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      const timeDiff = process.hrtime(timeBefore);
+
+      assert.instanceOf(error, Error);
+      assert.match(error.message, /^Failed to get response from SQL Server Browser/);
+
+      assert.approximately(500000000, timeDiff[1], 100000000);
     });
   });
 
   describe('when receiving a response before timing out', function() {
-    it('returns the port for the instance with a matching name', function(done) {
+    it('returns the port for the instance with a matching name', async function() {
       server.on('message', (msg, rinfo) => {
         const response = [
           'ServerName;WINDOWS2;InstanceName;first;IsClustered;No;Version;10.50.2500.0;tcp;1444;;',
@@ -216,25 +235,21 @@ describe('InstanceLookup', function() {
 
       const controller = new AbortController();
 
-      new InstanceLookup().instanceLookup({
+      const result = await new InstanceLookup().instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'second',
         timeout: 500,
         retries: 1,
         signal: controller.signal
-      }, (err, result) => {
-        assert.ifError(err);
-
-        assert.strictEqual(result, 1433);
-
-        done();
       });
+
+      assert.strictEqual(result, 1433);
     });
   });
 
   describe('when receiving a response that does not contain the requested instance name', function() {
-    it('returns an error', function(done) {
+    it('throws an error', async function() {
       server.on('message', (msg, rinfo) => {
         const response = [
           'ServerName;WINDOWS2;InstanceName;first;IsClustered;No;Version;10.50.2500.0;tcp;1444;;',
@@ -247,43 +262,49 @@ describe('InstanceLookup', function() {
 
       const controller = new AbortController();
 
-      new InstanceLookup().instanceLookup({
-        server: server.address().address,
-        port: server.address().port,
-        instanceName: 'other',
-        timeout: 500,
-        retries: 1,
-        signal: controller.signal
-      }, (err) => {
-        assert.instanceOf(err, Error);
-        assert.match(err.message, /^Port for other not found/);
+      let error;
+      try {
+        await new InstanceLookup().instanceLookup({
+          server: server.address().address,
+          port: server.address().port,
+          instanceName: 'other',
+          timeout: 500,
+          retries: 1,
+          signal: controller.signal
+        });
+      } catch (err) {
+        error = err;
+      }
 
-        done();
-      });
+      assert.instanceOf(error, Error);
+      assert.match(error.message, /^Port for other not found/);
     });
   });
 
   describe('when receiving an invalid response', function() {
-    it('returns an error', function(done) {
+    it('throws an error', async function() {
       server.on('message', (msg, rinfo) => {
         server.send('foo bar baz', rinfo.port, rinfo.address);
       });
 
       const controller = new AbortController();
 
-      new InstanceLookup().instanceLookup({
-        server: server.address().address,
-        port: server.address().port,
-        instanceName: 'other',
-        timeout: 500,
-        retries: 1,
-        signal: controller.signal
-      }, (err) => {
-        assert.instanceOf(err, Error);
-        assert.match(err.message, /^Port for other not found/);
+      let error;
+      try {
+        await new InstanceLookup().instanceLookup({
+          server: server.address().address,
+          port: server.address().port,
+          instanceName: 'other',
+          timeout: 500,
+          retries: 1,
+          signal: controller.signal
+        });
+      } catch (err) {
+        error = err;
+      }
 
-        done();
-      });
+      assert.instanceOf(error, Error);
+      assert.match(error.message, /^Port for other not found/);
     });
   });
 });
@@ -328,9 +349,9 @@ describe('parseBrowserResponse', function() {
 });
 
 describe('parseBrowserResponse', function() {
-  it('test IDN Server name', (done) => {
+  it('test IDN Server name', async function() {
     const lookup = sinon.spy(function lookup(hostname, options, callback) {
-      callback([{ address: '127.0.0.1', family: 4 }]);
+      callback(null, [{ address: '127.0.0.1', family: 4 }]);
     });
 
     const controller = new AbortController();
@@ -339,22 +360,24 @@ describe('parseBrowserResponse', function() {
       server: '本地主机.ad',
       instanceName: 'instance',
       timeout: 500,
-      retries: 1,
+      retries: 0,
       lookup: lookup,
       signal: controller.signal
     };
 
-    new InstanceLookup().instanceLookup(options, () => {
-      sinon.assert.calledOnce(lookup);
-      sinon.assert.calledWithMatch(lookup, punycode.toASCII(options.server));
+    try {
+      await new InstanceLookup().instanceLookup(options);
+    } catch (err) {
+      // ignore
+    }
 
-      done();
-    });
+    sinon.assert.calledOnce(lookup);
+    sinon.assert.calledWithMatch(lookup, punycode.toASCII(options.server));
   });
 
-  it('test ASCII Server name', (done) => {
+  it('test ASCII Server name', async function() {
     const lookup = sinon.spy(function lookup(hostname, options, callback) {
-      callback([{ address: '127.0.0.1', family: 4 }]);
+      callback(null, [{ address: '127.0.0.1', family: 4 }]);
     });
 
     const controller = new AbortController();
@@ -363,16 +386,18 @@ describe('parseBrowserResponse', function() {
       server: 'localhost',
       instanceName: 'instance',
       timeout: 500,
-      retries: 1,
+      retries: 0,
       lookup: lookup,
       signal: controller.signal
     };
 
-    new InstanceLookup().instanceLookup(options, (err) => {
-      sinon.assert.calledOnce(lookup);
-      sinon.assert.calledWithMatch(lookup, options.server);
+    try {
+      await new InstanceLookup().instanceLookup(options);
+    } catch (err) {
+      // ignore
+    }
 
-      done();
-    });
+    sinon.assert.calledOnce(lookup);
+    sinon.assert.calledWithMatch(lookup, options.server);
   });
 });

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -1,21 +1,16 @@
-const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
 const sinon = require('sinon');
 const punycode = require('punycode');
 const assert = require('chai').assert;
 const dgram = require('dgram');
 const { AbortController } = require('node-abort-controller');
 
+const { instanceLookup, parseBrowserResponse } = require('../../src/instance-lookup');
+
 describe('instanceLookup invalid args', function() {
-  let instanceLookup;
-
-  beforeEach(function() {
-    instanceLookup = new InstanceLookup();
-  });
-
   it('invalid server', async function() {
     let error;
     try {
-      await instanceLookup.instanceLookup({ server: 4 });
+      await instanceLookup({ server: 4 });
     } catch (err) {
       error = err;
     }
@@ -27,7 +22,7 @@ describe('instanceLookup invalid args', function() {
   it('invalid instanceName', async function() {
     let error;
     try {
-      await instanceLookup.instanceLookup({ server: 'serverName', instanceName: 4 });
+      await instanceLookup({ server: 'serverName', instanceName: 4 });
     } catch (err) {
       error = err;
     }
@@ -39,7 +34,7 @@ describe('instanceLookup invalid args', function() {
   it('invalid timeout', async function() {
     let error;
     try {
-      await instanceLookup.instanceLookup({
+      await instanceLookup({
         server: 'server',
         instanceName: 'instance',
         timeout: 'some string'
@@ -55,7 +50,7 @@ describe('instanceLookup invalid args', function() {
   it('invalid retries', async function() {
     let error;
     try {
-      await instanceLookup.instanceLookup({
+      await instanceLookup({
         server: 'server',
         instanceName: 'instance',
         timeout: 1000,
@@ -93,7 +88,7 @@ describe('InstanceLookup', function() {
     const controller = new AbortController();
 
     try {
-      await new InstanceLookup().instanceLookup({
+      await instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'second',
@@ -116,7 +111,7 @@ describe('InstanceLookup', function() {
 
     let error;
     try {
-      await new InstanceLookup().instanceLookup({
+      await instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'first',
@@ -145,7 +140,7 @@ describe('InstanceLookup', function() {
 
     let error;
     try {
-      await new InstanceLookup().instanceLookup({
+      await instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'first',
@@ -176,7 +171,7 @@ describe('InstanceLookup', function() {
 
     let error;
     try {
-      await new InstanceLookup().instanceLookup({
+      await instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'first',
@@ -200,7 +195,7 @@ describe('InstanceLookup', function() {
 
       let error;
       try {
-        await new InstanceLookup().instanceLookup({
+        await instanceLookup({
           server: server.address().address,
           port: server.address().port,
           instanceName: 'instance',
@@ -235,7 +230,7 @@ describe('InstanceLookup', function() {
 
       const controller = new AbortController();
 
-      const result = await new InstanceLookup().instanceLookup({
+      const result = await instanceLookup({
         server: server.address().address,
         port: server.address().port,
         instanceName: 'second',
@@ -264,7 +259,7 @@ describe('InstanceLookup', function() {
 
       let error;
       try {
-        await new InstanceLookup().instanceLookup({
+        await instanceLookup({
           server: server.address().address,
           port: server.address().port,
           instanceName: 'other',
@@ -291,7 +286,7 @@ describe('InstanceLookup', function() {
 
       let error;
       try {
-        await new InstanceLookup().instanceLookup({
+        await instanceLookup({
           server: server.address().address,
           port: server.address().port,
           instanceName: 'other',
@@ -310,17 +305,11 @@ describe('InstanceLookup', function() {
 });
 
 describe('parseBrowserResponse', function() {
-  let instanceLookup;
-
-  beforeEach(function() {
-    instanceLookup = new InstanceLookup();
-  });
-
   it('oneInstanceFound', () => {
     const response =
       'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;';
 
-    assert.strictEqual(instanceLookup.parseBrowserResponse(response, 'sqlexpress'), 1433);
+    assert.strictEqual(parseBrowserResponse(response, 'sqlexpress'), 1433);
   });
 
   it('twoInstancesFoundInFirst', () => {
@@ -328,7 +317,7 @@ describe('parseBrowserResponse', function() {
       'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;' +
       'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
 
-    assert.strictEqual(instanceLookup.parseBrowserResponse(response, 'sqlexpress'), 1433);
+    assert.strictEqual(parseBrowserResponse(response, 'sqlexpress'), 1433);
   });
 
   it('twoInstancesFoundInSecond', () => {
@@ -336,7 +325,7 @@ describe('parseBrowserResponse', function() {
       'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
       'ServerName;WINDOWS2;InstanceName;SQLEXPRESS;IsClustered;No;Version;10.50.2500.0;tcp;1433;;';
 
-    assert.strictEqual(instanceLookup.parseBrowserResponse(response, 'sqlexpress'), 1433);
+    assert.strictEqual(parseBrowserResponse(response, 'sqlexpress'), 1433);
   });
 
   it('twoInstancesNotFound', () => {
@@ -344,7 +333,7 @@ describe('parseBrowserResponse', function() {
       'ServerName;WINDOWS2;InstanceName;XXXXXXXXXX;IsClustered;No;Version;10.50.2500.0;tcp;0;;' +
       'ServerName;WINDOWS2;InstanceName;YYYYYYYYYY;IsClustered;No;Version;10.50.2500.0;tcp;0;;';
 
-    assert.strictEqual(instanceLookup.parseBrowserResponse(response, 'sqlexpress'), undefined);
+    assert.strictEqual(parseBrowserResponse(response, 'sqlexpress'), undefined);
   });
 });
 
@@ -366,7 +355,7 @@ describe('parseBrowserResponse', function() {
     };
 
     try {
-      await new InstanceLookup().instanceLookup(options);
+      await instanceLookup(options);
     } catch {
       // ignore
     }
@@ -392,7 +381,7 @@ describe('parseBrowserResponse', function() {
     };
 
     try {
-      await new InstanceLookup().instanceLookup(options);
+      await instanceLookup(options);
     } catch {
       // ignore
     }

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -101,7 +101,7 @@ describe('InstanceLookup', function() {
         retries: 1,
         signal: controller.signal
       });
-    } catch (err) {
+    } catch {
       // Ignore
     }
   });
@@ -367,7 +367,7 @@ describe('parseBrowserResponse', function() {
 
     try {
       await new InstanceLookup().instanceLookup(options);
-    } catch (err) {
+    } catch {
       // ignore
     }
 
@@ -393,7 +393,7 @@ describe('parseBrowserResponse', function() {
 
     try {
       await new InstanceLookup().instanceLookup(options);
-    } catch (err) {
+    } catch {
       // ignore
     }
 

--- a/test/unit/sender-test.js
+++ b/test/unit/sender-test.js
@@ -47,7 +47,7 @@ describe('Sender', function() {
       }
     });
 
-    it('uses the given lookup function to resolve host names', function(done) {
+    it('uses the given lookup function to resolve host names', async function() {
       function lookup(hostname, options, callback) {
         assert.strictEqual(hostname, 'foo.bar.baz');
         assert.deepEqual(options, { all: true });
@@ -63,10 +63,10 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute(done);
+      await sender.execute();
     });
 
-    it('forwards any errors happening during lookup', function(done) {
+    it('forwards any errors happening during lookup', async function() {
       const expectedError = new Error('fail');
 
       function lookup(hostname, options, callback) {
@@ -79,14 +79,18 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute((err) => {
-        assert.strictEqual(err, expectedError);
 
-        done();
-      });
+      let error;
+      try {
+        await sender.execute();
+      } catch (err) {
+        error = err;
+      }
+
+      assert.strictEqual(error, expectedError);
     });
 
-    it('sends the given request to the remote server', function(done) {
+    it('sends the given request to the remote server', async function() {
       const expectedRequest = Buffer.from([0x02]);
 
       server.once('message', (message, rinfo) => {
@@ -97,10 +101,10 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
-      sender.execute(done);
+      await sender.execute();
     });
 
-    it('calls the given callback with the received response', function(done) {
+    it('calls the given callback with the received response', async function() {
       const expectedResponse = Buffer.from('response');
 
       server.once('message', (message, rinfo) => {
@@ -109,18 +113,12 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute((err, message) => {
-        if (err) {
-          return done(err);
-        }
 
-        assert.deepEqual(message, expectedResponse);
-
-        done();
-      });
+      const message = await sender.execute();
+      assert.deepEqual(message, expectedResponse);
     });
 
-    it('can be aborted during the DNS lookup', function(done) {
+    it('can be aborted during the DNS lookup', async function() {
       function lookup(hostname, options, callback) {
         controller.abort();
 
@@ -135,15 +133,19 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute((err) => {
-        assert.instanceOf(err, Error);
-        assert.strictEqual(err.name, 'AbortError');
 
-        done();
-      });
+      let error;
+      try {
+        await sender.execute();
+      } catch (err) {
+        error = err;
+      }
+
+      assert.instanceOf(error, Error);
+      assert.strictEqual(error.name, 'AbortError');
     });
 
-    it('can be aborted after the DNS lookup', function(done) {
+    it('can be aborted after the DNS lookup', async function() {
       function lookup(hostname, options, callback) {
         process.nextTick(() => {
           controller.abort();
@@ -160,15 +162,19 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute((err) => {
-        assert.instanceOf(err, Error);
-        assert.strictEqual(err.name, 'AbortError');
 
-        done();
-      });
+      let error;
+      try {
+        await sender.execute();
+      } catch (err) {
+        error = err;
+      }
+
+      assert.instanceOf(error, Error);
+      assert.strictEqual(error.name, 'AbortError');
     });
 
-    it('can be aborted before receiving a response', function(done) {
+    it('can be aborted before receiving a response', async function() {
       const expectedRequest = Buffer.from([0x02]);
 
       server.once('message', (message, rinfo) => {
@@ -177,12 +183,16 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
-      sender.execute((err) => {
-        assert.instanceOf(err, Error);
-        assert.strictEqual(err.name, 'AbortError');
 
-        done();
-      });
+      let error;
+      try {
+        await sender.execute();
+      } catch (err) {
+        error = err;
+      }
+
+      assert.instanceOf(error, Error);
+      assert.strictEqual(error.name, 'AbortError');
     });
   });
 
@@ -227,7 +237,7 @@ describe('Sender', function() {
       }
     });
 
-    it('uses the given lookup function to resolve host names', function(done) {
+    it('uses the given lookup function to resolve host names', async function() {
       function lookup(hostname, options, callback) {
         assert.strictEqual(hostname, 'foo.bar.baz');
         assert.deepEqual(options, { all: true });
@@ -243,10 +253,10 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute(done);
+      await sender.execute();
     });
 
-    it('forwards any errors happening during lookup', function(done) {
+    it('forwards any errors happening during lookup', async function() {
       const expectedError = new Error('fail');
 
       function lookup(hostname, options, callback) {
@@ -259,14 +269,18 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute((err) => {
-        assert.strictEqual(err, expectedError);
 
-        done();
-      });
+      let error;
+      try {
+        await sender.execute();
+      } catch (err) {
+        error = err;
+      }
+
+      assert.strictEqual(error, expectedError);
     });
 
-    it('sends the given request to the remote server', function(done) {
+    it('sends the given request to the remote server', async function() {
       const expectedRequest = Buffer.from([0x02]);
 
       server.once('message', (message, rinfo) => {
@@ -277,10 +291,10 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
-      sender.execute(done);
+      await sender.execute();
     });
 
-    it('calls the given callback with the received response', function(done) {
+    it('calls the given callback with the received response', async function() {
       const expectedResponse = Buffer.from('response');
 
       server.once('message', (message, rinfo) => {
@@ -289,15 +303,9 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
-      sender.execute((err, message) => {
-        if (err) {
-          return done(err);
-        }
+      const message = await sender.execute();
 
-        assert.deepEqual(message, expectedResponse);
-
-        done();
-      });
+      assert.deepEqual(message, expectedResponse);
     });
   });
 
@@ -347,7 +355,7 @@ describe('Sender', function() {
       });
     });
 
-    it('sends the request to all servers', function(done) {
+    it('sends the request to all servers', async function() {
       function lookup(hostname, options, callback) {
         process.nextTick(callback, undefined, addresses.map((address) => {
           return { address: address, family: 4 };
@@ -368,22 +376,16 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
-      sender.execute((err) => {
-        if (err) {
-          return done(err);
-        }
+      await sender.execute();
 
-        assert.deepEqual([
-          [ '127.0.0.1', expectedRequest ],
-          [ '127.0.0.2', expectedRequest ],
-          [ '127.0.0.3', expectedRequest ]
-        ], messages);
-
-        done();
-      });
+      assert.deepEqual([
+        [ '127.0.0.1', expectedRequest ],
+        [ '127.0.0.2', expectedRequest ],
+        [ '127.0.0.3', expectedRequest ]
+      ], messages);
     });
 
-    it('calls the given callback with the first received response', function(done) {
+    it('calls the given callback with the first received response', async function() {
       function lookup(hostname, options, callback) {
         process.nextTick(callback, undefined, addresses.map((address) => {
           return { address: address, family: 4 };
@@ -406,16 +408,10 @@ describe('Sender', function() {
 
       const controller = new AbortController();
       const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
-      sender.execute((err, response) => {
-        if (err) {
-          return done(err);
-        }
+      const response = await sender.execute();
 
-        assert.strictEqual(messages.length, 3);
-        assert.deepEqual(response, Buffer.from('response #3'));
-
-        done();
-      });
+      assert.strictEqual(messages.length, 3);
+      assert.deepEqual(response, Buffer.from('response #3'));
     });
   });
 });

--- a/test/unit/sender-test.js
+++ b/test/unit/sender-test.js
@@ -3,9 +3,9 @@ const { assert } = require('chai');
 const dns = require('dns');
 const { AbortController } = require('node-abort-controller');
 
-const { Sender } = require('../../src/sender');
+const { sendMessage } = require('../../src/sender');
 
-describe('Sender', function() {
+describe('sendMessage', function() {
   describe('with a single IPv4 address', function() {
     /**
      * @type {dgram.Socket}
@@ -62,8 +62,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      await sender.execute();
+      await sendMessage('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
     });
 
     it('forwards any errors happening during lookup', async function() {
@@ -78,11 +77,10 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
 
       let error;
       try {
-        await sender.execute();
+        await sendMessage('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       } catch (err) {
         error = err;
       }
@@ -100,8 +98,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
-      await sender.execute();
+      await sendMessage(address, port, dns.lookup, controller.signal, expectedRequest);
     });
 
     it('calls the given callback with the received response', async function() {
@@ -112,9 +109,8 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
 
-      const message = await sender.execute();
+      const message = await sendMessage(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
       assert.deepEqual(message, expectedResponse);
     });
 
@@ -132,11 +128,10 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
 
       let error;
       try {
-        await sender.execute();
+        await sendMessage('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       } catch (err) {
         error = err;
       }
@@ -161,11 +156,10 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
 
       let error;
       try {
-        await sender.execute();
+        await sendMessage('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       } catch (err) {
         error = err;
       }
@@ -182,11 +176,10 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
 
       let error;
       try {
-        await sender.execute();
+        await sendMessage(address, port, dns.lookup, controller.signal, expectedRequest);
       } catch (err) {
         error = err;
       }
@@ -252,8 +245,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
-      await sender.execute();
+      await sendMessage('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
     });
 
     it('forwards any errors happening during lookup', async function() {
@@ -268,11 +260,10 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
 
       let error;
       try {
-        await sender.execute();
+        await sendMessage('foo.bar.baz', port, lookup, controller.signal, Buffer.from([0x02]));
       } catch (err) {
         error = err;
       }
@@ -290,8 +281,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender(address, port, dns.lookup, controller.signal, expectedRequest);
-      await sender.execute();
+      await sendMessage(address, port, dns.lookup, controller.signal, expectedRequest);
     });
 
     it('calls the given callback with the received response', async function() {
@@ -302,8 +292,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
-      const message = await sender.execute();
+      const message = await sendMessage(address, port, dns.lookup, controller.signal, Buffer.from([0x02]));
 
       assert.deepEqual(message, expectedResponse);
     });
@@ -375,8 +364,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
-      await sender.execute();
+      await sendMessage('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
 
       assert.deepEqual([
         [ '127.0.0.1', expectedRequest ],
@@ -407,8 +395,7 @@ describe('Sender', function() {
       });
 
       const controller = new AbortController();
-      const sender = new Sender('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
-      const response = await sender.execute();
+      const response = await sendMessage('foo.bar.baz', port, lookup, controller.signal, expectedRequest);
 
       assert.strictEqual(messages.length, 3);
       assert.deepEqual(response, Buffer.from('response #3'));


### PR DESCRIPTION
This is an attempt to start moving some of the `tedious` internals over to use `async`/`await`.