### PR TITLE
Convert token parser to an async generator function

### DIFF
--- a/benchmarks/token-parser/colmetadata-token.js
+++ b/benchmarks/token-parser/colmetadata-token.js
@@ -7,16 +7,19 @@ const bench = createBenchmark(main, {
   tokenCount: [10, 100, 1000, 10000]
 });
 
-function main({ n, tokenCount }) {
-  const parser = new Parser({ token: function() { } }, {}, {});
+async function * repeat(data, n) {
+  for (let i = 0; i < n; i++) {
+    yield data;
+  }
+}
 
+function main({ n, tokenCount }) {
   const data = Buffer.from('810300000000001000380269006400000000000900e7c8000904d00034046e0061006d006500000000000900e7ffff0904d000340b6400650073006300720069007000740069006f006e00'.repeat(tokenCount), 'hex');
+  const parser = new Parser(repeat(data, n), { token: function() { } }, {}, {});
 
   bench.start();
 
-  for (let i = 0; i < n; i++) {
-    parser.write(data);
-  }
-
-  bench.end(n);
+  parser.on('end', () => {
+    bench.end(n);
+  });
 }

--- a/benchmarks/token-parser/done-token.js
+++ b/benchmarks/token-parser/done-token.js
@@ -7,16 +7,19 @@ const bench = createBenchmark(main, {
   tokenCount: [10, 100, 1000, 10000]
 });
 
-function main({ n, tokenCount }) {
-  const parser = new Parser({ token: function() { } }, {}, {});
+async function * repeat(data, n) {
+  for (let i = 0; i < n; i++) {
+    yield data;
+  }
+}
 
+function main({ n, tokenCount }) {
   const data = Buffer.from('FE0000E0000000000000000000'.repeat(tokenCount), 'hex');
+  const parser = new Parser(repeat(data, n), { token: function() { } }, {}, {});
 
   bench.start();
 
-  for (let i = 0; i < n; i++) {
-    parser.write(data);
-  }
-
-  bench.end(n);
+  parser.on('end', () => {
+    bench.end(n);
+  });
 }

--- a/benchmarks/token-parser/simple-tokens.js
+++ b/benchmarks/token-parser/simple-tokens.js
@@ -6,9 +6,13 @@ const bench = createBenchmark(main, {
   n: [10, 100, 1000]
 });
 
-function main({ n }) {
-  const parser = new Parser({ token: function() { } }, {}, {});
+async function * repeat(data, n) {
+  for (let i = 0; i < n; i++) {
+    yield data;
+  }
+}
 
+function main({ n }) {
   const data = Buffer.from([
     '810300000000001000380269006400000000000900E7C8000904D00034046E00',
     '61006D006500000000000900E7FFFF0904D000340B6400650073006300720069',
@@ -343,11 +347,11 @@ function main({ n }) {
     '1100C10064000000000000007900000000FE0000E0000000000000000000'
   ].join(''), 'hex');
 
+  const parser = new Parser(repeat(data, n), { token: function() { } }, {}, {});
+
   bench.start();
 
-  for (let i = 0; i < n; i++) {
-    parser.write(data);
-  }
-
-  bench.end(n);
+  parser.on('end', () => {
+    bench.end(n);
+  });
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1935,8 +1935,8 @@ class Connection extends EventEmitter {
   /**
    * @private
    */
-  createTokenStreamParser() {
-    const tokenStreamParser = new TokenStreamParser(this.debug, this.config.options);
+  createTokenStreamParser(message: Message) {
+    const tokenStreamParser = new TokenStreamParser(message, this.debug, this.config.options);
 
     tokenStreamParser.on('infoMessage', (token) => {
       this.emit('infoMessage', token);
@@ -3376,26 +3376,7 @@ Connection.prototype.STATE = {
         }
       },
       message: function(message) {
-        const tokenStreamParser = this.createTokenStreamParser();
-
-        message.on('data', (data) => {
-          const ret = tokenStreamParser.write(data);
-          if (ret === false) {
-            // Bridge backpressure from the token stream parser transform to the
-            // packet stream transform.
-            this.messageIo.pause();
-
-            tokenStreamParser.once('drain', () => {
-              // Bridge the release of backpressure from the token stream parser
-              // transform to the packet stream transform.
-              this.messageIo.resume();
-            });
-          }
-        });
-
-        message.once('end', () => {
-          tokenStreamParser.end();
-        });
+        const tokenStreamParser = this.createTokenStreamParser(message);
 
         tokenStreamParser.once('end', () => {
           if (this.loggedIn) {
@@ -3430,26 +3411,7 @@ Connection.prototype.STATE = {
         this.transitionTo(this.STATE.FINAL);
       },
       message: function(message) {
-        const tokenStreamParser = this.createTokenStreamParser();
-
-        message.on('data', (data) => {
-          const ret = tokenStreamParser.write(data);
-          if (ret === false) {
-            // Bridge backpressure from the token stream parser transform to the
-            // packet stream transform.
-            this.messageIo.pause();
-
-            tokenStreamParser.once('drain', () => {
-              // Bridge the release of backpressure from the token stream parser
-              // transform to the packet stream transform.
-              this.messageIo.resume();
-            });
-          }
-        });
-
-        message.once('end', () => {
-          tokenStreamParser.end();
-        });
+        const tokenStreamParser = this.createTokenStreamParser(message);
 
         tokenStreamParser.once('end', () => {
           if (this.ntlmpacket) {
@@ -3503,26 +3465,7 @@ Connection.prototype.STATE = {
         this.fedAuthInfoToken = token;
       },
       message: function(message) {
-        const tokenStreamParser = this.createTokenStreamParser();
-
-        message.on('data', (data) => {
-          const ret = tokenStreamParser.write(data);
-          if (ret === false) {
-            // Bridge backpressure from the token stream parser transform to the
-            // packet stream transform.
-            this.messageIo.pause();
-
-            tokenStreamParser.once('drain', () => {
-              // Bridge the release of backpressure from the token stream parser
-              // transform to the packet stream transform.
-              this.messageIo.resume();
-            });
-          }
-        });
-
-        message.once('end', () => {
-          tokenStreamParser.end();
-        });
+        const tokenStreamParser = this.createTokenStreamParser(message);
 
         tokenStreamParser.once('end', () => {
           if (this.loggedIn) {
@@ -3629,26 +3572,7 @@ Connection.prototype.STATE = {
         this.transitionTo(this.STATE.FINAL);
       },
       message: function(message) {
-        const tokenStreamParser = this.createTokenStreamParser();
-
-        message.on('data', (data) => {
-          const ret = tokenStreamParser.write(data);
-          if (ret === false) {
-            // Bridge backpressure from the token stream parser transform to the
-            // packet stream transform.
-            this.messageIo.pause();
-
-            tokenStreamParser.once('drain', () => {
-              // Bridge the release of backpressure from the token stream parser
-              // transform to the packet stream transform.
-              this.messageIo.resume();
-            });
-          }
-        });
-
-        message.once('end', () => {
-          tokenStreamParser.end();
-        });
+        const tokenStreamParser = this.createTokenStreamParser(message);
 
         tokenStreamParser.once('end', () => {
           this.transitionTo(this.STATE.LOGGED_IN);
@@ -3682,26 +3606,7 @@ Connection.prototype.STATE = {
         // request timer is stopped on first data package
         this.clearRequestTimer();
 
-        const tokenStreamParser = this.createTokenStreamParser();
-
-        message.on('data', (data) => {
-          const ret = tokenStreamParser.write(data);
-          if (ret === false) {
-            // Bridge backpressure from the token stream parser transform to the
-            // packet stream transform.
-            this.messageIo.pause();
-
-            tokenStreamParser.once('drain', () => {
-              // Bridge the release of backpressure from the token stream parser
-              // transform to the packet stream transform.
-              this.messageIo.resume();
-            });
-          }
-        });
-
-        message.once('end', () => {
-          tokenStreamParser.end();
-        });
+        const tokenStreamParser = this.createTokenStreamParser(message);
 
         // If the request was canceled after the request was sent, but before
         // we started receiving a message, we send an attention message, fully
@@ -3737,14 +3642,6 @@ Connection.prototype.STATE = {
           const onCancel = () => {
             tokenStreamParser.removeListener('end', onEndOfMessage);
 
-            this.messageIo.sendMessage(TYPE.ATTENTION);
-            // Don't wait for the `tokenStreamParser` to end before switching
-            // to the `SENT_ATTENTION` state. The `end` event is delayed and
-            // we would switch to the new state after the attention acknowledgement
-            // message was received.
-            this.transitionTo(this.STATE.SENT_ATTENTION);
-            this.createCancelTimer();
-
             if (this.request instanceof Request && this.request.paused) {
               // resume the request if it was paused so we can read the remaining tokens
               this.request?.resume();
@@ -3752,6 +3649,10 @@ Connection.prototype.STATE = {
 
             this.request?.removeListener('pause', onPause);
             this.request?.removeListener('resume', onResume);
+
+            this.messageIo.sendMessage(TYPE.ATTENTION);
+            this.transitionTo(this.STATE.SENT_ATTENTION);
+            this.createCancelTimer();
           };
 
           const onEndOfMessage = () => {
@@ -3792,26 +3693,7 @@ Connection.prototype.STATE = {
         this.attentionReceived = true;
       },
       message: function(message) {
-        const tokenStreamParser = this.createTokenStreamParser();
-
-        message.on('data', (data) => {
-          const ret = tokenStreamParser.write(data);
-          if (ret === false) {
-            // Bridge backpressure from the token stream parser transform to the
-            // packet stream transform.
-            this.messageIo.pause();
-
-            tokenStreamParser.once('drain', () => {
-              // Bridge the release of backpressure from the token stream parser
-              // transform to the packet stream transform.
-              this.messageIo.resume();
-            });
-          }
-        });
-
-        message.once('end', () => {
-          tokenStreamParser.end();
-        });
+        const tokenStreamParser = this.createTokenStreamParser(message);
 
         tokenStreamParser.once('end', () => {
           // 3.2.5.7 Sent Attention State

--- a/src/metadata-parser.ts
+++ b/src/metadata-parser.ts
@@ -127,7 +127,7 @@ function metadataParse(parser: Parser, options: InternalConnectionOptions, callb
         const type: DataType = TYPE[typeNumber];
 
         if (!type) {
-          return parser.emit('error', new Error(sprintf('Unrecognised data type 0x%02X', typeNumber)));
+          throw new Error(sprintf('Unrecognised data type 0x%02X', typeNumber));
         }
 
         switch (type.name) {
@@ -328,7 +328,7 @@ function metadataParse(parser: Parser, options: InternalConnectionOptions, callb
             });
 
           default:
-            return parser.emit('error', new Error(sprintf('Unrecognised type %s', type.name)));
+            throw new Error(sprintf('Unrecognised type %s', type.name));
         }
       });
     });

--- a/src/token/env-change-token-parser.ts
+++ b/src/token/env-change-token-parser.ts
@@ -143,7 +143,7 @@ function readNewAndOldValue(parser: Parser, length: number, type: { name: string
           const protocol = routePacket.readUInt8(0);
 
           if (protocol !== 0) {
-            return parser.emit('error', new Error('Unknown protocol byte in routing change event'));
+            throw new Error('Unknown protocol byte in routing change event');
           }
 
           const port = routePacket.readUInt16LE(1);

--- a/src/value-parser.ts
+++ b/src/value-parser.ts
@@ -96,7 +96,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
             return readBigInt(parser, callback);
 
           default:
-            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for IntN'));
+            throw new Error('Unsupported dataLength ' + dataLength + ' for IntN');
         }
       });
 
@@ -118,7 +118,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
             return readFloat(parser, callback);
 
           default:
-            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for FloatN'));
+            throw new Error('Unsupported dataLength ' + dataLength + ' for FloatN');
         }
       });
 
@@ -140,7 +140,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
             return readMoney(parser, callback);
 
           default:
-            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for MoneyN'));
+            throw new Error('Unsupported dataLength ' + dataLength + ' for MoneyN');
         }
       });
 
@@ -157,7 +157,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
             return readBit(parser, callback);
 
           default:
-            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for BitN'));
+            throw new Error('Unsupported dataLength ' + dataLength + ' for BitN');
         }
       });
 
@@ -270,7 +270,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
             return readDateTime(parser, options.useUTC, callback);
 
           default:
-            return parser.emit('error', new Error('Unsupported dataLength ' + dataLength + ' for DateTimeN'));
+            throw new Error('Unsupported dataLength ' + dataLength + ' for DateTimeN');
         }
       });
 
@@ -330,7 +330,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
             return readUniqueIdentifier(parser, options, callback);
 
           default:
-            return parser.emit('error', new Error(sprintf('Unsupported guid size %d', dataLength! - 1)));
+            throw new Error(sprintf('Unsupported guid size %d', dataLength! - 1));
         }
       });
 
@@ -347,7 +347,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
       });
 
     default:
-      parser.emit('error', new Error(sprintf('Unrecognised type %s', type.name)));
+      throw new Error(sprintf('Unrecognised type %s', type.name));
   }
 }
 
@@ -371,7 +371,7 @@ function readNumeric(parser: Parser, dataLength: number, _precision: number, sca
     } else if (dataLength === 17) {
       readValue = parser.readUNumeric128LE;
     } else {
-      return parser.emit('error', new Error(sprintf('Unsupported numeric dataLength %d', dataLength)));
+      throw new Error(sprintf('Unsupported numeric dataLength %d', dataLength));
     }
 
     readValue.call(parser, (value) => {
@@ -568,7 +568,7 @@ function readMaxKnownLength(parser: Parser, totalLength: number, callback: (valu
 
   next(() => {
     if (offset !== totalLength) {
-      parser.emit('error', new Error('Partially Length-prefixed Bytes unmatched lengths : expected ' + totalLength + ', but got ' + offset + ' bytes'));
+      throw new Error('Partially Length-prefixed Bytes unmatched lengths : expected ' + totalLength + ', but got ' + offset + ' bytes');
     }
 
     callback(data);

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -97,34 +97,6 @@ describe('Pause-Resume Test', function() {
     connection.execSql(request);
   });
 
-  it('should test pausing request pauses transforms', function(done) {
-    const sql = `
-          with cte1 as
-            (select 1 as i union all select i + 1 from cte1 where i < 20000)
-          select i from cte1 option (maxrecursion 0)
-        `;
-
-    const request = new Request(sql, (error) => {
-      assert.ifError(error);
-
-      done();
-    });
-
-    request.on('row', (columns) => {
-      if (columns[0].value === 1000) {
-        request.pause();
-
-        setTimeout(() => {
-          assert.ok(connection.messageIo.incomingMessageStream.isPaused());
-
-          request.resume();
-        }, 3000);
-      }
-    });
-
-    connection.execSql(request);
-  });
-
   it('should test paused request can be cancelled', function(done) {
     connection.on('error', (err) => {
       assert.ifError(err);

--- a/test/unit/token/done-token-parser-test.js
+++ b/test/unit/token/done-token-parser-test.js
@@ -1,4 +1,4 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
@@ -14,42 +14,50 @@ function parse(status, curCmd, doneRowCount) {
   buffer.writeUInt32LE(doneRowCountLow);
   buffer.writeUInt32LE(doneRowCountHi);
 
-  var parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-  parser.write(buffer.data);
-  return parser.read();
+  var parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
+  return parser;
 }
 
 describe('Done Token Parser', () => {
-  it('should done', () => {
+  it('should done', async () => {
     const status = 0x0000;
     const curCmd = 1;
     const doneRowCount = 2;
 
-    const token = parse(status, curCmd, doneRowCount);
+    const parser = parse(status, curCmd, doneRowCount);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     assert.isOk(!token.more);
     assert.strictEqual(token.curCmd, curCmd);
     assert.isOk(!token.rowCount);
   });
 
-  it('should more', () => {
+  it('should more', async () => {
     const status = 0x0001;
     const curCmd = 1;
     const doneRowCount = 2;
 
-    const token = parse(status, curCmd, doneRowCount);
+    const parser = parse(status, curCmd, doneRowCount);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     assert.isOk(token.more);
     assert.strictEqual(token.curCmd, curCmd);
     assert.isOk(!token.rowCount);
   });
 
-  it('should done row count', () => {
+  it('should done row count', async () => {
     const status = 0x0010;
     const curCmd = 1;
     const doneRowCount = 0x1200000034;
 
-    const token = parse(status, curCmd, doneRowCount);
+    const parser = parse(status, curCmd, doneRowCount);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     assert.isOk(!token.more);
     assert.strictEqual(token.curCmd, 1);

--- a/test/unit/token/env-change-token-parser-test.js
+++ b/test/unit/token/env-change-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Env Change Token Parser', () => {
-  it('should write to database', () => {
+  it('should write to database', async () => {
     const oldDb = 'old';
     const newDb = 'new';
 
@@ -18,16 +18,16 @@ describe('Env Change Token Parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(data);
-    const token = parser.read();
-
+    const parser = StreamParser.parseTokens([data], {}, {});
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.strictEqual(token.type, 'DATABASE');
     assert.strictEqual(token.oldValue, 'old');
     assert.strictEqual(token.newValue, 'new');
   });
 
-  it('should write with correct packet size', () => {
+  it('should write with correct packet size', async () => {
     const oldSize = '1024';
     const newSize = '2048';
 
@@ -42,16 +42,17 @@ describe('Env Change Token Parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([data], {}, {});
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     assert.strictEqual(token.type, 'PACKET_SIZE');
     assert.strictEqual(token.oldValue, 1024);
     assert.strictEqual(token.newValue, 2048);
   });
 
-  it('should be of bad type', () => {
+  it('should be of bad type', async () => {
     const buffer = new WritableTrackingBuffer(50, 'ucs2');
 
     buffer.writeUInt8(0xe3);
@@ -61,10 +62,8 @@ describe('Env Change Token Parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(data);
-    const token = parser.read();
-
-    assert.strictEqual(token, null);
+    const parser = StreamParser.parseTokens([data], {}, {});
+    const result = await parser.next();
+    assert.isTrue(result.done);
   });
 });

--- a/test/unit/token/feature-ext-parser-test.js
+++ b/test/unit/token/feature-ext-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Feature Ext Praser', () => {
-  it('should be fed authentication', () => {
+  it('should be fed authentication', async () => {
     const buffer = new WritableTrackingBuffer(50, 'ucs2');
 
     buffer.writeUInt8(0xAE); // FEATUREEXTACK token header
@@ -22,11 +22,11 @@ describe('Feature Ext Praser', () => {
 
     buffer.writeUInt8(0xFF); // terminator
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(buffer.data);
-
-    const token = parser.read();
-
+    const parser = StreamParser.parseTokens([buffer.data], {}, {});
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.isOk(token.fedAuth.equals(Buffer.from('bc')));
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/fedauth-info-parser-test.js
+++ b/test/unit/token/fedauth-info-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Fedauth Info Parser', () => {
-  it('should contain fed auth info', () => {
+  it('should contain fed auth info', async () => {
     const buffer = new WritableTrackingBuffer(50, 'ucs-2');
     buffer.writeUInt8('0xEE');
     buffer.writeUInt32LE(40);
@@ -17,11 +17,13 @@ describe('Fedauth Info Parser', () => {
     buffer.writeString('spn');
     buffer.writeString('stsurl');
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(buffer.data);
-    const token = parser.read();
-
+    const parser = StreamParser.parseTokens([buffer.data], {}, {});
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.strictEqual(token.stsurl, 'stsurl');
     assert.strictEqual(token.spn, 'spn');
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/infoerror-token-parser-test.js
+++ b/test/unit/token/infoerror-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Infoerror token parser', () => {
-  it('should have correct info', () => {
+  it('should have correct info', async () => {
     const number = 3;
     const state = 4;
     const class_ = 5;
@@ -27,10 +27,10 @@ describe('Infoerror token parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(data);
-    const token = parser.read();
-
+    const parser = StreamParser.parseTokens([data], {}, { tdsVersion: '7_2' });
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.strictEqual(token.number, number);
     assert.strictEqual(token.state, state);
     assert.strictEqual(token.class, class_);
@@ -38,5 +38,7 @@ describe('Infoerror token parser', () => {
     assert.strictEqual(token.serverName, serverName);
     assert.strictEqual(token.procName, procName);
     assert.strictEqual(token.lineNumber, lineNumber);
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/loginack-token-parser-test.js
+++ b/test/unit/token/loginack-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Loginack Token Parser', () => {
-  it('should have correct info', () => {
+  it('should have correct info', async () => {
     const interfaceType = 1;
     const version = 0x72090002;
     const progName = 'prog';
@@ -30,13 +30,16 @@ describe('Loginack Token Parser', () => {
     data.writeUInt16LE(data.length - 3, 1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([data], { tdsVersion: '7_2' });
 
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.strictEqual(token.interface, 'SQL_TSQL');
     assert.strictEqual(token.tdsVersion, '7_2');
     assert.strictEqual(token.progName, progName);
     assert.deepEqual(token.progVersion, progVersion);
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/order-token-parser-test.js
+++ b/test/unit/token/order-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Order Token Parser', () => {
-  it('should have one column', () => {
+  it('should have one column', async () => {
     const numberOfColumns = 1;
     const length = numberOfColumns * 2;
     const column = 3;
@@ -15,16 +15,16 @@ describe('Order Token Parser', () => {
     buffer.writeUInt16LE(column);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
-
+    const parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.strictEqual(token.orderColumns.length, 1);
+
     assert.strictEqual(token.orderColumns[0], column);
   });
 
-  it('should have two columns', () => {
+  it('should have two columns', async () => {
     const numberOfColumns = 2;
     const length = numberOfColumns * 2;
     const column1 = 3;
@@ -38,13 +38,14 @@ describe('Order Token Parser', () => {
     buffer.writeUInt16LE(column2);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
-
+    const parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
     assert.strictEqual(token.orderColumns.length, 2);
     assert.strictEqual(token.orderColumns[0], column1);
     assert.strictEqual(token.orderColumns[1], column2);
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/token-stream-parser-test.js
+++ b/test/unit/token/token-stream-parser-test.js
@@ -29,13 +29,12 @@ describe('Token Stream Parser', () => {
   it('should envChange', (done) => {
     var buffer = createDbChangeBuffer();
 
-    var parser = new Parser(debug);
+    var parser = new Parser([buffer], debug);
     parser.on('databaseChange', function(event) {
       assert.isOk(event);
     });
 
-    parser.write(buffer);
-    parser.end();
+    // parser.end();
 
     parser.on('end', done);
   });
@@ -43,14 +42,11 @@ describe('Token Stream Parser', () => {
   it('should split token across buffers', (done) => {
     var buffer = createDbChangeBuffer();
 
-    var parser = new Parser(debug);
+    var parser = new Parser([buffer.slice(0, 6), buffer.slice(6)], debug);
+
     parser.on('databaseChange', function(event) {
       assert.isOk(event);
     });
-
-    parser.write(buffer.slice(0, 6));
-    parser.write(buffer.slice(6));
-    parser.end();
 
     parser.on('end', done);
   });


### PR DESCRIPTION
This pull request converts the token parsing code from a `Transform` stream into a async generator function that consumes a `AsyncIterable<Buffer>` and yields back parsed tokens.

All of the existing token parsing implementation is retained, this mostly just switches out how the parsing is "driven". This gives us the option to call other async code during the parsing (e.g. as is required for always encrypted to get encryption keys).

Right now, the async generator is wrapped in a `Readable.from` call, so we can keep most of the existing code as-is.

This depends on https://github.com/tediousjs/tedious/pull/1226 to be merged first.

---

### Performance

This change has a negative impact on performance, mostly because we introduce some additional overhead by having a async generator and wrapping it back into a `Readable` stream via `Readable.from`. This is an interim solution and will hopefully be refactored away soon, which should improve performance again. In the mean time, I believe the performance hit is acceptable.

#### Before

```
root ➜ ~/workspace/tedious (master) $ node benchmarks/query/select-many-rows.js 
query/select-many-rows.js size=10 n=10: 532.4236697461165 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=10: 284.16636656330303 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=10: 85.51023654585572 (minor: 3 - 3.2305240000000004ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=10: 15.934764679625893 (minor: 24 - 17.215927ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=100: 674.8609042503098 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=100: 463.037634212558 (minor: 3 - 3.7732279999999996ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=100: 147.4007835928836 (minor: 27 - 15.749910000000002ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=100: 20.14078649029258 (minor: 235 - 112.42549800000005ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=1000: 895.6707557867154 (minor: 6 - 14.221501ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=1000: 635.4394020000775 (minor: 31 - 30.979024999999993ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=1000: 166.43689997146637 (minor: 267 - 136.60967799999997ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=1000: 20.153075716417455 (minor: 2371 - 1165.8097820000007ms, major: 0 - 0ms, incremental: 0 - 0ms)
```

#### After

```
root ➜ ~/workspace/tedious (arthur/token-parser-async-generator) $ node benchmarks/query/select-many-rows.js 
query/select-many-rows.js size=10 n=10: 502.91585584057805 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=10: 227.16272888405445 (minor: 1 - 2.704519ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=10: 81.94501407610478 (minor: 3 - 3.8326270000000005ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=10: 13.575519515447352 (minor: 32 - 22.000658ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=100: 524.0109713434697 (minor: 1 - 1.42641ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=100: 404.50896107083423 (minor: 5 - 8.497362ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=100: 107.47463633511748 (minor: 34 - 35.75296500000001ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=100: 16.49632461244278 (minor: 320 - 232.55980199999993ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10 n=1000: 854.1123887852357 (minor: 9 - 18.826438ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=100 n=1000: 539.9230060830604 (minor: 43 - 57.258018ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=1000 n=1000: 143.33281997154975 (minor: 344 - 222.09660600000004ms, major: 0 - 0ms, incremental: 0 - 0ms)
query/select-many-rows.js size=10000 n=1000: 15.99416653285739 (minor: 3203 - 2346.3768180000034ms, major: 0 - 0ms, incremental: 0 - 0ms)
```