### PR TITLE
Throw and catch `TypeError`s instead of returning them

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -164,9 +164,9 @@ class RowTransform extends Transform {
     for (let i = 0; i < this.columns.length; i++) {
       const c = this.columns[i];
       if (this.bulkLoad.options.validateBulkLoadParameters) {
-        const error = c.type.validate(row[i]);
-
-        if (error instanceof TypeError) {
+        try {
+          c.type.validate(row[i]);
+        } catch (error) {
           return callback(error);
         }
       }
@@ -429,10 +429,7 @@ class BulkLoad extends EventEmitter {
    */
   colTypeValidation(column: Column, value: any) {
     if (this.options.validateBulkLoadParameters) {
-      const error = column.type.validate(value);
-      if (error instanceof TypeError) {
-        throw error;
-      }
+      column.type.validate(value);
     }
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2772,14 +2772,16 @@ class Connection extends EventEmitter {
    * @param request A [[Request]] object representing the request.
    */
   execSql(request: Request) {
-    request.transformIntoExecuteSqlRpc();
+    try {
+      request.transformIntoExecuteSqlRpc();
+    } catch (error) {
+      request.error = error;
 
-    const error = request.error;
-    if (error != null) {
       process.nextTick(() => {
         this.debug.log(error.message);
         request.callback(error);
       });
+
       return;
     }
 
@@ -2882,10 +2884,11 @@ class Connection extends EventEmitter {
    *   request is executed.
    */
   execute(request: Request, parameters: { [key: string]: unknown }) {
-    request.transformIntoExecuteRpc(parameters);
+    try {
+      request.transformIntoExecuteRpc(parameters);
+    } catch (error) {
+      request.error = error;
 
-    const error = request.error;
-    if (error != null) {
       process.nextTick(() => {
         this.debug.log(error.message);
         request.callback(error);

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -36,7 +36,7 @@ const BigInt: DataType = {
     yield buffer.data;
   },
 
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
@@ -46,11 +46,11 @@ const BigInt: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
 
     if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
-      return new TypeError(`Value must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}, inclusive.  For smaller or bigger numbers, use VarChar type.`);
+      throw new TypeError(`Value must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}, inclusive.  For smaller or bigger numbers, use VarChar type.`);
     }
 
     return value;

--- a/src/data-types/binary.ts
+++ b/src/data-types/binary.ts
@@ -60,13 +60,13 @@ const Binary: { maximumLength: number } & DataType = {
     yield parameter.value.slice(0, parameter.length !== undefined ? Math.min(parameter.length, this.maximumLength) : this.maximumLength);
   },
 
-  validate: function(value): Buffer | null | TypeError {
+  validate: function(value): Buffer | null {
     if (value == null) {
       return null;
     }
 
     if (!Buffer.isBuffer(value)) {
-      return new TypeError('Invalid buffer.');
+      throw new TypeError('Invalid buffer.');
     }
 
     return value;

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -73,13 +73,13 @@ const Char: { maximumLength: number } & DataType = {
     yield Buffer.from(parameter.value, 'ascii');
   },
 
-  validate: function(value): null | string | TypeError {
+  validate: function(value): null | string {
     if (value == null) {
       return null;
     }
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
-        return TypeError('Invalid string.');
+        throw new TypeError('Invalid string.');
       }
       value = value.toString();
     }

--- a/src/data-types/date.ts
+++ b/src/data-types/date.ts
@@ -49,7 +49,7 @@ const Date: DataType = {
   },
 
   // TODO: value is techincally of type 'unknown'.
-  validate: function(value): null | Date | TypeError {
+  validate: function(value): null | Date {
     if (value == null) {
       return null;
     }
@@ -59,7 +59,7 @@ const Date: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid date.');
+      throw new TypeError('Invalid date.');
     }
 
     return value;

--- a/src/data-types/datetime.ts
+++ b/src/data-types/datetime.ts
@@ -72,7 +72,7 @@ const DateTime: DataType = {
   },
 
   // TODO: type 'any' needs to be revisited.
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
@@ -82,7 +82,7 @@ const DateTime: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid date.');
+      throw new TypeError('Invalid date.');
     }
 
     return value;

--- a/src/data-types/datetime2.ts
+++ b/src/data-types/datetime2.ts
@@ -102,7 +102,7 @@ const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']
     yield buffer.data;
   },
 
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
@@ -112,7 +112,7 @@ const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid date.');
+      throw new TypeError('Invalid date.');
     }
 
     return value;

--- a/src/data-types/datetimeoffset.ts
+++ b/src/data-types/datetimeoffset.ts
@@ -92,7 +92,7 @@ const DateTimeOffset: DataType & { resolveScale: NonNullable<DataType['resolveSc
     buffer.writeInt16LE(offset);
     yield buffer.data;
   },
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
@@ -102,7 +102,7 @@ const DateTimeOffset: DataType & { resolveScale: NonNullable<DataType['resolveSc
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid date.');
+      throw new TypeError('Invalid date.');
     }
 
     return value;

--- a/src/data-types/decimal.ts
+++ b/src/data-types/decimal.ts
@@ -97,13 +97,13 @@ const Decimal: DataType & { resolvePrecision: NonNullable<DataType['resolvePreci
     }
   },
 
-  validate: function(value): number | null | TypeError {
+  validate: function(value): number | null {
     if (value == null) {
       return null;
     }
     value = parseFloat(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
     return value;
   }

--- a/src/data-types/float.ts
+++ b/src/data-types/float.ts
@@ -34,13 +34,13 @@ const Float: DataType = {
     yield buffer;
   },
 
-  validate: function(value): number | null | TypeError {
+  validate: function(value): number | null {
     if (value == null) {
       return null;
     }
     value = parseFloat(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
     return value;
   }

--- a/src/data-types/image.ts
+++ b/src/data-types/image.ts
@@ -46,12 +46,12 @@ const Image: DataType = {
     yield parameter.value;
   },
 
-  validate: function(value): null | TypeError | Buffer {
+  validate: function(value): null | Buffer {
     if (value == null) {
       return null;
     }
     if (!Buffer.isBuffer(value)) {
-      return new TypeError('Invalid buffer.');
+      throw new TypeError('Invalid buffer.');
     }
     return value;
   }

--- a/src/data-types/int.ts
+++ b/src/data-types/int.ts
@@ -35,7 +35,7 @@ const Int: DataType = {
     yield buffer;
   },
 
-  validate: function(value): number | null | TypeError {
+  validate: function(value): number | null {
     if (value == null) {
       return null;
     }
@@ -45,11 +45,11 @@ const Int: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
 
     if (value < -2147483648 || value > 2147483647) {
-      return new TypeError('Value must be between -2147483648 and 2147483647, inclusive.');
+      throw new TypeError('Value must be between -2147483648 and 2147483647, inclusive.');
     }
 
     return value | 0;

--- a/src/data-types/money.ts
+++ b/src/data-types/money.ts
@@ -41,13 +41,13 @@ const Money: DataType = {
     yield buffer;
   },
 
-  validate: function(value): number | null | TypeError {
+  validate: function(value): number | null {
     if (value == null) {
       return null;
     }
     value = parseFloat(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
     return value;
   }

--- a/src/data-types/nchar.ts
+++ b/src/data-types/nchar.ts
@@ -89,13 +89,13 @@ const NChar: DataType & { maximumLength: number } = {
     }
   },
 
-  validate: function(value): string | null | TypeError {
+  validate: function(value): string | null {
     if (value == null) {
       return null;
     }
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
-        return TypeError('Invalid string.');
+        throw new TypeError('Invalid string.');
       }
       value = value.toString();
     }

--- a/src/data-types/numeric.ts
+++ b/src/data-types/numeric.ts
@@ -96,13 +96,13 @@ const Numeric: DataType & { resolveScale: NonNullable<DataType['resolveScale']>,
     }
   },
 
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
     value = parseFloat(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
     return value;
   }

--- a/src/data-types/nvarchar.ts
+++ b/src/data-types/nvarchar.ts
@@ -129,13 +129,13 @@ const NVarChar: { maximumLength: number } & DataType = {
     }
   },
 
-  validate: function(value): null | string | TypeError {
+  validate: function(value): null | string {
     if (value == null) {
       return null;
     }
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
-        return TypeError('Invalid string.');
+        throw new TypeError('Invalid string.');
       }
       value = value.toString();
     }

--- a/src/data-types/real.ts
+++ b/src/data-types/real.ts
@@ -35,13 +35,13 @@ const Real: DataType = {
     yield buffer;
   },
 
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
     value = parseFloat(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
     return value;
   }

--- a/src/data-types/smalldatetime.ts
+++ b/src/data-types/smalldatetime.ts
@@ -51,7 +51,7 @@ const SmallDateTime: DataType = {
     yield buffer;
   },
 
-  validate: function(value): null | Date | TypeError {
+  validate: function(value): null | Date {
     if (value == null) {
       return null;
     }
@@ -61,7 +61,7 @@ const SmallDateTime: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid date.');
+      throw new TypeError('Invalid date.');
     }
 
     return value;

--- a/src/data-types/smallint.ts
+++ b/src/data-types/smallint.ts
@@ -35,7 +35,7 @@ const SmallInt: DataType = {
     yield buffer;
   },
 
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
@@ -45,11 +45,11 @@ const SmallInt: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
 
     if (value < -32768 || value > 32767) {
-      return new TypeError('Value must be between -32768 and 32767, inclusive.');
+      throw new TypeError('Value must be between -32768 and 32767, inclusive.');
     }
 
     return value | 0;

--- a/src/data-types/smallmoney.ts
+++ b/src/data-types/smallmoney.ts
@@ -35,16 +35,16 @@ const SmallMoney: DataType = {
     yield buffer;
   },
 
-  validate: function(value): null | number | TypeError {
+  validate: function(value): null | number {
     if (value == null) {
       return null;
     }
     value = parseFloat(value);
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
     if (value < -214748.3648 || value > 214748.3647) {
-      return new TypeError('Value must be between -214748.3648 and 214748.3647.');
+      throw new TypeError('Value must be between -214748.3648 and 214748.3647.');
     }
     return value;
   }

--- a/src/data-types/text.ts
+++ b/src/data-types/text.ts
@@ -49,13 +49,13 @@ const Text: DataType = {
     yield Buffer.from(parameter.value.toString(), 'ascii');
   },
 
-  validate: function(value): string | null | TypeError {
+  validate: function(value): string | null {
     if (value == null) {
       return null;
     }
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
-        return TypeError('Invalid string.');
+        throw new TypeError('Invalid string.');
       }
       value = value.toString();
     }

--- a/src/data-types/time.ts
+++ b/src/data-types/time.ts
@@ -86,7 +86,7 @@ const Time: DataType = {
     yield buffer.data;
   },
 
-  validate: function(value): null | number | TypeError | Date {
+  validate: function(value): null | number | Date {
     if (value == null) {
       return null;
     }
@@ -96,7 +96,7 @@ const Time: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid time.');
+      throw new TypeError('Invalid time.');
     }
 
     return value;

--- a/src/data-types/tinyint.ts
+++ b/src/data-types/tinyint.ts
@@ -35,7 +35,7 @@ const TinyInt: DataType = {
     yield buffer;
   },
 
-  validate: function(value): number | null | TypeError {
+  validate: function(value): number | null {
     if (value == null) {
       return null;
     }
@@ -45,11 +45,11 @@ const TinyInt: DataType = {
     }
 
     if (isNaN(value)) {
-      return new TypeError('Invalid number.');
+      throw new TypeError('Invalid number.');
     }
 
     if (value < 0 || value > 255) {
-      return new TypeError('Value must be between 0 and 255, inclusive.');
+      throw new TypeError('Value must be between 0 and 255, inclusive.');
     }
 
     return value | 0;

--- a/src/data-types/tvp.ts
+++ b/src/data-types/tvp.ts
@@ -99,21 +99,21 @@ const TVP: DataType = {
     yield TVP_END_TOKEN;
   },
 
-  validate: function(value): Buffer | null | TypeError {
+  validate: function(value): Buffer | null {
     if (value == null) {
       return null;
     }
 
     if (typeof value !== 'object') {
-      return new TypeError('Invalid table.');
+      throw new TypeError('Invalid table.');
     }
 
     if (!Array.isArray(value.columns)) {
-      return new TypeError('Invalid table.');
+      throw new TypeError('Invalid table.');
     }
 
     if (!Array.isArray(value.rows)) {
-      return new TypeError('Invalid table.');
+      throw new TypeError('Invalid table.');
     }
 
     return value;

--- a/src/data-types/uniqueidentifier.ts
+++ b/src/data-types/uniqueidentifier.ts
@@ -37,21 +37,21 @@ const UniqueIdentifier: DataType = {
     yield Buffer.from(guidToArray(parameter.value));
   },
 
-  validate: function(value): string | null | TypeError {
+  validate: function(value): string | null {
     if (value == null) {
       return null;
     }
 
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
-        return TypeError('Invalid string.');
+        throw new TypeError('Invalid string.');
       }
 
       value = value.toString();
     }
 
     if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)) {
-      return TypeError('Invalid GUID.');
+      throw new TypeError('Invalid GUID.');
     }
 
     return value;

--- a/src/data-types/varbinary.ts
+++ b/src/data-types/varbinary.ts
@@ -118,12 +118,12 @@ const VarBinary: { maximumLength: number } & DataType = {
     }
   },
 
-  validate: function(value): Buffer | null | TypeError {
+  validate: function(value): Buffer | null {
     if (value == null) {
       return null;
     }
     if (!Buffer.isBuffer(value)) {
-      return new TypeError('Invalid buffer.');
+      throw new TypeError('Invalid buffer.');
     }
     return value;
   }

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -124,13 +124,13 @@ const VarChar: { maximumLength: number } & DataType = {
     }
   },
 
-  validate: function(value): string | null | TypeError {
+  validate: function(value): string | null {
     if (value == null) {
       return null;
     }
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
-        return TypeError('Invalid string.');
+        throw new TypeError('Invalid string.');
       }
       value = value.toString();
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -444,9 +444,7 @@ class Request extends EventEmitter {
    * @private
    */
   transformIntoExecuteSqlRpc() {
-    if (this.validateParameters()) {
-      return;
-    }
+    this.validateParameters();
 
     this.originalParameters = this.parameters;
     this.parameters = [];
@@ -504,9 +502,7 @@ class Request extends EventEmitter {
       this.parameters.push(parameter);
     }
 
-    if (this.validateParameters()) {
-      return;
-    }
+    this.validateParameters();
 
     this.sqlTextOrProcedure = 'sp_execute';
   }
@@ -517,13 +513,13 @@ class Request extends EventEmitter {
   validateParameters() {
     for (let i = 0, len = this.parameters.length; i < len; i++) {
       const parameter = this.parameters[i];
-      const value = parameter.type.validate(parameter.value);
-      if (value instanceof TypeError) {
-        return this.error = new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + value.message, 'EPARAM');
+
+      try {
+        parameter.value = parameter.type.validate(parameter.value);
+      } catch (error) {
+        throw new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + error.message, 'EPARAM');
       }
-      parameter.value = value;
     }
-    return null;
   }
 
   /**

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -1240,10 +1240,10 @@ describe('UniqueIdentifier', function() {
       assert.strictEqual(actual, expected);
     });
 
-    it('returns a TypeError for values that don\'t matcht the UUID format', function() {
-      const result = TYPES.UniqueIdentifier.validate('invalid');
-      assert.instanceOf(result, TypeError);
-      assert.strictEqual(result.message, 'Invalid GUID.');
+    it("returns a TypeError for values that don't match the UUID format", function() {
+      assert.throws(() => {
+        TYPES.UniqueIdentifier.validate('invalid');
+      }, TypeError, 'Invalid GUID.');
     });
   });
 });

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -32,8 +32,9 @@ describe('Validations', function() {
     value = TYPE.TinyInt.validate('15');
     assert.strictEqual(value, 15);
 
-    value = TYPE.TinyInt.validate(256);
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.TinyInt.validate(256);
+    }, TypeError, 'Value must be between 0 and 255, inclusive.');
   });
 
   it('SmallInt', () => {
@@ -43,8 +44,9 @@ describe('Validations', function() {
     value = TYPE.SmallInt.validate(-32768);
     assert.strictEqual(value, -32768);
 
-    value = TYPE.SmallInt.validate(-32769);
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.SmallInt.validate(-32769);
+    }, TypeError, 'Value must be between -32768 and 32767, inclusive.');
   });
 
   it('Int', () => {
@@ -54,8 +56,9 @@ describe('Validations', function() {
     value = TYPE.Int.validate(2147483647);
     assert.strictEqual(value, 2147483647);
 
-    value = TYPE.Int.validate(2147483648);
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Int.validate(2147483648);
+    }, TypeError, 'Value must be between -2147483648 and 2147483647, inclusive.');
   });
 
   it('BigInt', () => {
@@ -71,11 +74,13 @@ describe('Validations', function() {
     value = TYPE.BigInt.validate(9007199254740991);
     assert.strictEqual(value, 9007199254740991);
 
-    value = TYPE.BigInt.validate(-9007199254740992);
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.BigInt.validate(-9007199254740992);
+    }, TypeError, 'Value must be between -9007199254740991 and 9007199254740991, inclusive.  For smaller or bigger numbers, use VarChar type.');
 
-    value = TYPE.BigInt.validate(9007199254740992);
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.BigInt.validate(9007199254740992);
+    }, TypeError, 'Value must be between -9007199254740991 and 9007199254740991, inclusive.  For smaller or bigger numbers, use VarChar type.');
   });
 
   it('SmallDateTime', () => {
@@ -89,8 +94,9 @@ describe('Validations', function() {
     value = TYPE.SmallDateTime.validate('2015-02-12T16:43:13.632Z');
     assert.strictEqual(+value, 1423759393632);
 
-    value = TYPE.SmallDateTime.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.SmallDateTime.validate('xxx');
+    }, TypeError, 'Invalid date.');
   });
 
   it('DateTime', () => {
@@ -104,8 +110,9 @@ describe('Validations', function() {
     value = TYPE.DateTime.validate('2015-02-12T16:43:13.632Z');
     assert.strictEqual(+value, 1423759393632);
 
-    value = TYPE.DateTime.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.DateTime.validate('xxx');
+    }, TypeError, 'Invalid date.');
   });
 
   it('DateTime2', () => {
@@ -119,8 +126,9 @@ describe('Validations', function() {
     value = TYPE.DateTime2.validate('2015-02-12T16:43:13.632Z');
     assert.strictEqual(+value, 1423759393632);
 
-    value = TYPE.DateTime2.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.DateTime2.validate('xxx');
+    }, TypeError, 'Invalid date.');
   });
 
   it('Time', () => {
@@ -134,8 +142,9 @@ describe('Validations', function() {
     value = TYPE.Time.validate('2015-02-12T16:43:13.632Z');
     assert.strictEqual(+value, 1423759393632);
 
-    value = TYPE.Time.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Time.validate('xxx');
+    }, TypeError, 'Invalid time.');
   });
 
   it('DateTimeOffset', () => {
@@ -149,8 +158,9 @@ describe('Validations', function() {
     value = TYPE.DateTimeOffset.validate('2015-02-12T16:43:13.632Z');
     assert.strictEqual(+value, 1423759393632);
 
-    value = TYPE.DateTimeOffset.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.DateTimeOffset.validate('xxx');
+    }, TypeError, 'Invalid date.');
   });
 
   it('Real', () => {
@@ -163,8 +173,9 @@ describe('Validations', function() {
     value = TYPE.Real.validate('1516.61556');
     assert.strictEqual(value, 1516.61556);
 
-    value = TYPE.Real.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Real.validate('xxx');
+    }, TypeError, 'Invalid number.');
   });
 
   it('Float', () => {
@@ -177,8 +188,9 @@ describe('Validations', function() {
     value = TYPE.Float.validate('1516.61556');
     assert.strictEqual(value, 1516.61556);
 
-    value = TYPE.Float.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Float.validate('xxx');
+    }, TypeError, 'Invalid number.');
   });
 
   it('Decimal', () => {
@@ -191,8 +203,9 @@ describe('Validations', function() {
     value = TYPE.Decimal.validate('1516.61556');
     assert.strictEqual(value, 1516.61556);
 
-    value = TYPE.Decimal.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Decimal.validate('xxx');
+    }, TypeError, 'Invalid number.');
   });
 
   it('Numeric', () => {
@@ -205,8 +218,9 @@ describe('Validations', function() {
     value = TYPE.Numeric.validate('1516.61556');
     assert.strictEqual(value, 1516.61556);
 
-    value = TYPE.Numeric.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Numeric.validate('xxx');
+    }, TypeError, 'Invalid number.');
   });
 
   it('Money', () => {
@@ -219,8 +233,9 @@ describe('Validations', function() {
     value = TYPE.Money.validate('1516.61556');
     assert.strictEqual(value, 1516.61556);
 
-    value = TYPE.Money.validate('xxx');
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Money.validate('xxx');
+    }, TypeError, 'Invalid number.');
   });
 
   it('SmallMoney', () => {
@@ -230,8 +245,9 @@ describe('Validations', function() {
     value = TYPE.SmallMoney.validate(214748.3647);
     assert.strictEqual(value, 214748.3647);
 
-    value = TYPE.SmallMoney.validate(214748.3648);
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.SmallMoney.validate(214748.3648);
+    }, TypeError, 'Value must be between -214748.3648 and 214748.3647');
   });
 
   it('Image', () => {
@@ -242,8 +258,9 @@ describe('Validations', function() {
     value = TYPE.Image.validate(buffer);
     assert.strictEqual(value, buffer);
 
-    value = TYPE.Image.validate({});
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Image.validate({});
+    }, TypeError, 'Invalid buffer.');
   });
 
   it('Binary', () => {
@@ -254,8 +271,9 @@ describe('Validations', function() {
     value = TYPE.Binary.validate(buffer);
     assert.strictEqual(value, buffer);
 
-    value = TYPE.Binary.validate({});
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Binary.validate({});
+    }, TypeError, 'Invalid buffer.');
   });
 
   it('VarBinary', () => {
@@ -266,8 +284,9 @@ describe('Validations', function() {
     value = TYPE.VarBinary.validate(buffer);
     assert.strictEqual(value, buffer);
 
-    value = TYPE.VarBinary.validate({});
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.VarBinary.validate({});
+    }, TypeError, 'Invalid buffer.');
   });
 
   it('Text', () => {
@@ -280,8 +299,9 @@ describe('Validations', function() {
     value = TYPE.Text.validate(Buffer.from('asdf', 'utf8'));
     assert.strictEqual(value, 'asdf');
 
-    value = TYPE.Text.validate({ toString: null });
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Text.validate({ toString: null });
+    }, TypeError, 'Invalid string.');
   });
 
   it('VarChar', () => {
@@ -294,8 +314,9 @@ describe('Validations', function() {
     value = TYPE.VarChar.validate(Buffer.from('asdf', 'utf8'));
     assert.strictEqual(value, 'asdf');
 
-    value = TYPE.VarChar.validate({ toString: null });
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.VarChar.validate({ toString: null });
+    }, TypeError, 'Invalid string.');
   });
 
   it('NVarChar', () => {
@@ -308,8 +329,9 @@ describe('Validations', function() {
     value = TYPE.NVarChar.validate(Buffer.from('asdf', 'utf8'));
     assert.strictEqual(value, 'asdf');
 
-    value = TYPE.NVarChar.validate({ toString: null });
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.NVarChar.validate({ toString: null });
+    }, TypeError, 'Invalid string.');
   });
 
   it('Char', () => {
@@ -322,8 +344,9 @@ describe('Validations', function() {
     value = TYPE.Char.validate(Buffer.from('asdf', 'utf8'));
     assert.strictEqual(value, 'asdf');
 
-    value = TYPE.Char.validate({ toString: null });
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.Char.validate({ toString: null });
+    }, TypeError, 'Invalid string.');
   });
 
   it('NChar', () => {
@@ -336,8 +359,9 @@ describe('Validations', function() {
     value = TYPE.NChar.validate(Buffer.from('asdf', 'utf8'));
     assert.strictEqual(value, 'asdf');
 
-    value = TYPE.NChar.validate({ toString: null });
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.NChar.validate({ toString: null });
+    }, TypeError, 'Invalid string.');
   });
 
   it('TVP', () => {
@@ -348,7 +372,8 @@ describe('Validations', function() {
     value = TYPE.TVP.validate(table);
     assert.strictEqual(value, table);
 
-    value = TYPE.TVP.validate({});
-    assert.ok(value instanceof TypeError);
+    assert.throws(() => {
+      TYPE.TVP.validate({});
+    }, TypeError, 'Invalid table.');
   });
 });


### PR DESCRIPTION
This is a pretty straightforward change - instead of returning `TypeError` instances from the `.validate` method on different `DataType` objects, we just throw them and catch them.

The calling code is regular synchronous code, so there's no harm in doing so.