### PR TITLE
refactor: wip: updating token unit tests

### DIFF
--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -1,3 +1,4 @@
+import Debug from '../debug';
 import { InternalConnectionOptions } from '../connection';
 import JSBI from 'jsbi';
 
@@ -16,7 +17,6 @@ import returnValueParser from './returnvalue-token-parser';
 import rowParser from './row-token-parser';
 import nbcRowParser from './nbcrow-token-parser';
 import sspiParser from './sspi-token-parser';
-import Debug from '../debug';
 
 const tokenParsers = {
   [TYPE.COLMETADATA]: colMetadataParser,
@@ -93,7 +93,6 @@ class Parser {
               parser.colMetadata = token.columns;
             }
             yield token;
-            token = undefined;
           }
         } else {
           throw new Error('Unknown type: ' + type);

--- a/test/unit/token/colmetadata-token-parser-test.js
+++ b/test/unit/token/colmetadata-token-parser-test.js
@@ -2,7 +2,6 @@ const dataTypeByName = require('../../../src/data-type').typeByName;
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const StreamParser = require('../../../src/token/stream-parser');
 const assert = require('chai').assert;
-const Readable = require('readable-stream').Readable;
 
 describe('Colmetadata Token Parser', () => {
   it('should int', async () => {
@@ -23,14 +22,15 @@ describe('Colmetadata Token Parser', () => {
 
     const parser = StreamParser.parseTokens([buffer.data], {}, {});
 
-    for await (let token of parser) { // (4)
-      assert.isOk(!token.error);
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].userType, 2);
-      assert.strictEqual(token.columns[0].flags, 3);
-      assert.strictEqual(token.columns[0].type.name, 'Int');
-      assert.strictEqual(token.columns[0].colName, 'name');
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.isOk(!token.error);
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].userType, 2);
+    assert.strictEqual(token.columns[0].flags, 3);
+    assert.strictEqual(token.columns[0].type.name, 'Int');
+    assert.strictEqual(token.columns[0].colName, 'name');
   });
 
   it('should varchar', async () => {
@@ -55,20 +55,20 @@ describe('Colmetadata Token Parser', () => {
 
 
     const parser = StreamParser.parseTokens([buffer.data], {}, {});
-
-    for await (let token of parser) { // (4)
-      assert.isOk(!token.error);
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].userType, 2);
-      assert.strictEqual(token.columns[0].flags, 3);
-      assert.strictEqual(token.columns[0].type.name, 'VarChar');
-      assert.strictEqual(token.columns[0].collation.lcid, 0x0409);
-      assert.strictEqual(token.columns[0].collation.codepage, 'CP1257');
-      assert.strictEqual(token.columns[0].collation.flags, 0x57);
-      assert.strictEqual(token.columns[0].collation.version, 0x8);
-      assert.strictEqual(token.columns[0].collation.sortId, 0x9a);
-      assert.strictEqual(token.columns[0].colName, 'name');
-      assert.strictEqual(token.columns[0].dataLength, length);
-    }
-  })
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.isOk(!token.error);
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].userType, 2);
+    assert.strictEqual(token.columns[0].flags, 3);
+    assert.strictEqual(token.columns[0].type.name, 'VarChar');
+    assert.strictEqual(token.columns[0].collation.lcid, 0x0409);
+    assert.strictEqual(token.columns[0].collation.codepage, 'CP1257');
+    assert.strictEqual(token.columns[0].collation.flags, 0x57);
+    assert.strictEqual(token.columns[0].collation.version, 0x8);
+    assert.strictEqual(token.columns[0].collation.sortId, 0x9a);
+    assert.strictEqual(token.columns[0].colName, 'name');
+    assert.strictEqual(token.columns[0].dataLength, length);
+  });
 });

