### PR TITLE
Fix `varchar` and `varbinary` to generate exact length in `TYPE_INFO` header

### DIFF
--- a/src/data-types/varbinary.ts
+++ b/src/data-types/varbinary.ts
@@ -49,7 +49,7 @@ const VarBinary: { maximumLength: number } & DataType = {
     buffer.writeUInt8(this.id, 0);
 
     if (parameter.length! <= this.maximumLength) {
-      buffer.writeUInt16LE(this.maximumLength, 1);
+      buffer.writeUInt16LE(parameter.length!, 1);
     } else {
       buffer.writeUInt16LE(MAX, 1);
     }

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -55,7 +55,7 @@ const VarChar: { maximumLength: number } & DataType = {
     buffer.writeUInt8(this.id, 0);
 
     if (parameter.length! <= this.maximumLength) {
-      buffer.writeUInt16LE(this.maximumLength, 1);
+      buffer.writeUInt16LE(parameter.length!, 1);
     } else {
       buffer.writeUInt16LE(MAX, 1);
     }

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -1324,7 +1324,7 @@ describe('VarBinary', function() {
   describe('.generateTypeInfo', function() {
     it('returns the correct type information', function() {
       // Length <= Maximum Length
-      const expected = Buffer.from([0xA5, 0x40, 0x1F]);
+      const expected = Buffer.from([0xA5, 0x01, 0x00]);
 
       const result = TYPES.VarBinary.generateTypeInfo({ length: 1 });
       assert.deepEqual(result, expected);
@@ -1392,7 +1392,7 @@ describe('VarChar', function() {
   describe('.generateTypeInfo', function() {
     it('returns the correct type information', function() {
       // Length <= Maximum Length
-      const expected = Buffer.from('a7401f0000000000', 'hex');
+      const expected = Buffer.from('a7010000000000000', 'hex');
 
       const result = TYPES.VarChar.generateTypeInfo({ length: 1 });
       assert.deepEqual(result, expected);


### PR DESCRIPTION
Refactors varchar and varbinary data-type to generate exact length specified by the user when generating `TYPE_INFO`