### PR TITLE
Cleanups around message handling

### DIFF
--- a/benchmarks/token-parser/colmetadata-token.js
+++ b/benchmarks/token-parser/colmetadata-token.js
@@ -15,7 +15,7 @@ function main({ n, tokenCount }) {
   bench.start();
 
   for (let i = 0; i < n; i++) {
-    parser.addBuffer(data);
+    parser.write(data);
   }
 
   bench.end(n);

--- a/benchmarks/token-parser/done-token.js
+++ b/benchmarks/token-parser/done-token.js
@@ -15,7 +15,7 @@ function main({ n, tokenCount }) {
   bench.start();
 
   for (let i = 0; i < n; i++) {
-    parser.addBuffer(data);
+    parser.write(data);
   }
 
   bench.end(n);

--- a/benchmarks/token-parser/simple-tokens.js
+++ b/benchmarks/token-parser/simple-tokens.js
@@ -346,7 +346,7 @@ function main({ n }) {
   bench.start();
 
   for (let i = 0; i < n; i++) {
-    parser.addBuffer(data);
+    parser.write(data);
   }
 
   bench.end(n);

--- a/src/request.ts
+++ b/src/request.ts
@@ -273,6 +273,10 @@ class Request extends EventEmitter {
 
   on(event: 'cancel', listener: () => void): this
 
+  on(event: 'pause', listener: () => void): this
+
+  on(event: 'resume', listener: () => void): this
+
   on(event: string | symbol, listener: (...args: any[]) => void) {
     return super.on(event, listener);
   }
@@ -317,6 +321,14 @@ class Request extends EventEmitter {
    * @private
    */
   emit(event: 'cancel'): boolean
+  /**
+   * @private
+   */
+  emit(event: 'pause'): boolean
+  /**
+   * @private
+   */
+  emit(event: 'resume'): boolean
   /**
    * @private
    */
@@ -534,10 +546,8 @@ class Request extends EventEmitter {
     if (this.paused) {
       return;
     }
+    this.emit('pause');
     this.paused = true;
-    if (this.connection) {
-      this.connection.pauseRequest(this);
-    }
   }
 
   /**
@@ -549,9 +559,7 @@ class Request extends EventEmitter {
       return;
     }
     this.paused = false;
-    if (this.connection) {
-      this.connection.resumeRequest(this);
-    }
+    this.emit('resume');
   }
 
   /**

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -3,7 +3,7 @@ import { InternalConnectionOptions } from '../connection';
 import JSBI from 'jsbi';
 
 import { Transform } from 'readable-stream';
-import { TYPE, Token, EndOfMessageToken, ColMetadataToken } from './token';
+import { TYPE, Token, ColMetadataToken } from './token';
 
 import colMetadataParser, { ColumnMetadata } from './colmetadata-token-parser';
 import { doneParser, doneInProcParser, doneProcParser } from './done-token-parser';
@@ -38,13 +38,10 @@ const tokenParsers = {
   [TYPE.SSPI]: sspiParser
 };
 
-class EndOfMessageMarker {}
-
 class Parser extends Transform {
   debug: Debug;
   colMetadata: ColumnMetadata[];
   options: InternalConnectionOptions;
-  endOfMessageMarker: EndOfMessageMarker;
 
   buffer: Buffer;
   position: number;
@@ -57,7 +54,6 @@ class Parser extends Transform {
     this.debug = debug;
     this.colMetadata = [];
     this.options = options;
-    this.endOfMessageMarker = new EndOfMessageMarker();
 
     this.buffer = Buffer.alloc(0);
     this.position = 0;
@@ -65,11 +61,7 @@ class Parser extends Transform {
     this.next = undefined;
   }
 
-  _transform(input: Buffer | EndOfMessageMarker, _encoding: string, done: (error?: Error | undefined, token?: Token) => void) {
-    if (input instanceof EndOfMessageMarker) {
-      return done(undefined, new EndOfMessageToken());
-    }
-
+  _transform(input: Buffer, _encoding: string, done: (error?: Error | undefined, token?: Token) => void) {
     if (this.position === this.buffer.length) {
       this.buffer = input;
     } else {

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -26,8 +26,7 @@ import {
   ReturnValueToken,
   DoneInProcToken,
   DoneProcToken,
-  DoneToken,
-  EndOfMessageToken
+  DoneToken
 } from './token';
 
 /*
@@ -57,8 +56,13 @@ export class Parser extends EventEmitter {
         this.emit(token.event, token);
       }
     });
+
     this.parser.on('drain', () => {
       this.emit('drain');
+    });
+
+    this.parser.on('end', () => {
+      this.emit('end');
     });
   }
 
@@ -85,25 +89,16 @@ export class Parser extends EventEmitter {
     ((event: 'done', listener: (token: DoneToken) => void) => this) &
     ((event: 'doneInProc', listener: (token: DoneInProcToken) => void) => this) &
     ((event: 'doneProc', listener: (token: DoneProcToken) => void) => this) &
-    ((event: 'endOfMessage', listener: (token: EndOfMessageToken) => void) => this) &
     ((event: string | symbol, listener: (...args: any[]) => void) => this)
   );
 
   // Returns false to apply backpressure.
-  addBuffer(buffer: Buffer) {
+  write(buffer: Buffer) {
     return this.parser.write(buffer);
   }
 
-  // Writes an end-of-message (EOM) marker into the parser transform input
-  // queue. StreamParser will emit a 'data' event with an 'endOfMessage'
-  // pseudo token when the EOM marker has passed through the transform stream.
-  // Returns false to apply backpressure.
-  addEndOfMessageMarker() {
-    return this.parser.write(this.parser.endOfMessageMarker);
-  }
-
-  isEnd() {
-    return this.parser.buffer.length === this.parser.position;
+  end() {
+    this.parser.end();
   }
 
   // Temporarily suspends the token stream parser transform from emitting events.

--- a/src/token/token.ts
+++ b/src/token/token.ts
@@ -492,12 +492,3 @@ export class SSPIToken extends Token {
     this.ntlmpacketBuffer = ntlmpacketBuffer;
   }
 }
-
-export class EndOfMessageToken extends Token {
-  declare name: 'EOM';
-  declare event: 'endOfMessage';
-
-  constructor() {
-    super('EOM', 'endOfMessage');
-  }
-}

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -116,7 +116,6 @@ describe('Pause-Resume Test', function() {
 
         setTimeout(() => {
           assert.ok(connection.messageIo.incomingMessageStream.isPaused());
-          assert.ok(connection.tokenStreamParser.parser.isPaused());
 
           request.resume();
         }, 3000);

--- a/test/unit/token/token-stream-parser-test.js
+++ b/test/unit/token/token-stream-parser-test.js
@@ -34,11 +34,10 @@ describe('Token Stream Parser', () => {
       assert.isOk(event);
     });
 
-    parser.addBuffer(buffer);
+    parser.write(buffer);
+    parser.end();
 
-    assert.isOk(parser.isEnd());
-
-    done();
+    parser.on('end', done);
   });
 
   it('should split token across buffers', (done) => {
@@ -49,11 +48,10 @@ describe('Token Stream Parser', () => {
       assert.isOk(event);
     });
 
-    parser.addBuffer(buffer.slice(0, 6));
-    parser.addBuffer(buffer.slice(6));
+    parser.write(buffer.slice(0, 6));
+    parser.write(buffer.slice(6));
+    parser.end();
 
-    assert.isOk(parser.isEnd());
-
-    done();
+    parser.on('end', done);
   });
 });


### PR DESCRIPTION
This further cleans up some logic around message handling.

The biggest change here is that each message is handled by a new token parser object. This allows us to get rid of the "fake" `EndOfMessageToken`, and we can simply wait for the `end` event coming from the token parser. This opens up the possibility to use directly `.pipe` a message into the token parser directly, or convert the token parser to an async generator function that consumes a message. This will be explored in a follow up PR.

There's some additional changes around pause/resume and cancellation behavior, but those should not make much of a difference.

---

These changes have a small negative impact on performance, because each incoming message generates a new token parser object, and registers a bunch of event handlers. The performance hit is rather small, from what I've benchmarked:

#### Before

```
root ➜ /workspace (master ✗) $ node benchmarks/query/select-many-rows.js 
query/select-many-rows.js size=10 n=10: 588.2487546332677 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=10: 261.9831279197856 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=10: 99.80497807868491 (minor: 3 - 2.60689ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=10: 19.306442130170502 (minor: 27 - 15.837257999999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=100: 772.554154578383 (minor: 2 - 2.800477ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=100: 538.9699181054613 (minor: 4 - 3.93395ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=100: 184.51681130638127 (minor: 29 - 14.130182999999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=100: 23.826393117095794 (minor: 267 - 110.2691079999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=1000: 1,167.9108255236938 (minor: 11 - 13.298981999999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=1000: 793.9495864957719 (minor: 39 - 33.63353200000001ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=1000: 202.59161794052602 (minor: 289 - 140.69072700000007ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=1000: 24.29268440602386 (minor: 2666 - 1016.4431079999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
```

#### After

```
root ➜ /workspace (arthur/cleanups ✗) $ node benchmarks/query/select-many-rows.js 
query/select-many-rows.js size=10 n=10: 593.4516292116595 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=10: 283.3080613099043 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=10: 93.0445669146658 (minor: 3 - 3.511271ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=10: 20.052101777089447 (minor: 27 - 12.085761ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=100: 791.370497247285 (minor: 2 - 2.444847ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=100: 522.5869254760995 (minor: 4 - 3.794459ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=100: 178.18937654751682 (minor: 29 - 17.400887ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=100: 23.107443947021952 (minor: 267 - 135.67801599999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=1000: 1,138.7238822945124 (minor: 12 - 16.9776ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=1000: 766.2731053515291 (minor: 40 - 44.07308800000001ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=1000: 204.67734657150825 (minor: 290 - 159.481954ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=1000: 23.797390898453546 (minor: 2667 - 1067.162521999999ms, major: 0 - 0ms, incremental: 0 - 0ms)
```