--- a/test/unit/token/colmetadata-token-parser-test.js
+++ b/test/unit/token/colmetadata-token-parser-test.js
@@ -5,7 +5,7 @@ const assert = require('chai').assert;
 const Readable = require('readable-stream').Readable;
 
 describe('Colmetadata Token Parser', () => {
-  it('should int', (done) => {
+  it('should int', async () => {
     const numberOfColumns = 1;
     const userType = 2;
     const flags = 3;
@@ -23,20 +23,17 @@ describe('Colmetadata Token Parser', () => {
 
     const parser = StreamParser.parseTokens([buffer.data], {}, {});
 
-    (async () => {
-      for await (let token of parser) { // (4)
-        assert.isOk(!token.error);
-        assert.strictEqual(token.columns.length, 1);
-        assert.strictEqual(token.columns[0].userType, 2);
-        assert.strictEqual(token.columns[0].flags, 3);
-        assert.strictEqual(token.columns[0].type.name, 'Int');
-        assert.strictEqual(token.columns[0].colName, 'name');
-        done();
-      }
-    })()
+    for await (let token of parser) { // (4)
+      assert.isOk(!token.error);
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].userType, 2);
+      assert.strictEqual(token.columns[0].flags, 3);
+      assert.strictEqual(token.columns[0].type.name, 'Int');
+      assert.strictEqual(token.columns[0].colName, 'name');
+    }
   });
 
-  it('should varchar', (done) => {
+  it('should varchar', async () => {
     const numberOfColumns = 1;
     const userType = 2;
     const flags = 3;
@@ -59,22 +56,19 @@ describe('Colmetadata Token Parser', () => {
 
     const parser = StreamParser.parseTokens([buffer.data], {}, {});
 
-    (async () => {
-      for await (let token of parser) { // (4)
-        assert.isOk(!token.error);
-        assert.strictEqual(token.columns.length, 1);
-        assert.strictEqual(token.columns[0].userType, 2);
-        assert.strictEqual(token.columns[0].flags, 3);
-        assert.strictEqual(token.columns[0].type.name, 'VarChar');
-        assert.strictEqual(token.columns[0].collation.lcid, 0x0409);
-        assert.strictEqual(token.columns[0].collation.codepage, 'CP1257');
-        assert.strictEqual(token.columns[0].collation.flags, 0x57);
-        assert.strictEqual(token.columns[0].collation.version, 0x8);
-        assert.strictEqual(token.columns[0].collation.sortId, 0x9a);
-        assert.strictEqual(token.columns[0].colName, 'name');
-        assert.strictEqual(token.columns[0].dataLength, length);
-        done();
-      }
-    })()
+    for await (let token of parser) { // (4)
+      assert.isOk(!token.error);
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].userType, 2);
+      assert.strictEqual(token.columns[0].flags, 3);
+      assert.strictEqual(token.columns[0].type.name, 'VarChar');
+      assert.strictEqual(token.columns[0].collation.lcid, 0x0409);
+      assert.strictEqual(token.columns[0].collation.codepage, 'CP1257');
+      assert.strictEqual(token.columns[0].collation.flags, 0x57);
+      assert.strictEqual(token.columns[0].collation.version, 0x8);
+      assert.strictEqual(token.columns[0].collation.sortId, 0x9a);
+      assert.strictEqual(token.columns[0].colName, 'name');
+      assert.strictEqual(token.columns[0].dataLength, length);
+    }
   })
 });

--- a/test/unit/token/colmetadata-token-parser-test.js
+++ b/test/unit/token/colmetadata-token-parser-test.js
@@ -25,12 +25,15 @@ describe('Colmetadata Token Parser', () => {
     const result = await parser.next();
     assert.isFalse(result.done);
     const token = result.value;
+
     assert.isOk(!token.error);
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].userType, 2);
     assert.strictEqual(token.columns[0].flags, 3);
     assert.strictEqual(token.columns[0].type.name, 'Int');
     assert.strictEqual(token.columns[0].colName, 'name');
+
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should varchar', async () => {

--- a/test/unit/token/done-token-parser-test.js
+++ b/test/unit/token/done-token-parser-test.js
@@ -14,13 +14,7 @@ function parse(status, curCmd, doneRowCount) {
   buffer.writeUInt32LE(doneRowCountLow);
   buffer.writeUInt32LE(doneRowCountHi);
 
-  const asyncIterable = {
-    async*[Symbol.asyncIterator]() {
-      yield buffer.data;
-    }
-  };
-
-  var parser = StreamParser.parseTokens(asyncIterable, {}, { tdsVersion: '7_2' });
+  var parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
   return parser;
 }
 

--- a/test/unit/token/done-token-parser-test.js
+++ b/test/unit/token/done-token-parser-test.js
@@ -31,13 +31,13 @@ describe('Done Token Parser', () => {
     const doneRowCount = 2;
 
     const parser = parse(status, curCmd, doneRowCount);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) { // (4)
-
-      assert.isOk(!token.more);
-      assert.strictEqual(token.curCmd, curCmd);
-      assert.isOk(!token.rowCount);
-    }
+    assert.isOk(!token.more);
+    assert.strictEqual(token.curCmd, curCmd);
+    assert.isOk(!token.rowCount);
   });
 
   it('should more', async () => {
@@ -46,13 +46,13 @@ describe('Done Token Parser', () => {
     const doneRowCount = 2;
 
     const parser = parse(status, curCmd, doneRowCount);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) { // (4)
-
-      assert.isOk(token.more);
-      assert.strictEqual(token.curCmd, curCmd);
-      assert.isOk(!token.rowCount);
-    }
+    assert.isOk(token.more);
+    assert.strictEqual(token.curCmd, curCmd);
+    assert.isOk(!token.rowCount);
   });
 
   it('should done row count', async () => {
@@ -61,11 +61,12 @@ describe('Done Token Parser', () => {
     const doneRowCount = 0x1200000034;
 
     const parser = parse(status, curCmd, doneRowCount);
-    for await (let token of parser) { // (4)
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-      assert.isOk(!token.more);
-      assert.strictEqual(token.curCmd, 1);
-      assert.strictEqual(token.rowCount, doneRowCount);
-    }
+    assert.isOk(!token.more);
+    assert.strictEqual(token.curCmd, 1);
+    assert.strictEqual(token.rowCount, doneRowCount);
   });
 });

--- a/test/unit/token/env-change-token-parser-test.js
+++ b/test/unit/token/env-change-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Env Change Token Parser', () => {
-  it('should write to database', () => {
+  it('should write to database', async () => {
     const oldDb = 'old';
     const newDb = 'new';
 
@@ -18,16 +18,16 @@ describe('Env Change Token Parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([data], {}, {});
 
-    assert.strictEqual(token.type, 'DATABASE');
-    assert.strictEqual(token.oldValue, 'old');
-    assert.strictEqual(token.newValue, 'new');
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.type, 'DATABASE');
+      assert.strictEqual(token.oldValue, 'old');
+      assert.strictEqual(token.newValue, 'new');
+    }
   });
 
-  it('should write with correct packet size', () => {
+  it('should write with correct packet size', async () => {
     const oldSize = '1024';
     const newSize = '2048';
 
@@ -40,18 +40,19 @@ describe('Env Change Token Parser', () => {
     buffer.writeBVarchar(oldSize);
 
     const data = buffer.data;
-    data.writeUInt16LE(data.length - 3, 1);
+    data.writeUInt16LE(data.length - 3, 1)
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([], {}, {});
+    // const token = parser.read();
 
-    assert.strictEqual(token.type, 'PACKET_SIZE');
-    assert.strictEqual(token.oldValue, 1024);
-    assert.strictEqual(token.newValue, 2048);
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.type, 'PACKET_SIZE');
+      assert.strictEqual(token.oldValue, 1024);
+      assert.strictEqual(token.newValue, 2048);
+    }
   });
 
-  it('should be of bad type', () => {
+  it('should be of bad type', async () => {
     const buffer = new WritableTrackingBuffer(50, 'ucs2');
 
     buffer.writeUInt8(0xe3);
@@ -61,10 +62,10 @@ describe('Env Change Token Parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([data], {}, {});
 
-    assert.strictEqual(token, null);
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token, null);
+    }
   });
 });

--- a/test/unit/token/env-change-token-parser-test.js
+++ b/test/unit/token/env-change-token-parser-test.js
@@ -19,12 +19,12 @@ describe('Env Change Token Parser', () => {
     data.writeUInt16LE(data.length - 3, 1);
 
     const parser = StreamParser.parseTokens([data], {}, {});
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.type, 'DATABASE');
-      assert.strictEqual(token.oldValue, 'old');
-      assert.strictEqual(token.newValue, 'new');
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.type, 'DATABASE');
+    assert.strictEqual(token.oldValue, 'old');
+    assert.strictEqual(token.newValue, 'new');
   });
 
   it('should write with correct packet size', async () => {
@@ -40,16 +40,16 @@ describe('Env Change Token Parser', () => {
     buffer.writeBVarchar(oldSize);
 
     const data = buffer.data;
-    data.writeUInt16LE(data.length - 3, 1)
+    data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = StreamParser.parseTokens([], {}, {});
+    const parser = StreamParser.parseTokens([data], {}, {});
     // const token = parser.read();
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.type, 'PACKET_SIZE');
-      assert.strictEqual(token.oldValue, 1024);
-      assert.strictEqual(token.newValue, 2048);
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.type, 'PACKET_SIZE');
+    assert.strictEqual(token.oldValue, 1024);
+    assert.strictEqual(token.newValue, 2048);
   });
 
   it('should be of bad type', async () => {
@@ -63,9 +63,7 @@ describe('Env Change Token Parser', () => {
     data.writeUInt16LE(data.length - 3, 1);
 
     const parser = StreamParser.parseTokens([data], {}, {});
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token, null);
-    }
+    const result = await parser.next();
+    assert.isTrue(result.done);
   });
 });

--- a/test/unit/token/env-change-token-parser-test.js
+++ b/test/unit/token/env-change-token-parser-test.js
@@ -43,10 +43,10 @@ describe('Env Change Token Parser', () => {
     data.writeUInt16LE(data.length - 3, 1);
 
     const parser = StreamParser.parseTokens([data], {}, {});
-    // const token = parser.read();
     const result = await parser.next();
     assert.isFalse(result.done);
     const token = result.value;
+
     assert.strictEqual(token.type, 'PACKET_SIZE');
     assert.strictEqual(token.oldValue, 1024);
     assert.strictEqual(token.newValue, 2048);

--- a/test/unit/token/feature-ext-parser-test.js
+++ b/test/unit/token/feature-ext-parser-test.js
@@ -27,5 +27,6 @@ describe('Feature Ext Praser', () => {
     assert.isFalse(result.done);
     const token = result.value;
     assert.isOk(token.fedAuth.equals(Buffer.from('bc')));
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/feature-ext-parser-test.js
+++ b/test/unit/token/feature-ext-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Feature Ext Praser', () => {
-  it('should be fed authentication', () => {
+  it('should be fed authentication', async () => {
     const buffer = new WritableTrackingBuffer(50, 'ucs2');
 
     buffer.writeUInt8(0xAE); // FEATUREEXTACK token header
@@ -22,11 +22,10 @@ describe('Feature Ext Praser', () => {
 
     buffer.writeUInt8(0xFF); // terminator
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(buffer.data);
+    const parser = StreamParser.parseTokens([buffer.data], {}, {});
 
-    const token = parser.read();
-
-    assert.isOk(token.fedAuth.equals(Buffer.from('bc')));
+    for await (let token of parser) { // (4)
+      assert.isOk(token.fedAuth.equals(Buffer.from('bc')));
+    }
   });
 });

--- a/test/unit/token/feature-ext-parser-test.js
+++ b/test/unit/token/feature-ext-parser-test.js
@@ -23,9 +23,9 @@ describe('Feature Ext Praser', () => {
     buffer.writeUInt8(0xFF); // terminator
 
     const parser = StreamParser.parseTokens([buffer.data], {}, {});
-
-    for await (let token of parser) { // (4)
-      assert.isOk(token.fedAuth.equals(Buffer.from('bc')));
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.isOk(token.fedAuth.equals(Buffer.from('bc')));
   });
 });

--- a/test/unit/token/fedauth-info-parser-test.js
+++ b/test/unit/token/fedauth-info-parser-test.js
@@ -23,5 +23,7 @@ describe('Fedauth Info Parser', () => {
     const token = result.value;
     assert.strictEqual(token.stsurl, 'stsurl');
     assert.strictEqual(token.spn, 'spn');
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/fedauth-info-parser-test.js
+++ b/test/unit/token/fedauth-info-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Fedauth Info Parser', () => {
-  it('should contain fed auth info', () => {
+  it('should contain fed auth info', async () => {
     const buffer = new WritableTrackingBuffer(50, 'ucs-2');
     buffer.writeUInt8('0xEE');
     buffer.writeUInt32LE(40);
@@ -17,11 +17,11 @@ describe('Fedauth Info Parser', () => {
     buffer.writeString('spn');
     buffer.writeString('stsurl');
 
-    const parser = new Parser({ token() { } }, {}, {});
-    parser.write(buffer.data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([buffer.data], {}, {});
 
-    assert.strictEqual(token.stsurl, 'stsurl');
-    assert.strictEqual(token.spn, 'spn');
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.stsurl, 'stsurl');
+      assert.strictEqual(token.spn, 'spn');
+    }
   });
 });

--- a/test/unit/token/fedauth-info-parser-test.js
+++ b/test/unit/token/fedauth-info-parser-test.js
@@ -18,10 +18,10 @@ describe('Fedauth Info Parser', () => {
     buffer.writeString('stsurl');
 
     const parser = StreamParser.parseTokens([buffer.data], {}, {});
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.stsurl, 'stsurl');
-      assert.strictEqual(token.spn, 'spn');
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.stsurl, 'stsurl');
+    assert.strictEqual(token.spn, 'spn');
   });
 });

--- a/test/unit/token/infoerror-token-parser-test.js
+++ b/test/unit/token/infoerror-token-parser-test.js
@@ -28,14 +28,15 @@ describe('Infoerror token parser', () => {
     data.writeUInt16LE(data.length - 3, 1);
 
     const parser = StreamParser.parseTokens([data], {}, { tdsVersion: '7_2' });
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.number, number);
-      assert.strictEqual(token.state, state);
-      assert.strictEqual(token.class, class_);
-      assert.strictEqual(token.message, message);
-      assert.strictEqual(token.serverName, serverName);
-      assert.strictEqual(token.procName, procName);
-      assert.strictEqual(token.lineNumber, lineNumber);
-     }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.number, number);
+    assert.strictEqual(token.state, state);
+    assert.strictEqual(token.class, class_);
+    assert.strictEqual(token.message, message);
+    assert.strictEqual(token.serverName, serverName);
+    assert.strictEqual(token.procName, procName);
+    assert.strictEqual(token.lineNumber, lineNumber);
   });
 });

--- a/test/unit/token/infoerror-token-parser-test.js
+++ b/test/unit/token/infoerror-token-parser-test.js
@@ -38,5 +38,7 @@ describe('Infoerror token parser', () => {
     assert.strictEqual(token.serverName, serverName);
     assert.strictEqual(token.procName, procName);
     assert.strictEqual(token.lineNumber, lineNumber);
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/infoerror-token-parser-test.js
+++ b/test/unit/token/infoerror-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Infoerror token parser', () => {
-  it('should have correct info', () => {
+  it('should have correct info', async () => {
     const number = 3;
     const state = 4;
     const class_ = 5;
@@ -27,16 +27,15 @@ describe('Infoerror token parser', () => {
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(data);
-    const token = parser.read();
-
-    assert.strictEqual(token.number, number);
-    assert.strictEqual(token.state, state);
-    assert.strictEqual(token.class, class_);
-    assert.strictEqual(token.message, message);
-    assert.strictEqual(token.serverName, serverName);
-    assert.strictEqual(token.procName, procName);
-    assert.strictEqual(token.lineNumber, lineNumber);
+    const parser = StreamParser.parseTokens([data], {}, { tdsVersion: '7_2' });
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.number, number);
+      assert.strictEqual(token.state, state);
+      assert.strictEqual(token.class, class_);
+      assert.strictEqual(token.message, message);
+      assert.strictEqual(token.serverName, serverName);
+      assert.strictEqual(token.procName, procName);
+      assert.strictEqual(token.lineNumber, lineNumber);
+     }
   });
 });

--- a/test/unit/token/loginack-token-parser-test.js
+++ b/test/unit/token/loginack-token-parser-test.js
@@ -32,12 +32,12 @@ describe('Loginack Token Parser', () => {
 
     const parser = StreamParser.parseTokens([data], { tdsVersion: '7_2' });
 
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.interface, 'SQL_TSQL');
-      assert.strictEqual(token.tdsVersion, '7_2');
-      assert.strictEqual(token.progName, progName);
-      assert.deepEqual(token.progVersion, progVersion);
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.interface, 'SQL_TSQL');
+    assert.strictEqual(token.tdsVersion, '7_2');
+    assert.strictEqual(token.progName, progName);
+    assert.deepEqual(token.progVersion, progVersion);
   });
 });

