### PR TITLE
fix: add connection.connect() to broken minimal example

### DIFF
--- a/examples/minimal.js
+++ b/examples/minimal.js
@@ -26,6 +26,8 @@ connection.on('connect', (err) => {
   executeStatement();
 });
 
+connection.connect();
+
 function executeStatement() {
   const request = new Request('select * from MyTable', (err, rowCount) => {
     if (err) {


### PR DESCRIPTION
This PR fixes the `minimal` example, which is currently broken.

Running the example currently yields no output, as a `connect()` call is missing. Adding the missing call executes the query as expected after the connection is ready.