### PR TITLE
Delete unused `flow` configuration file

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,0 @@
-[ignore]
-<PROJECT_ROOT>/lib/.*
-.*/config-chain/test/broken.json
-.*/npmconf/test/fixtures/package.json


### PR DESCRIPTION
We've switched from `flow` to `typescript` quite some while ago.