--- a/test/unit/token/loginack-token-parser-test.js
+++ b/test/unit/token/loginack-token-parser-test.js
@@ -39,5 +39,7 @@ describe('Loginack Token Parser', () => {
     assert.strictEqual(token.tdsVersion, '7_2');
     assert.strictEqual(token.progName, progName);
     assert.deepEqual(token.progVersion, progVersion);
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/loginack-token-parser-test.js
+++ b/test/unit/token/loginack-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Loginack Token Parser', () => {
-  it('should have correct info', () => {
+  it('should have correct info', async () => {
     const interfaceType = 1;
     const version = 0x72090002;
     const progName = 'prog';
@@ -30,13 +30,14 @@ describe('Loginack Token Parser', () => {
     data.writeUInt16LE(data.length - 3, 1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(data);
-    const token = parser.read();
+    const parser = StreamParser.parseTokens([data], { tdsVersion: '7_2' });
 
-    assert.strictEqual(token.interface, 'SQL_TSQL');
-    assert.strictEqual(token.tdsVersion, '7_2');
-    assert.strictEqual(token.progName, progName);
-    assert.deepEqual(token.progVersion, progVersion);
+
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.interface, 'SQL_TSQL');
+      assert.strictEqual(token.tdsVersion, '7_2');
+      assert.strictEqual(token.progName, progName);
+      assert.deepEqual(token.progVersion, progVersion);
+    }
   });
 });

--- a/test/unit/token/order-token-parser-test.js
+++ b/test/unit/token/order-token-parser-test.js
@@ -16,11 +16,11 @@ describe('Order Token Parser', () => {
     // console.log(buffer.data)
 
     const parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.orderColumns.length, 1);
-      assert.strictEqual(token.orderColumns[0], column);
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.orderColumns.length, 1);
+    assert.strictEqual(token.orderColumns[0], column);
   });
 
   it('should have two columns', async () => {
@@ -38,11 +38,11 @@ describe('Order Token Parser', () => {
     // console.log(buffer.data)
 
     const parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
-
-    for await (let token of parser) { // (4)
-      assert.strictEqual(token.orderColumns.length, 2);
-      assert.strictEqual(token.orderColumns[0], column1);
-      assert.strictEqual(token.orderColumns[1], column2);
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.strictEqual(token.orderColumns.length, 2);
+    assert.strictEqual(token.orderColumns[0], column1);
+    assert.strictEqual(token.orderColumns[1], column2);
   });
 });

--- a/test/unit/token/order-token-parser-test.js
+++ b/test/unit/token/order-token-parser-test.js
@@ -20,6 +20,7 @@ describe('Order Token Parser', () => {
     assert.isFalse(result.done);
     const token = result.value;
     assert.strictEqual(token.orderColumns.length, 1);
+
     assert.strictEqual(token.orderColumns[0], column);
   });
 
@@ -44,5 +45,7 @@ describe('Order Token Parser', () => {
     assert.strictEqual(token.orderColumns.length, 2);
     assert.strictEqual(token.orderColumns[0], column1);
     assert.strictEqual(token.orderColumns[1], column2);
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/order-token-parser-test.js
+++ b/test/unit/token/order-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('Order Token Parser', () => {
-  it('should have one column', () => {
+  it('should have one column', async () => {
     const numberOfColumns = 1;
     const length = numberOfColumns * 2;
     const column = 3;
@@ -15,16 +15,15 @@ describe('Order Token Parser', () => {
     buffer.writeUInt16LE(column);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
 
-    assert.strictEqual(token.orderColumns.length, 1);
-    assert.strictEqual(token.orderColumns[0], column);
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.orderColumns.length, 1);
+      assert.strictEqual(token.orderColumns[0], column);
+    }
   });
 
-  it('should have two columns', () => {
+  it('should have two columns', async () => {
     const numberOfColumns = 2;
     const length = numberOfColumns * 2;
     const column1 = 3;
@@ -38,13 +37,12 @@ describe('Order Token Parser', () => {
     buffer.writeUInt16LE(column2);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, {}, { tdsVersion: '7_2' });
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parser = StreamParser.parseTokens([buffer.data], {}, { tdsVersion: '7_2' });
 
-    assert.strictEqual(token.orderColumns.length, 2);
-    assert.strictEqual(token.orderColumns[0], column1);
-    assert.strictEqual(token.orderColumns[1], column2);
+    for await (let token of parser) { // (4)
+      assert.strictEqual(token.orderColumns.length, 2);
+      assert.strictEqual(token.orderColumns[0], column1);
+      assert.strictEqual(token.orderColumns[1], column2);
+    }
   });
 });

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -32,6 +32,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write bigint', async () => {
@@ -54,6 +55,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 2);
     assert.strictEqual('1', token.columns[0].value);
     assert.strictEqual('9223372036854775807', token.columns[1].value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write real', async () => {
@@ -73,6 +75,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write float', async () => {
@@ -93,6 +96,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write Money', async () => {
@@ -134,6 +138,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns[3].value, value);
     assert.strictEqual(token.columns[4].value, value);
     assert.strictEqual(token.columns[5].value, valueLarge);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varchar without code page', async () => {
@@ -161,6 +166,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varchar with code page', async () => {
@@ -188,6 +194,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write nvarchar', async () => {
@@ -208,6 +215,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varBinary', async () => {
@@ -229,6 +237,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.deepEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write binary', async () => {
@@ -250,6 +259,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.deepEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varcharMaxNull', async () => {
@@ -278,6 +288,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, null);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varcharMaxUnkownLength', async () => {
@@ -312,6 +323,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varcharMaxKnownLength', async () => {
@@ -345,6 +357,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varcharmaxWithCodePage', async () => {
@@ -377,6 +390,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varcharMaxKnownLengthWrong', async () => {
@@ -412,6 +426,7 @@ describe('Row Token Parser', () => {
 
     assert.instanceOf(error, Error);
     assert.strictEqual(error.message, 'Partially Length-prefixed Bytes unmatched lengths : expected 7, but got 6 bytes');
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varBinaryMaxNull', async () => {
@@ -437,6 +452,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, null);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write varBinaryMaxUnknownLength', async () => {
@@ -467,6 +483,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns.length, 1);
     assert.deepEqual(token.columns[0].value, value);
     assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write intN', async () => {
@@ -611,6 +628,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual('100', token.columns[9].value);
     assert.strictEqual('1000', token.columns[10].value);
     assert.strictEqual('10000', token.columns[11].value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `false`', async () => {
@@ -657,6 +675,7 @@ describe('Row Token Parser', () => {
       '67452301-AB89-EFCD-0123-456789ABCDEF',
       token.columns[1].value
     );
+    assert.isTrue((await parser.next()).done);
 
   });
 
@@ -702,6 +721,7 @@ describe('Row Token Parser', () => {
       '67452301-ab89-efcd-0123-456789abcdef',
       token.columns[1].value
     );
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write floatN', async () => {
@@ -743,6 +763,7 @@ describe('Row Token Parser', () => {
     assert.strictEqual(token.columns[0].value, null);
     assert.strictEqual(9.5, token.columns[1].value);
     assert.strictEqual(9.5, token.columns[2].value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write datetime', async () => {
@@ -773,6 +794,7 @@ describe('Row Token Parser', () => {
 
       result = await parser.next();
       assert.isTrue(result.done);
+      assert.isTrue((await parser.next()).done);
     }
 
     {
@@ -790,6 +812,7 @@ describe('Row Token Parser', () => {
 
       result = await parser.next();
       assert.isTrue(result.done);
+      assert.isTrue((await parser.next()).done);
     }
   });
 
@@ -810,6 +833,7 @@ describe('Row Token Parser', () => {
     // console.log(token)
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, null);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write numeric4Bytes', async () => {
@@ -839,6 +863,7 @@ describe('Row Token Parser', () => {
     // console.log(token)
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write numeric4BytesNegative', async () => {
@@ -867,6 +892,7 @@ describe('Row Token Parser', () => {
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write numeric8Bytes', async () => {
@@ -898,6 +924,7 @@ describe('Row Token Parser', () => {
     // console.log(token)
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write numeric12Bytes', async () => {
@@ -929,6 +956,7 @@ describe('Row Token Parser', () => {
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write numeric16Bytes', async () => {
@@ -966,6 +994,7 @@ describe('Row Token Parser', () => {
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, value);
+    assert.isTrue((await parser.next()).done);
   });
 
   it('should write numericNull', async () => {
@@ -990,5 +1019,6 @@ describe('Row Token Parser', () => {
 
     assert.strictEqual(token.columns.length, 1);
     assert.strictEqual(token.columns[0].value, null);
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -24,15 +24,14 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0xd1);
     buffer.writeUInt32LE(value);
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write bigint', async () => {
@@ -47,15 +46,14 @@ describe('Row Token Parser', () => {
       Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 127])
     );
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 2);
-      assert.strictEqual('1', token.columns[0].value);
-      assert.strictEqual('9223372036854775807', token.columns[1].value);
-    }
+    assert.strictEqual(token.columns.length, 2);
+    assert.strictEqual('1', token.columns[0].value);
+    assert.strictEqual('9223372036854775807', token.columns[1].value);
   });
 
   it('should write real', async () => {
@@ -66,16 +64,15 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x18, 0x41]));
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     // console.log(token)
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write float', async () => {
@@ -88,15 +85,14 @@ describe('Row Token Parser', () => {
       Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x23, 0x40])
     );
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write Money', async () => {
@@ -126,19 +122,18 @@ describe('Row Token Parser', () => {
       Buffer.from([0x08, 0xf4, 0x10, 0x22, 0x11, 0xdc, 0x6a, 0xe9, 0x7d])
     );
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 6);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[1].value, value);
-      assert.strictEqual(token.columns[2].value, null);
-      assert.strictEqual(token.columns[3].value, value);
-      assert.strictEqual(token.columns[4].value, value);
-      assert.strictEqual(token.columns[5].value, valueLarge);
-    }
+    assert.strictEqual(token.columns.length, 6);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[1].value, value);
+    assert.strictEqual(token.columns[2].value, null);
+    assert.strictEqual(token.columns[3].value, value);
+    assert.strictEqual(token.columns[4].value, value);
+    assert.strictEqual(token.columns[5].value, valueLarge);
   });
 
   it('should write varchar without code page', async () => {
@@ -158,15 +153,14 @@ describe('Row Token Parser', () => {
     // console.log(buffer.data)
 
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varchar with code page', async () => {
@@ -186,15 +180,14 @@ describe('Row Token Parser', () => {
     // console.log(buffer.data)
 
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write nvarchar', async () => {
@@ -207,15 +200,14 @@ describe('Row Token Parser', () => {
     buffer.writeString(value);
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varBinary', async () => {
@@ -228,16 +220,15 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value));
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
 
-      assert.strictEqual(token.columns.length, 1);
-      assert.deepEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.deepEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write binary', async () => {
@@ -250,16 +241,15 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value));
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
 
-      assert.strictEqual(token.columns.length, 1);
-      assert.deepEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.deepEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxNull', async () => {
@@ -280,16 +270,14 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, null);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, null);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxUnkownLength', async () => {
@@ -316,16 +304,14 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxKnownLength', async () => {
@@ -351,16 +337,14 @@ describe('Row Token Parser', () => {
     // console.log(buffer.data)
 
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
-
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharmaxWithCodePage', async () => {
@@ -385,23 +369,24 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varcharMaxKnownLengthWrong', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
-        dataLength: 65535
+        dataLength: 65535,
+        collation: {
+          codepage: 'WINDOWS-1252'
+        }
       }
     ];
     const value = 'abcdef';
@@ -416,18 +401,17 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
 
-    for await (let token of parser) {
-      try {
-        assert.isOk(false);
-      } catch {
-        //???
-      }
+    let error;
+    try {
+      await parser.next();
+    } catch (err) {
+      error = err;
     }
 
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Partially Length-prefixed Bytes unmatched lengths : expected 7, but got 6 bytes');
   });
 
   it('should write varBinaryMaxNull', async () => {
@@ -445,17 +429,14 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, null);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
-
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, null);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write varBinaryMaxUnknownLength', async () => {
@@ -478,15 +459,14 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value.slice(2, 4)));
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.deepEqual(token.columns[0].value, value);
-      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.deepEqual(token.columns[0].value, value);
+    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
   });
 
   it('should write intN', async () => {
@@ -613,26 +593,24 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 12);
-      assert.strictEqual(token.columns[0].value, null);
-      assert.strictEqual('0', token.columns[1].value);
-      assert.strictEqual('1', token.columns[2].value);
-      assert.strictEqual('-1', token.columns[3].value);
-      assert.strictEqual('2', token.columns[4].value);
-      assert.strictEqual('-2', token.columns[5].value);
-      assert.strictEqual('9223372036854775807', token.columns[6].value);
-      assert.strictEqual('-9223372036854775808', token.columns[7].value);
-      assert.strictEqual('10', token.columns[8].value);
-      assert.strictEqual('100', token.columns[9].value);
-      assert.strictEqual('1000', token.columns[10].value);
-      assert.strictEqual('10000', token.columns[11].value);
-    }
+    assert.strictEqual(token.columns.length, 12);
+    assert.strictEqual(token.columns[0].value, null);
+    assert.strictEqual('0', token.columns[1].value);
+    assert.strictEqual('1', token.columns[2].value);
+    assert.strictEqual('-1', token.columns[3].value);
+    assert.strictEqual('2', token.columns[4].value);
+    assert.strictEqual('-2', token.columns[5].value);
+    assert.strictEqual('9223372036854775807', token.columns[6].value);
+    assert.strictEqual('-9223372036854775808', token.columns[7].value);
+    assert.strictEqual('10', token.columns[8].value);
+    assert.strictEqual('100', token.columns[9].value);
+    assert.strictEqual('1000', token.columns[10].value);
+    assert.strictEqual('10000', token.columns[11].value);
   });
 
   it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `false`', async () => {
@@ -668,18 +646,17 @@ describe('Row Token Parser', () => {
     // console.log(buffer.data)
 
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], { lowerCaseGuids: false }, options, parserObj)
+    const parser = Parser.parseTokens([buffer.data], { lowerCaseGuids: false }, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 2);
-      assert.strictEqual(token.columns[0].value, null);
-      assert.deepEqual(
-        '67452301-AB89-EFCD-0123-456789ABCDEF',
-        token.columns[1].value
-      );
-    }
+    assert.strictEqual(token.columns.length, 2);
+    assert.strictEqual(token.columns[0].value, null);
+    assert.deepEqual(
+      '67452301-AB89-EFCD-0123-456789ABCDEF',
+      token.columns[1].value
+    );
 
   });
 
@@ -714,20 +691,17 @@ describe('Row Token Parser', () => {
       ])
     );
 
+    const parser = Parser.parseTokens([buffer.data], {}, { ...options, lowerCaseGuids: true }, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], Object.assign({ lowerCaseGuids: true }), options, parserObj);
-
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 2);
-      assert.strictEqual(token.columns[0].value, null);
-      assert.deepEqual(
-        '67452301-ab89-efcd-0123-456789abcdef',
-        token.columns[1].value
-      );
-    }
+    assert.strictEqual(token.columns.length, 2);
+    assert.strictEqual(token.columns[0].value, null);
+    assert.deepEqual(
+      '67452301-ab89-efcd-0123-456789abcdef',
+      token.columns[1].value
+    );
   });
 
   it('should write floatN', async () => {
@@ -760,17 +734,15 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-
-      assert.strictEqual(token.columns.length, 3);
-      assert.strictEqual(token.columns[0].value, null);
-      assert.strictEqual(9.5, token.columns[1].value);
-      assert.strictEqual(9.5, token.columns[2].value);
-    }
+    assert.strictEqual(token.columns.length, 3);
+    assert.strictEqual(token.columns[0].value, null);
+    assert.strictEqual(9.5, token.columns[1].value);
+    assert.strictEqual(9.5, token.columns[2].value);
   });
 
   it('should write datetime', async () => {
@@ -786,39 +758,39 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(threeHundredthsOfSecond);
     // console.log(buffer)
 
+    {
+      const parser = Parser.parseTokens([buffer.data], {}, { ...options, useUTC: false }, colMetadata);
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, { useUTC: false }, parserObj);
-    const parser2 = Parser.parseTokens([buffer.data], {}, { useUTC: true }, parserObj);
+      let result = await parser.next();
+      assert.isFalse(result.done);
 
-    // for await (let token of parser) {
-    //   assert.strictEqual(token.columns.length, 1);
-    //   assert.strictEqual(
-    //     token.columns[0].value.getTime(),
-    //     new Date('January 3, 1900 00:00:45').getTime()
-    //   );
-    // }
+      const token = result.value;
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(
+        token.columns[0].value.getTime(),
+        new Date('January 3, 1900 00:00:45').getTime()
+      );
 
-    for await (let token of parser2) {
+      result = await parser.next();
+      assert.isTrue(result.done);
+    }
+
+    {
+      const parser = Parser.parseTokens([buffer.data], {}, { ...options, useUTC: true }, colMetadata);
+
+      let result = await parser.next();
+      assert.isFalse(result.done);
+
+      const token = result.value;
       assert.strictEqual(token.columns.length, 1);
       assert.strictEqual(
         token.columns[0].value.getTime(),
         new Date('January 3, 1900 00:00:45 GMT').getTime()
       );
+
+      result = await parser.next();
+      assert.isTrue(result.done);
     }
-
-    // parser = new Parser({ token() { } }, { useUTC: true });
-    // parser.colMetadata = colMetadata;
-    // parser.write(buffer.data);
-    // token = parser.read();
-    // // console.log(token)
-
-    // assert.strictEqual(token.columns.length, 1);
-    // assert.strictEqual(
-    //   token.columns[0].value.getTime(),
-    //   new Date('January 3, 1900 00:00:45 GMT').getTime()
-    // );
   });
 
   it('should write datetimeN', async () => {
@@ -830,15 +802,14 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     // console.log(token)
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, null);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, null);
   });
 
   it('should write numeric4Bytes', async () => {
@@ -860,16 +831,14 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(93);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
     // console.log(token)
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-    }
-
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
   });
 
   it('should write numeric4BytesNegative', async () => {
@@ -891,14 +860,13 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(93);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
   });
 
   it('should write numeric8Bytes', async () => {
@@ -921,17 +889,15 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
 
 
     // console.log(token)
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-    }
-
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
   });
 
   it('should write numeric12Bytes', async () => {
@@ -955,16 +921,14 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
     // console.log(token)
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-    }
-
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
   });
 
   it('should write numeric16Bytes', async () => {
@@ -994,15 +958,14 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
     // console.log(token)
+    assert.isFalse(result.done);
+    const token = result.value;
 
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, value);
-    }
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, value);
   });
 
   it('should write numericNull', async () => {
@@ -1019,13 +982,13 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0);
     // console.log(buffer)
 
-    const parserObj = new Parser({}, options);
-    parserObj.colMetadata = colMetadata;
-    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+    const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+    const result = await parser.next();
     // console.log(token)
-    for await (let token of parser) {
-      assert.strictEqual(token.columns.length, 1);
-      assert.strictEqual(token.columns[0].value, null);
-    }
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.strictEqual(token.columns.length, 1);
+    assert.strictEqual(token.columns[0].value, null);
   });
 });

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -16,7 +16,7 @@ const options = {
 };
 
 describe('Row Token Parser', () => {
-  it('should write int', () => {
+  it('should write int', async () => {
     const colMetadata = [{ type: dataTypeByName.Int }];
     const value = 3;
 
@@ -24,18 +24,18 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0xd1);
     buffer.writeUInt32LE(value);
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    parser.write(buffer.data);
-    const token = parser.read();
-
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write bigint', () => {
+  it('should write bigint', async () => {
     const colMetadata = [
       { type: dataTypeByName.BigInt },
       { type: dataTypeByName.BigInt }
@@ -47,19 +47,18 @@ describe('Row Token Parser', () => {
       Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 127])
     );
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
-
-    assert.strictEqual(token.columns.length, 2);
-    assert.strictEqual('1', token.columns[0].value);
-    assert.strictEqual('9223372036854775807', token.columns[1].value);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 2);
+      assert.strictEqual('1', token.columns[0].value);
+      assert.strictEqual('9223372036854775807', token.columns[1].value);
+    }
   });
 
-  it('should write real', () => {
+  it('should write real', async () => {
     const colMetadata = [{ type: dataTypeByName.Real }];
     const value = 9.5;
 
@@ -67,18 +66,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x18, 0x41]));
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    // console.log(token)
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write float', () => {
+  it('should write float', async () => {
     const colMetadata = [{ type: dataTypeByName.Float }];
     const value = 9.5;
 
@@ -88,18 +88,18 @@ describe('Row Token Parser', () => {
       Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x23, 0x40])
     );
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write Money', () => {
+  it('should write Money', async () => {
     const colMetadata = [
       { type: SmallMoney },
       { type: Money },
@@ -126,22 +126,22 @@ describe('Row Token Parser', () => {
       Buffer.from([0x08, 0xf4, 0x10, 0x22, 0x11, 0xdc, 0x6a, 0xe9, 0x7d])
     );
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 6);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[1].value, value);
-    assert.strictEqual(token.columns[2].value, null);
-    assert.strictEqual(token.columns[3].value, value);
-    assert.strictEqual(token.columns[4].value, value);
-    assert.strictEqual(token.columns[5].value, valueLarge);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 6);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[1].value, value);
+      assert.strictEqual(token.columns[2].value, null);
+      assert.strictEqual(token.columns[3].value, value);
+      assert.strictEqual(token.columns[4].value, value);
+      assert.strictEqual(token.columns[5].value, valueLarge);
+    }
   });
 
-  it('should write varchar without code page', () => {
+  it('should write varchar without code page', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -157,18 +157,19 @@ describe('Row Token Parser', () => {
     buffer.writeUsVarchar(value);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write varchar with code page', () => {
+  it('should write varchar with code page', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -184,18 +185,19 @@ describe('Row Token Parser', () => {
     buffer.writeUsVarchar(value);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write nvarchar', () => {
+  it('should write nvarchar', async () => {
     const colMetadata = [{ type: dataTypeByName.NVarChar }];
     const value = 'abc';
 
@@ -205,18 +207,18 @@ describe('Row Token Parser', () => {
     buffer.writeString(value);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write varBinary', () => {
+  it('should write varBinary', async () => {
     const colMetadata = [{ type: dataTypeByName.VarBinary }];
     const value = Buffer.from([0x12, 0x34]);
 
@@ -226,18 +228,19 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value));
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.deepEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 1);
+      assert.deepEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write binary', () => {
+  it('should write binary', async () => {
     const colMetadata = [{ type: dataTypeByName.Binary }];
     const value = Buffer.from([0x12, 0x34]);
 
@@ -247,18 +250,19 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value));
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.deepEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 1);
+      assert.deepEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write varcharMaxNull', () => {
+  it('should write varcharMaxNull', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -276,18 +280,19 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, null);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write varcharMaxUnkownLength', () => {
+  it('should write varcharMaxUnkownLength', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -311,18 +316,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write varcharMaxKnownLength', () => {
+  it('should write varcharMaxKnownLength', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -344,18 +350,20 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
+
   });
 
-  it('should write varcharmaxWithCodePage', () => {
+  it('should write varcharmaxWithCodePage', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -377,18 +385,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write varcharMaxKnownLengthWrong', () => {
+  it('should write varcharMaxKnownLengthWrong', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarChar,
@@ -407,18 +416,21 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
-    try {
-      const parser = new Parser({ token() { } }, options);
-      parser.colMetadata = colMetadata;
-      parser.write(buffer.data);
-      parser.read();
-      assert.isOk(false);
-    } catch {
-      // ???
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
+
+    for await (let token of parser) {
+      try {
+        assert.isOk(false);
+      } catch {
+        //???
+      }
     }
+
   });
 
-  it('should write varBinaryMaxNull', () => {
+  it('should write varBinaryMaxNull', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarBinary,
@@ -433,18 +445,20 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, null);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
+
   });
 
-  it('should write varBinaryMaxUnknownLength', () => {
+  it('should write varBinaryMaxUnknownLength', async () => {
     const colMetadata = [
       {
         type: dataTypeByName.VarBinary,
@@ -464,19 +478,18 @@ describe('Row Token Parser', () => {
     buffer.writeBuffer(Buffer.from(value.slice(2, 4)));
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
-
-    assert.strictEqual(token.columns.length, 1);
-    assert.deepEqual(token.columns[0].value, value);
-    assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.deepEqual(token.columns[0].value, value);
+      assert.strictEqual(token.columns[0].metadata, colMetadata[0]);
+    }
   });
 
-  it('should write intN', () => {
+  it('should write intN', async () => {
     const colMetadata = [
       { type: IntN },
       { type: IntN },
@@ -600,28 +613,29 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 12);
-    assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual('0', token.columns[1].value);
-    assert.strictEqual('1', token.columns[2].value);
-    assert.strictEqual('-1', token.columns[3].value);
-    assert.strictEqual('2', token.columns[4].value);
-    assert.strictEqual('-2', token.columns[5].value);
-    assert.strictEqual('9223372036854775807', token.columns[6].value);
-    assert.strictEqual('-9223372036854775808', token.columns[7].value);
-    assert.strictEqual('10', token.columns[8].value);
-    assert.strictEqual('100', token.columns[9].value);
-    assert.strictEqual('1000', token.columns[10].value);
-    assert.strictEqual('10000', token.columns[11].value);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 12);
+      assert.strictEqual(token.columns[0].value, null);
+      assert.strictEqual('0', token.columns[1].value);
+      assert.strictEqual('1', token.columns[2].value);
+      assert.strictEqual('-1', token.columns[3].value);
+      assert.strictEqual('2', token.columns[4].value);
+      assert.strictEqual('-2', token.columns[5].value);
+      assert.strictEqual('9223372036854775807', token.columns[6].value);
+      assert.strictEqual('-9223372036854775808', token.columns[7].value);
+      assert.strictEqual('10', token.columns[8].value);
+      assert.strictEqual('100', token.columns[9].value);
+      assert.strictEqual('1000', token.columns[10].value);
+      assert.strictEqual('10000', token.columns[11].value);
+    }
   });
 
-  it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `false`', () => {
+  it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `false`', async () => {
     const colMetadata = [
       { type: dataTypeByName.UniqueIdentifier },
       { type: dataTypeByName.UniqueIdentifier }
@@ -653,21 +667,23 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() {} }, Object.assign({ lowerCaseGuids: false }, options));
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    var token = parser.read();
-    // console.log(token)
 
-    assert.strictEqual(token.columns.length, 2);
-    assert.strictEqual(token.columns[0].value, null);
-    assert.deepEqual(
-      '67452301-AB89-EFCD-0123-456789ABCDEF',
-      token.columns[1].value
-    );
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], { lowerCaseGuids: false }, options, parserObj)
+
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 2);
+      assert.strictEqual(token.columns[0].value, null);
+      assert.deepEqual(
+        '67452301-AB89-EFCD-0123-456789ABCDEF',
+        token.columns[1].value
+      );
+    }
+
   });
 
-  it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `true`', () => {
+  it('parsing a UniqueIdentifier value when `lowerCaseGuids` option is `true`', async () => {
     var colMetadata = [
       { type: dataTypeByName.UniqueIdentifier },
       { type: dataTypeByName.UniqueIdentifier }
@@ -697,22 +713,24 @@ describe('Row Token Parser', () => {
         0xef
       ])
     );
-    // console.log(buffer.data)
-    const parser = new Parser({ token() {} }, Object.assign({ lowerCaseGuids: true }, options));
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
 
-    assert.strictEqual(token.columns.length, 2);
-    assert.strictEqual(token.columns[0].value, null);
-    assert.deepEqual(
-      '67452301-ab89-efcd-0123-456789abcdef',
-      token.columns[1].value
-    );
+
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], Object.assign({ lowerCaseGuids: true }), options, parserObj);
+
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 2);
+      assert.strictEqual(token.columns[0].value, null);
+      assert.deepEqual(
+        '67452301-ab89-efcd-0123-456789abcdef',
+        token.columns[1].value
+      );
+    }
   });
 
-  it('should write floatN', () => {
+  it('should write floatN', async () => {
     const colMetadata = [
       { type: FloatN },
       { type: FloatN },
@@ -742,19 +760,20 @@ describe('Row Token Parser', () => {
     );
     // console.log(buffer.data)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 3);
-    assert.strictEqual(token.columns[0].value, null);
-    assert.strictEqual(9.5, token.columns[1].value);
-    assert.strictEqual(9.5, token.columns[2].value);
+    for await (let token of parser) {
+
+      assert.strictEqual(token.columns.length, 3);
+      assert.strictEqual(token.columns[0].value, null);
+      assert.strictEqual(9.5, token.columns[1].value);
+      assert.strictEqual(9.5, token.columns[2].value);
+    }
   });
 
-  it('should write datetime', () => {
+  it('should write datetime', async () => {
     const colMetadata = [{ type: dataTypeByName.DateTime }];
 
     const days = 2; // 3rd January 1900
@@ -767,32 +786,42 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(threeHundredthsOfSecond);
     // console.log(buffer)
 
-    let parser = new Parser({ token() { } }, { useUTC: false });
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    let token = parser.read();
-    // console.log(token)
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(
-      token.columns[0].value.getTime(),
-      new Date('January 3, 1900 00:00:45').getTime()
-    );
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, { useUTC: false }, parserObj);
+    const parser2 = Parser.parseTokens([buffer.data], {}, { useUTC: true }, parserObj);
 
-    parser = new Parser({ token() { } }, { useUTC: true });
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    token = parser.read();
-    // console.log(token)
+    // for await (let token of parser) {
+    //   assert.strictEqual(token.columns.length, 1);
+    //   assert.strictEqual(
+    //     token.columns[0].value.getTime(),
+    //     new Date('January 3, 1900 00:00:45').getTime()
+    //   );
+    // }
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(
-      token.columns[0].value.getTime(),
-      new Date('January 3, 1900 00:00:45 GMT').getTime()
-    );
+    for await (let token of parser2) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(
+        token.columns[0].value.getTime(),
+        new Date('January 3, 1900 00:00:45 GMT').getTime()
+      );
+    }
+
+    // parser = new Parser({ token() { } }, { useUTC: true });
+    // parser.colMetadata = colMetadata;
+    // parser.write(buffer.data);
+    // token = parser.read();
+    // // console.log(token)
+
+    // assert.strictEqual(token.columns.length, 1);
+    // assert.strictEqual(
+    //   token.columns[0].value.getTime(),
+    //   new Date('January 3, 1900 00:00:45 GMT').getTime()
+    // );
   });
 
-  it('should write datetimeN', () => {
+  it('should write datetimeN', async () => {
     const colMetadata = [{ type: DateTimeN }];
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
@@ -801,17 +830,18 @@ describe('Row Token Parser', () => {
     buffer.writeUInt8(0);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, null);
+    // console.log(token)
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, null);
+    }
   });
 
-  it('should write numeric4Bytes', () => {
+  it('should write numeric4Bytes', async () => {
     const colMetadata = [
       {
         type: NumericN,
@@ -830,17 +860,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(93);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
+    // console.log(token)
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+    }
+
   });
 
-  it('should write numeric4BytesNegative', () => {
+  it('should write numeric4BytesNegative', async () => {
     const colMetadata = [
       {
         type: NumericN,
@@ -859,17 +891,17 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(93);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+    }
   });
 
-  it('should write numeric8Bytes', () => {
+  it('should write numeric8Bytes', async () => {
     const colMetadata = [
       {
         type: NumericN,
@@ -889,17 +921,20 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
-    // console.log(token)
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
+
+    // console.log(token)
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+    }
+
   });
 
-  it('should write numeric12Bytes', () => {
+  it('should write numeric12Bytes', async () => {
     const colMetadata = [
       {
         type: NumericN,
@@ -920,17 +955,19 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
     // console.log(token)
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+    }
+
   });
 
-  it('should write numeric16Bytes', () => {
+  it('should write numeric16Bytes', async () => {
     const colMetadata = [
       {
         type: NumericN,
@@ -957,17 +994,18 @@ describe('Row Token Parser', () => {
     buffer.writeUInt32LE(1);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
     // console.log(token)
 
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, value);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, value);
+    }
   });
 
-  it('should write numericNull', () => {
+  it('should write numericNull', async () => {
     const colMetadata = [
       {
         type: NumericN,
@@ -978,17 +1016,16 @@ describe('Row Token Parser', () => {
 
     const buffer = new WritableTrackingBuffer(0, 'ucs2');
     buffer.writeUInt8(0xd1);
-
     buffer.writeUInt8(0);
     // console.log(buffer)
 
-    const parser = new Parser({ token() { } }, options);
-    parser.colMetadata = colMetadata;
-    parser.write(buffer.data);
-    const token = parser.read();
+    const parserObj = new Parser({}, options);
+    parserObj.colMetadata = colMetadata;
+    const parser = Parser.parseTokens([buffer.data], {}, options, parserObj);
     // console.log(token)
-
-    assert.strictEqual(token.columns.length, 1);
-    assert.strictEqual(token.columns[0].value, null);
+    for await (let token of parser) {
+      assert.strictEqual(token.columns.length, 1);
+      assert.strictEqual(token.columns[0].value, null);
+    }
   });
 });

--- a/test/unit/token/sspi-token-parser-test.js
+++ b/test/unit/token/sspi-token-parser-test.js
@@ -49,5 +49,7 @@ describe('sspi token parser', () => {
     assert.deepEqual(token.ntlmpacket, expected);
     // Skip token (first byte) and length of VarByte (2 bytes).
     assert.isOk(token.ntlmpacketBuffer.equals(data.slice(3)));
+
+    assert.isTrue((await parser.next()).done);
   });
 });

--- a/test/unit/token/sspi-token-parser-test.js
+++ b/test/unit/token/sspi-token-parser-test.js
@@ -43,10 +43,11 @@ describe('sspi token parser', () => {
       domain: 'domain',
       target: Buffer.from([0x00, 0xab, 0xcd, 0xef])
     };
-    for await (let token of parser) { // (4)
-      assert.deepEqual(token.ntlmpacket, expected);
-      // Skip token (first byte) and length of VarByte (2 bytes).
-      assert.isOk(token.ntlmpacketBuffer.equals(data.slice(3)));
-    }
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+    assert.deepEqual(token.ntlmpacket, expected);
+    // Skip token (first byte) and length of VarByte (2 bytes).
+    assert.isOk(token.ntlmpacketBuffer.equals(data.slice(3)));
   });
 });

--- a/test/unit/token/sspi-token-parser-test.js
+++ b/test/unit/token/sspi-token-parser-test.js
@@ -1,9 +1,9 @@
-const Parser = require('../../../src/token/stream-parser');
+const StreamParser = require('../../../src/token/stream-parser');
 const WriteBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
 
 describe('sspi token parser', () => {
-  it('should parse challenge', () => {
+  it('should parse challenge', async () => {
     const source = new WriteBuffer(68);
     source.writeUInt8(0xed);
     source.writeUInt16LE(0);
@@ -22,11 +22,10 @@ describe('sspi token parser', () => {
     source.writeString('domain', 'ucs2'); // domain
     source.writeInt32BE(11259375); // target == 'abcdef'
 
-    const parser = new Parser({ token() { } }, {}, {});
     const data = source.data;
     data.writeUInt16LE(data.length - 3, 1);
-    parser.write(data);
-    const challenge = parser.read();
+    const parser = StreamParser.parseTokens([data], {}, { tdsVersion: '7_2' });
+
 
     const expected = {
       magic: 'NTLMSSP\0',
@@ -44,10 +43,10 @@ describe('sspi token parser', () => {
       domain: 'domain',
       target: Buffer.from([0x00, 0xab, 0xcd, 0xef])
     };
-
-    assert.deepEqual(challenge.ntlmpacket, expected);
-
-    // Skip token (first byte) and length of VarByte (2 bytes).
-    assert.isOk(challenge.ntlmpacketBuffer.equals(data.slice(3)));
+    for await (let token of parser) { // (4)
+      assert.deepEqual(token.ntlmpacket, expected);
+      // Skip token (first byte) and length of VarByte (2 bytes).
+      assert.isOk(token.ntlmpacketBuffer.equals(data.slice(3)));
+    }
   });
 });

--- a/test/unit/token/token-stream-parser-test.js
+++ b/test/unit/token/token-stream-parser-test.js
@@ -29,28 +29,30 @@ describe('Token Stream Parser', () => {
   it('should envChange', (done) => {
     var buffer = createDbChangeBuffer();
 
-    var parser = new Parser(debug);
+    var parser = new Parser([buffer], debug);
     parser.on('databaseChange', function(event) {
       assert.isOk(event);
     });
 
-    parser.write(buffer);
-    parser.end();
+    // parser.end();
 
     parser.on('end', done);
   });
 
   it('should split token across buffers', (done) => {
     var buffer = createDbChangeBuffer();
+    
+    const asyncIterable = {
+      async*[Symbol.asyncIterator]() {
+        yield buffer.slice(0, 6);
+        yield buffer.slice(6);
+      }
+    };
+    var parser = new Parser(asyncIterable, debug);
 
-    var parser = new Parser(debug);
     parser.on('databaseChange', function(event) {
       assert.isOk(event);
     });
-
-    parser.write(buffer.slice(0, 6));
-    parser.write(buffer.slice(6));
-    parser.end();
 
     parser.on('end', done);
   });

--- a/test/unit/token/token-stream-parser-test.js
+++ b/test/unit/token/token-stream-parser-test.js
@@ -41,14 +41,8 @@ describe('Token Stream Parser', () => {
 
   it('should split token across buffers', (done) => {
     var buffer = createDbChangeBuffer();
-    
-    const asyncIterable = {
-      async*[Symbol.asyncIterator]() {
-        yield buffer.slice(0, 6);
-        yield buffer.slice(6);
-      }
-    };
-    var parser = new Parser(asyncIterable, debug);
+
+    var parser = new Parser([buffer.slice(0, 6), buffer.slice(6)], debug);
 
     parser.on('databaseChange', function(event) {
       assert.isOk(event);


### PR DESCRIPTION
This PR refactors current unit/token tests to call the updated stream-parser function properly. 
- There are currently 3 failing tests (all from row-stream-parser-test.js)
- For `token/stream-parser.ts`, I've added 
  - An overall `try catch` for the whole `*parseTokens` function
  - A `yield null` on line 101 (to keep the behavior consistent with master)
  - An optional premade `Parser` object in the `*parseTokens` function to get row-token-parser tests working properly