### PR TITLE
refactor: improve message handling

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -390,14 +390,11 @@ interface State {
     socketError?(this: Connection, err: Error): void;
     connectTimeout?(this: Connection): void;
     socketConnect?(this: Connection): void;
-    data?(this: Connection, data: Buffer): void;
-    message?(this: Connection): void;
+    message?(this: Connection, message: Message): void;
     retry?(this: Connection): void;
-    routingChange?(this: Connection): void;
     reconnect?(this: Connection): void;
     featureExtAck?(this: Connection, token: FeatureExtAckToken): void;
     fedAuthInfo?(this: Connection, token: FedAuthInfoToken): void;
-    endOfMessageMarkerReceived?(this: Connection): void;
     loginFailed?(this: Connection): void;
     attention?(this: Connection): void;
   };
@@ -2029,7 +2026,6 @@ class Connection extends EventEmitter {
 
     tokenStreamParser.on('routingChange', (token) => {
       this.routingData = token.newValue;
-      this.dispatchEvent('routingChange');
     });
 
     tokenStreamParser.on('packetSizeChange', (token) => {
@@ -2107,7 +2103,7 @@ class Connection extends EventEmitter {
           if (this.config.options.rowCollectionOnDone) {
             request.rst!.push(token.columns);
           }
-          if (!(this.state === this.STATE.SENT_ATTENTION && request.paused)) {
+          if (!request.canceled) {
             request.emit('row', token.columns);
           }
         }
@@ -2197,20 +2193,8 @@ class Connection extends EventEmitter {
       }
     });
 
-    tokenStreamParser.on('endOfMessage', () => { // EOM pseudo token received
-      if (this.state === this.STATE.SENT_CLIENT_REQUEST) {
-        this.dispatchEvent('endOfMessageMarkerReceived');
-      }
-    });
-
     tokenStreamParser.on('resetConnection', () => {
       this.emit('resetConnection');
-    });
-
-    tokenStreamParser.on('drain', () => {
-      // Bridge the release of backpressure from the token stream parser
-      // transform to the packet stream transform.
-      this.messageIo.resume();
     });
 
     return tokenStreamParser;
@@ -2239,8 +2223,7 @@ class Connection extends EventEmitter {
       socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY);
 
       this.messageIo = new MessageIO(socket, this.config.options.packetSize, this.debug);
-      this.messageIo.on('data', (data) => { this.dispatchEvent('data', data); });
-      this.messageIo.on('message', () => { this.dispatchEvent('message'); });
+      this.messageIo.on('data', (message) => { this.dispatchEvent('message', message); });
       this.messageIo.on('secure', (cleartext) => { this.emit('secure', cleartext); });
       this.messageIo.on('error', (error) => {
         this.socketError(error);
@@ -3147,24 +3130,20 @@ class Connection extends EventEmitter {
       let message: Message;
 
       request.once('cancel', () => {
-        // There's three ways to handle request cancelation:
-        if (!this.isRequestActive(request)) {
-          // Cancel was called on a request that is no longer active on this connection
-          return;
-        } else if (message.writable) {
+        if (message.writable) {
           // - if the message is still writable, we'll set the ignore bit
           //   and end the message.
           message.ignore = true;
           message.end();
-        } else {
-          // - but if the message has been ended (and thus has been fully sent off),
-          //   we need to send an `ATTENTION` message to the server
-          this.messageIo.sendMessage(TYPE.ATTENTION);
-          this.transitionTo(this.STATE.SENT_ATTENTION);
-        }
 
-        this.clearRequestTimer();
-        this.createCancelTimer();
+          this.clearRequestTimer();
+          this.createCancelTimer();
+
+          if (request instanceof Request && request.paused) {
+            // resume the request if it was paused so we can read the remaining tokens
+            request.resume();
+          }
+        }
       });
 
       this.createRequestTimer();
@@ -3302,37 +3281,40 @@ Connection.prototype.STATE = {
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
       },
-      data: function(data) {
-        this.addToMessageBuffer(data);
-      },
-      message: function() {
-        const preloginPayload = new PreloginPayload(this.messageBuffer);
-        this.debug.payload(function() {
-          return preloginPayload.toString('  ');
+      message: function(message) {
+        message.on('data', (data) => {
+          this.addToMessageBuffer(data);
         });
 
-        if (preloginPayload.fedAuthRequired === 1) {
-          this.fedAuthRequired = true;
-        }
+        message.once('end', () => {
+          const preloginPayload = new PreloginPayload(this.messageBuffer);
+          this.debug.payload(function() {
+            return preloginPayload.toString('  ');
+          });
 
-        if (preloginPayload.encryptionString === 'ON' || preloginPayload.encryptionString === 'REQ') {
-          if (!this.config.options.encrypt) {
-            this.emit('connect', ConnectionError("Server requires encryption, set 'encrypt' config option to true.", 'EENCRYPT'));
-            return this.close();
+          if (preloginPayload.fedAuthRequired === 1) {
+            this.fedAuthRequired = true;
           }
 
-          this.messageIo.startTls(this.secureContext, this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
-          this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
-        } else {
-          this.sendLogin7Packet();
+          if (preloginPayload.encryptionString === 'ON' || preloginPayload.encryptionString === 'REQ') {
+            if (!this.config.options.encrypt) {
+              this.emit('connect', ConnectionError("Server requires encryption, set 'encrypt' config option to true.", 'EENCRYPT'));
+              return this.close();
+            }
 
-          const { authentication } = this.config;
-          if (authentication.type === 'ntlm') {
-            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
+            this.messageIo.startTls(this.secureContext, this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
+            this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
           } else {
-            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+            this.sendLogin7Packet();
+
+            const { authentication } = this.config;
+            if (authentication.type === 'ntlm') {
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
+            } else {
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+            }
           }
-        }
+        });
       }
     }
   },
@@ -3384,23 +3366,26 @@ Connection.prototype.STATE = {
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
       },
-      data: function(data) {
-        this.messageIo.tlsHandshakeData(data);
-      },
-      message: function() {
-        if (this.messageIo.tlsNegotiationComplete) {
-          this.sendLogin7Packet();
+      message: function(message) {
+        message.on('data', (data) => {
+          this.messageIo.tlsHandshakeData(data);
+        });
 
-          const { authentication } = this.config;
+        message.once('end', () => {
+          if (this.messageIo.tlsNegotiationComplete) {
+            this.sendLogin7Packet();
 
-          if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service' || authentication.type === 'azure-active-directory-service-principal-secret') {
-            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_FEDAUTH);
-          } else if (authentication.type === 'ntlm') {
-            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
-          } else {
-            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+            const { authentication } = this.config;
+
+            if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service' || authentication.type === 'azure-active-directory-service-principal-secret') {
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_FEDAUTH);
+            } else if (authentication.type === 'ntlm') {
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
+            } else {
+              this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+            }
           }
-        }
+        });
       }
     }
   },
@@ -3412,12 +3397,6 @@ Connection.prototype.STATE = {
       },
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
-      },
-      data: function(data) {
-        this.sendDataToTokenStreamParser(data);
-      },
-      routingChange: function() {
-        this.transitionTo(this.STATE.REROUTING);
       },
       featureExtAck: function(token) {
         const { authentication } = this.config;
@@ -3437,21 +3416,49 @@ Connection.prototype.STATE = {
           this.loggedIn = false;
         }
       },
-      message: function() {
-        if (this.loggedIn) {
-          this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
-        } else if (this.loginError) {
-          if (this.loginError.isTransient) {
-            this.debug.log('Initiating retry on transient error');
-            this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
+      message: function(message) {
+        message.on('data', (data) => {
+          const ret = this.sendDataToTokenStreamParser(data);
+          if (ret === false) {
+            // Bridge backpressure from the token stream parser transform to the
+            // packet stream transform.
+            this.messageIo.pause();
+
+            this.tokenStreamParser.once('drain', () => {
+              // Bridge the release of backpressure from the token stream parser
+              // transform to the packet stream transform.
+              this.messageIo.resume();
+            });
+          }
+        });
+
+        message.once('end', () => {
+          // We have to channel the 'message' (EOM) event through the token stream
+          // parser transform, to keep it in line with the flow of the tokens, when
+          // the incoming data flow is paused and resumed.
+          this.tokenStreamParser.addEndOfMessageMarker();
+        });
+
+        this.tokenStreamParser.once('endOfMessage', () => {
+          if (this.loggedIn) {
+            if (this.routingData) {
+              this.transitionTo(this.STATE.REROUTING);
+            } else {
+              this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
+            }
+          } else if (this.loginError) {
+            if (this.loginError.isTransient) {
+              this.debug.log('Initiating retry on transient error');
+              this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
+            } else {
+              this.emit('connect', this.loginError);
+              this.transitionTo(this.STATE.FINAL);
+            }
           } else {
-            this.emit('connect', this.loginError);
+            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
             this.transitionTo(this.STATE.FINAL);
           }
-        } else {
-          this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
-          this.transitionTo(this.STATE.FINAL);
-        }
+        });
       }
     }
   },
@@ -3464,40 +3471,65 @@ Connection.prototype.STATE = {
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
       },
-      data: function(data) {
-        this.sendDataToTokenStreamParser(data);
-      },
-      message: function() {
-        if (this.ntlmpacket) {
-          const authentication = this.config.authentication as NtlmAuthentication;
+      message: function(message) {
+        message.on('data', (data) => {
+          const ret = this.sendDataToTokenStreamParser(data);
+          if (ret === false) {
+            // Bridge backpressure from the token stream parser transform to the
+            // packet stream transform.
+            this.messageIo.pause();
 
-          const payload = new NTLMResponsePayload({
-            domain: authentication.options.domain,
-            userName: authentication.options.userName,
-            password: authentication.options.password,
-            ntlmpacket: this.ntlmpacket
-          });
+            this.tokenStreamParser.once('drain', () => {
+              // Bridge the release of backpressure from the token stream parser
+              // transform to the packet stream transform.
+              this.messageIo.resume();
+            });
+          }
+        });
 
-          this.messageIo.sendMessage(TYPE.NTLMAUTH_PKT, payload.data);
-          this.debug.payload(function() {
-            return payload.toString('  ');
-          });
+        message.once('end', () => {
+          // We have to channel the 'message' (EOM) event through the token stream
+          // parser transform, to keep it in line with the flow of the tokens, when
+          // the incoming data flow is paused and resumed.
+          this.tokenStreamParser.addEndOfMessageMarker();
+        });
 
-          this.ntlmpacket = undefined;
-        } else if (this.loggedIn) {
-          this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
-        } else if (this.loginError) {
-          if (this.loginError.isTransient) {
-            this.debug.log('Initiating retry on transient error');
-            this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
+        this.tokenStreamParser.once('endOfMessage', () => {
+          if (this.ntlmpacket) {
+            const authentication = this.config.authentication as NtlmAuthentication;
+
+            const payload = new NTLMResponsePayload({
+              domain: authentication.options.domain,
+              userName: authentication.options.userName,
+              password: authentication.options.password,
+              ntlmpacket: this.ntlmpacket
+            });
+
+            this.messageIo.sendMessage(TYPE.NTLMAUTH_PKT, payload.data);
+            this.debug.payload(function() {
+              return payload.toString('  ');
+            });
+
+            this.ntlmpacket = undefined;
+          } else if (this.loggedIn) {
+            if (this.routingData) {
+              this.transitionTo(this.STATE.REROUTING);
+            } else {
+              this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
+            }
+          } else if (this.loginError) {
+            if (this.loginError.isTransient) {
+              this.debug.log('Initiating retry on transient error');
+              this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
+            } else {
+              this.emit('connect', this.loginError);
+              this.transitionTo(this.STATE.FINAL);
+            }
           } else {
-            this.emit('connect', this.loginError);
+            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
             this.transitionTo(this.STATE.FINAL);
           }
-        } else {
-          this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
-          this.transitionTo(this.STATE.FINAL);
-        }
+        });
       }
     }
   },
@@ -3510,93 +3542,121 @@ Connection.prototype.STATE = {
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
       },
-      data: function(data) {
-        this.sendDataToTokenStreamParser(data);
-      },
-      routingChange: function() {
-        this.transitionTo(this.STATE.REROUTING);
-      },
       fedAuthInfo: function(token) {
         this.fedAuthInfoToken = token;
       },
-      message: function() {
-        const fedAuthInfoToken = this.fedAuthInfoToken;
+      message: function(message) {
+        message.on('data', (data) => {
+          const ret = this.sendDataToTokenStreamParser(data);
+          if (ret === false) {
+            // Bridge backpressure from the token stream parser transform to the
+            // packet stream transform.
+            this.messageIo.pause();
 
-        if (fedAuthInfoToken && fedAuthInfoToken.stsurl && fedAuthInfoToken.spn) {
-          const authentication = this.config.authentication as AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryServicePrincipalSecret;
+            this.tokenStreamParser.once('drain', () => {
+              // Bridge the release of backpressure from the token stream parser
+              // transform to the packet stream transform.
+              this.messageIo.resume();
+            });
+          }
+        });
 
-          const getToken = (callback: (error: Error | null, token?: string) => void) => {
-            const getTokenFromCredentials = (err: Error | undefined, credentials?: UserTokenCredentials | MSIAppServiceTokenCredentials | MSIVmTokenCredentials | ApplicationTokenCredentials) => {
-              if (err) {
-                return callback(err);
+        message.once('end', () => {
+          // We have to channel the 'message' (EOM) event through the token stream
+          // parser transform, to keep it in line with the flow of the tokens, when
+          // the incoming data flow is paused and resumed.
+          this.tokenStreamParser.addEndOfMessageMarker();
+        });
+
+        this.tokenStreamParser.once('endOfMessage', () => {
+          if (this.loggedIn) {
+            if (this.routingData) {
+              this.transitionTo(this.STATE.REROUTING);
+            } else {
+              this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
+            }
+
+            return;
+          }
+
+          const fedAuthInfoToken = this.fedAuthInfoToken;
+
+          if (fedAuthInfoToken && fedAuthInfoToken.stsurl && fedAuthInfoToken.spn) {
+            const authentication = this.config.authentication as AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryServicePrincipalSecret;
+
+            const getToken = (callback: (error: Error | null, token?: string) => void) => {
+              const getTokenFromCredentials = (err: Error | undefined, credentials?: UserTokenCredentials | MSIAppServiceTokenCredentials | MSIVmTokenCredentials | ApplicationTokenCredentials) => {
+                if (err) {
+                  return callback(err);
+                }
+
+                credentials!.getToken().then((tokenResponse: { accessToken: string | undefined }) => {
+                  callback(null, tokenResponse.accessToken);
+                }, callback);
+              };
+
+              if (authentication.type === 'azure-active-directory-password') {
+                const credentials = new UserTokenCredentials(
+                  '7f98cb04-cd1e-40df-9140-3bf7e2cea4db',
+                  authentication.options.domain ?? 'common',
+                  authentication.options.userName,
+                  authentication.options.password,
+                  fedAuthInfoToken.spn,
+                  undefined, // environment
+                  authenticationCache
+                );
+
+                getTokenFromCredentials(undefined, credentials);
+              } else if (authentication.type === 'azure-active-directory-msi-vm') {
+                loginWithVmMSI({
+                  clientId: authentication.options.clientId,
+                  msiEndpoint: authentication.options.msiEndpoint,
+                  resource: fedAuthInfoToken.spn
+                }, getTokenFromCredentials);
+              } else if (authentication.type === 'azure-active-directory-msi-app-service') {
+                loginWithAppServiceMSI({
+                  msiEndpoint: authentication.options.msiEndpoint,
+                  msiSecret: authentication.options.msiSecret,
+                  resource: fedAuthInfoToken.spn,
+                  clientId: authentication.options.clientId
+                }, getTokenFromCredentials);
+              } else if (authentication.type === 'azure-active-directory-service-principal-secret') {
+                const credentials = new ApplicationTokenCredentials(
+                  authentication.options.clientId,
+                  authentication.options.tenantId, // domain
+                  authentication.options.clientSecret,
+                  fedAuthInfoToken.spn,
+                  undefined, // environment
+                  authenticationCache
+                );
+
+                getTokenFromCredentials(undefined, credentials);
               }
-
-              credentials!.getToken().then((tokenResponse: { accessToken: string | undefined }) => {
-                callback(null, tokenResponse.accessToken);
-              }, callback);
             };
 
-            if (authentication.type === 'azure-active-directory-password') {
-              const credentials = new UserTokenCredentials(
-                '7f98cb04-cd1e-40df-9140-3bf7e2cea4db',
-                authentication.options.domain ?? 'common',
-                authentication.options.userName,
-                authentication.options.password,
-                fedAuthInfoToken.spn,
-                undefined, // environment
-                authenticationCache
-              );
+            getToken((err, token) => {
+              if (err) {
+                this.loginError = ConnectionError('Security token could not be authenticated or authorized.', 'EFEDAUTH');
+                this.emit('connect', this.loginError);
+                this.transitionTo(this.STATE.FINAL);
+                return;
+              }
 
-              getTokenFromCredentials(undefined, credentials);
-            } else if (authentication.type === 'azure-active-directory-msi-vm') {
-              loginWithVmMSI({
-                clientId: authentication.options.clientId,
-                msiEndpoint: authentication.options.msiEndpoint,
-                resource: fedAuthInfoToken.spn
-              }, getTokenFromCredentials);
-            } else if (authentication.type === 'azure-active-directory-msi-app-service') {
-              loginWithAppServiceMSI({
-                msiEndpoint: authentication.options.msiEndpoint,
-                msiSecret: authentication.options.msiSecret,
-                resource: fedAuthInfoToken.spn,
-                clientId: authentication.options.clientId
-              }, getTokenFromCredentials);
-            } else if (authentication.type === 'azure-active-directory-service-principal-secret') {
-              const credentials = new ApplicationTokenCredentials(
-                authentication.options.clientId,
-                authentication.options.tenantId, // domain
-                authentication.options.clientSecret,
-                fedAuthInfoToken.spn,
-                undefined, // environment
-                authenticationCache
-              );
-
-              getTokenFromCredentials(undefined, credentials);
-            }
-          };
-
-          getToken((err, token) => {
-            if (err) {
-              this.loginError = ConnectionError('Security token could not be authenticated or authorized.', 'EFEDAUTH');
+              this.sendFedAuthTokenMessage(token!);
+            });
+          } else if (this.loginError) {
+            if (this.loginError.isTransient) {
+              this.debug.log('Initiating retry on transient error');
+              this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
+            } else {
               this.emit('connect', this.loginError);
               this.transitionTo(this.STATE.FINAL);
-              return;
             }
-
-            this.sendFedAuthTokenMessage(token!);
-          });
-        } else if (this.loginError) {
-          if (this.loginError.isTransient) {
-            this.debug.log('Initiating retry on transient error');
-            this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
           } else {
-            this.emit('connect', this.loginError);
+            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
             this.transitionTo(this.STATE.FINAL);
           }
-        } else {
-          this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
-          this.transitionTo(this.STATE.FINAL);
-        }
+        });
       }
     }
   },
@@ -3612,12 +3672,33 @@ Connection.prototype.STATE = {
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
       },
-      data: function(data) {
-        this.sendDataToTokenStreamParser(data);
-      },
-      message: function() {
-        this.transitionTo(this.STATE.LOGGED_IN);
-        this.processedInitialSql();
+      message: function(message) {
+        message.on('data', (data) => {
+          const ret = this.sendDataToTokenStreamParser(data);
+          if (ret === false) {
+            // Bridge backpressure from the token stream parser transform to the
+            // packet stream transform.
+            this.messageIo.pause();
+
+            this.tokenStreamParser.once('drain', () => {
+              // Bridge the release of backpressure from the token stream parser
+              // transform to the packet stream transform.
+              this.messageIo.resume();
+            });
+          }
+        });
+
+        message.once('end', () => {
+          // We have to channel the 'message' (EOM) event through the token stream
+          // parser transform, to keep it in line with the flow of the tokens, when
+          // the incoming data flow is paused and resumed.
+          this.tokenStreamParser.addEndOfMessageMarker();
+        });
+
+        this.tokenStreamParser.once('endOfMessage', () => {
+          this.transitionTo(this.STATE.LOGGED_IN);
+          this.processedInitialSql();
+        });
       }
     }
   },
@@ -3633,9 +3714,6 @@ Connection.prototype.STATE = {
     name: 'SentClientRequest',
     exit: function(nextState) {
       this.clearRequestTimer();
-      if (nextState !== this.STATE.FINAL) {
-        this.tokenStreamParser.resume();
-      }
     },
     events: {
       socketError: function(err) {
@@ -3645,29 +3723,78 @@ Connection.prototype.STATE = {
 
         sqlRequest.callback(err);
       },
-      data: function(data) {
-        this.clearRequestTimer(); // request timer is stopped on first data package
-        const ret = this.sendDataToTokenStreamParser(data);
-        if (ret === false) {
-          // Bridge backpressure from the token stream parser transform to the
-          // packet stream transform.
-          this.messageIo.pause();
+      message: function(message) {
+        // request timer is stopped on first data package
+        this.clearRequestTimer();
+
+        message.on('data', (data) => {
+          const ret = this.sendDataToTokenStreamParser(data);
+          if (ret === false) {
+            // Bridge backpressure from the token stream parser transform to the
+            // packet stream transform.
+            this.messageIo.pause();
+
+            this.tokenStreamParser.once('drain', () => {
+              // Bridge the release of backpressure from the token stream parser
+              // transform to the packet stream transform.
+              this.messageIo.resume();
+            });
+          }
+        });
+
+        message.once('end', () => {
+          // We have to channel the 'message' (EOM) event through the token stream
+          // parser transform, to keep it in line with the flow of the tokens, when
+          // the incoming data flow is paused and resumed.
+          this.tokenStreamParser.addEndOfMessageMarker();
+        });
+
+        // If the request was canceled after the request was sent, but before
+        // we started receiving a message, we send an attention message, fully
+        // consume the current message, and then switch the next state.
+        if (this.request?.canceled) {
+          this.tokenStreamParser.once('endOfMessage', () => {
+            this.transitionTo(this.STATE.SENT_ATTENTION);
+          });
+
+          this.messageIo.sendMessage(TYPE.ATTENTION);
+          this.createCancelTimer();
+
+          if (this.request instanceof Request && this.request.paused) {
+            // resume the request if it was paused so we can read the remaining tokens
+            this.request?.resume();
+          }
+        } else {
+          const onCancel = () => {
+            this.tokenStreamParser.removeListener('endOfMessage', onEndOfMessage);
+            this.tokenStreamParser.once('endOfMessage', () => {
+              this.transitionTo(this.STATE.SENT_ATTENTION);
+            });
+
+            this.messageIo.sendMessage(TYPE.ATTENTION);
+            this.createCancelTimer();
+
+            if (this.request instanceof Request && this.request.paused) {
+              // resume the request if it was paused so we can read the remaining tokens
+              this.request?.resume();
+            }
+          };
+
+          const onEndOfMessage = () => {
+            this.request?.removeListener('cancel', onCancel);
+
+            this.transitionTo(this.STATE.LOGGED_IN);
+            const sqlRequest = this.request as Request;
+            this.request = undefined;
+            if (this.config.options.tdsVersion < '7_2' && sqlRequest.error && this.isSqlBatch) {
+              this.inTransaction = false;
+            }
+            sqlRequest.callback(sqlRequest.error, sqlRequest.rowCount, sqlRequest.rows);
+          };
+
+          this.tokenStreamParser.once('endOfMessage', onEndOfMessage);
+          this.request?.once('cancel', onCancel);
         }
-      },
-      message: function() {
-        // We have to channel the 'message' (EOM) event through the token stream
-        // parser transform, to keep it in line with the flow of the tokens, when
-        // the incoming data flow is paused and resumed.
-        this.tokenStreamParser.addEndOfMessageMarker();
-      },
-      endOfMessageMarkerReceived: function() {
-        this.transitionTo(this.STATE.LOGGED_IN);
-        const sqlRequest = this.request as Request;
-        this.request = undefined;
-        if (this.config.options.tdsVersion < '7_2' && sqlRequest.error && this.isSqlBatch) {
-          this.inTransaction = false;
-        }
-        sqlRequest.callback(sqlRequest.error, sqlRequest.rowCount, sqlRequest.rows);
       }
     }
   },
@@ -3685,28 +3812,49 @@ Connection.prototype.STATE = {
 
         sqlRequest.callback(err);
       },
-      data: function(data) {
-        this.sendDataToTokenStreamParser(data);
-      },
       attention: function() {
         this.attentionReceived = true;
       },
-      message: function() {
-        // 3.2.5.7 Sent Attention State
-        // Discard any data contained in the response, until we receive the attention response
-        if (this.attentionReceived) {
-          this.clearCancelTimer();
+      message: function(message) {
+        message.on('data', (data) => {
+          const ret = this.sendDataToTokenStreamParser(data);
+          if (ret === false) {
+            // Bridge backpressure from the token stream parser transform to the
+            // packet stream transform.
+            this.messageIo.pause();
 
-          const sqlRequest = this.request!;
-          this.request = undefined;
-          this.transitionTo(this.STATE.LOGGED_IN);
-
-          if (sqlRequest.error && sqlRequest.error instanceof RequestError && sqlRequest.error.code === 'ETIMEOUT') {
-            sqlRequest.callback(sqlRequest.error);
-          } else {
-            sqlRequest.callback(RequestError('Canceled.', 'ECANCEL'));
+            this.tokenStreamParser.once('drain', () => {
+              // Bridge the release of backpressure from the token stream parser
+              // transform to the packet stream transform.
+              this.messageIo.resume();
+            });
           }
-        }
+        });
+
+        message.once('end', () => {
+          // We have to channel the 'message' (EOM) event through the token stream
+          // parser transform, to keep it in line with the flow of the tokens, when
+          // the incoming data flow is paused and resumed.
+          this.tokenStreamParser.addEndOfMessageMarker();
+        });
+
+        this.tokenStreamParser.once('endOfMessage', () => {
+          // 3.2.5.7 Sent Attention State
+          // Discard any data contained in the response, until we receive the attention response
+          if (this.attentionReceived) {
+            this.clearCancelTimer();
+
+            const sqlRequest = this.request!;
+            this.request = undefined;
+            this.transitionTo(this.STATE.LOGGED_IN);
+
+            if (sqlRequest.error && sqlRequest.error instanceof RequestError && sqlRequest.error.code === 'ETIMEOUT') {
+              sqlRequest.callback(sqlRequest.error);
+            } else {
+              sqlRequest.callback(RequestError('Canceled.', 'ECANCEL'));
+            }
+          }
+        });
       }
     }
   },

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -38,8 +38,7 @@ class MessageIO extends EventEmitter {
 
     this.incomingMessageStream = new IncomingMessageStream(this.debug);
     this.incomingMessageStream.on('data', (message: Message) => {
-      message.on('data', (chunk: Buffer) => { this.emit('data', chunk); });
-      message.on('end', () => { this.emit('message'); });
+      this.emit('data', message);
     });
 
     this.incomingMessageStream.on('error', (message) => {


### PR DESCRIPTION
The TDS protocol is message based - the client sends a request message to the server, and the server sends a response message back. Messages are broken up into smaller packets, that are sent over the connection, but there is no interleaving of packets from different messages.

But the way that message handling in tedious is implemented is not making this obvious. Different states have separate `data` (for message contents) and `message` (for the end of a message) handlers. This generally works fine. If a message is received, data is processed via `data` events and then once the message is fully handled, the `message` event should handle cleanup tasks, like switching to a different state.

Unfortunately, that model easily gets messed up if we switch the connection before a message has been fully consumed, and that has been leading to all sorts of confusion.

To simplify this, I'm merging the message and data event handlers into a single `message` event that is responsible for consuming the message fully. I've also changed all the uses of the token stream parser to correctly account for backpressure and to wait until all data has been processed fully before performing any state switching.

---

This is similar to https://github.com/tediousjs/tedious/pull/1215, but does not make use of `async`/`await` - instead it uses regular events to reach the same goal.

---

I believe this fixes the event emitter leak mentioned in https://github.com/tediousjs/tedious/issues/1201, because we now properly remove `cancel` event listeners before we move to a different state.