### PR TITLE
Fix maximum call stack errors when parsing query results

### DIFF
--- a/test/integration/request/max-columns-test.ts
+++ b/test/integration/request/max-columns-test.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import { homedir } from 'os';
+
+import Connection from '../../../src/connection';
+import Request from '../../../src/request';
+
+const config = JSON.parse(
+  fs.readFileSync(homedir() + '/.tedious/test-connection.json', 'utf8')
+).config;
+config.options.textsize = 8 * 1024;
+
+const debug = false;
+if (debug) {
+  config.options.debug = {
+    packet: true,
+    data: true,
+    payload: true,
+    token: true,
+    log: true,
+  };
+} else {
+  config.options.debug = {};
+}
+
+config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
+
+describe('Request', function() {
+  let connection: Connection;
+
+  beforeEach(function(done) {
+    connection = new Connection(config);
+
+    connection.on('errorMessage', function(error) {
+      console.log(`${error.number} : ${error.message}`);
+    });
+
+    if (debug) {
+      connection.on('debug', function(message) {
+        console.log(message);
+      });
+    }
+
+    connection.connect(done);
+  });
+
+  afterEach(function(done) {
+    if (!connection.closed) {
+      connection.on('end', done);
+      connection.close();
+    } else {
+      done();
+    }
+  });
+
+  it('should succesfully allow selecting all columns from a table with the maximum number of columns', function(done) {
+    const columnDefintions = [];
+    for (let i = 0; i < 1024; i++) {
+      columnDefintions.push('[' + i + '] binary(4)');
+    }
+
+    const createTableSql = 'CREATE TABLE #temp (' + columnDefintions.join(', ') + ')';
+
+    const request = new Request(createTableSql, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      const request = new Request('SELECT * FROM #temp', (err) => {
+        if (err) {
+          return done(err);
+        }
+
+        const sql = 'INSERT INTO #temp VALUES ' +
+          '(' + (new Array(1024).fill('0x1234').join(', ')) + '), ' +
+          // The below row data is set to trigger a NBC Row Token (decided by the SQL Server that may be subject to possible change without notice)
+          '(' + (new Array(64 + 32).fill('NULL').join(', ')) + ', ' + (new Array(512 + 256 + 128 + 32).fill('0x1234').join(', ')) + ')';
+
+        const request = new Request(sql, (err) => {
+          if (err) {
+            return done(err);
+          }
+
+          const request = new Request('SELECT * FROM #temp', done);
+          connection.execSql(request);
+        });
+
+        connection.execSql(request);
+      });
+
+      connection.execSql(request);
+    });
+
+    connection.execSqlBatch(request);
+  });
+});

--- a/test/unit/token/nbcrow-token-parser-test.js
+++ b/test/unit/token/nbcrow-token-parser-test.js
@@ -1,0 +1,46 @@
+const assert = require('chai').assert;
+
+const Parser = require('../../../src/token/stream-parser');
+const dataTypeByName = require('../../../src/data-type').typeByName;
+const WritableTrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
+const options = {
+  useUTC: false,
+  tdsVersion: '7_2'
+};
+
+describe('NBCRow Token Parser', function() {
+  describe('parsing a row with many columns', function() {
+    it('should parse them correctly', async function() {
+      const buffer = new WritableTrackingBuffer(0, 'ascii');
+      buffer.writeUInt8(0xd2);
+
+      // Write the null bitmap
+      buffer.writeBuffer(Buffer.alloc(1024 / 8, 0));
+
+      const colMetadata = [];
+      for (let i = 0; i < 1024; i += 1) {
+        colMetadata.push({
+          type: dataTypeByName.VarChar,
+          collation: {
+            codepage: undefined
+          }
+        });
+        buffer.writeUsVarchar(i.toString());
+      }
+
+      const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+      const result = await parser.next();
+      assert.isFalse(result.done);
+      const token = result.value;
+
+      assert.strictEqual(token.columns.length, 1024);
+
+      for (let i = 0; i < 1024; i += 1) {
+        assert.strictEqual(token.columns[i].value, i.toString());
+        assert.strictEqual(token.columns[i].metadata, colMetadata[i]);
+      }
+
+      assert.isTrue((await parser.next()).done);
+    });
+  });
+});

--- a/test/unit/token/row-token-parser-test.js
+++ b/test/unit/token/row-token-parser-test.js
@@ -16,6 +16,38 @@ const options = {
 };
 
 describe('Row Token Parser', () => {
+  describe('parsing a row with many columns', function() {
+    it('should parse them correctly', async function() {
+      const buffer = new WritableTrackingBuffer(0, 'ascii');
+      buffer.writeUInt8(0xd1);
+
+      const colMetadata = [];
+      for (let i = 0; i < 1024; i += 1) {
+        colMetadata.push({
+          type: dataTypeByName.VarChar,
+          collation: {
+            codepage: undefined
+          }
+        });
+        buffer.writeUsVarchar(i.toString());
+      }
+
+      const parser = Parser.parseTokens([buffer.data], {}, options, colMetadata);
+      const result = await parser.next();
+      assert.isFalse(result.done);
+      const token = result.value;
+
+      assert.strictEqual(token.columns.length, 1024);
+
+      for (let i = 0; i < 1024; i += 1) {
+        assert.strictEqual(token.columns[i].value, i.toString());
+        assert.strictEqual(token.columns[i].metadata, colMetadata[i]);
+      }
+
+      assert.isTrue((await parser.next()).done);
+    });
+  });
+
   it('should write int', async () => {
     const colMetadata = [{ type: dataTypeByName.Int }];
     const value = 3;


### PR DESCRIPTION
This reworks the `COLMETADATA`, `ROW` and `NBCROW` token parsing logic to parse incoming data in a fashion that does not grow the call stack in relation to the incoming packet size.

Fixes: #839
Fixes: #1206