### PR TITLE
Deprecate `validateBulkLoadParameters` connection option

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -813,7 +813,7 @@ interface ConnectionOptions {
   /**
    * A boolean determining whether BulkLoad parameters should be validated.
    *
-   * (default: `false`).
+   * (default: `true`).
    */
   validateBulkLoadParameters?: boolean;
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1649,6 +1649,10 @@ class Connection extends EventEmitter {
           throw new TypeError('The "config.options.validateBulkLoadParameters" property must be of type boolean.');
         }
 
+        if (config.options.validateBulkLoadParameters === false) {
+          deprecate('Setting the "config.options.validateBulkLoadParameters" to `false` is deprecated and will no longer work in the next major version of `tedious`. Set the value to `true` and update your use of BulkLoad functionality to silence this message.');
+        }
+
         this.config.options.validateBulkLoadParameters = config.options.validateBulkLoadParameters;
       }
 


### PR DESCRIPTION
This deprecates setting `validateBulkLoadParameters` to `false`.

This option was added to ease migration for code that relied on missing bulk load parameter validation. Skipping bulk load validation can lead to really weird bugs, so validating parameters should not be optional.

The `validateBulkLoadParameters` option will be removed in the next major release.