### PR TITLE
fix: procedure validate errors not being caught

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2863,14 +2863,16 @@ class Connection extends EventEmitter {
    * @param request A [[Request]] object representing the request.
    */
   callProcedure(request: Request) {
-    request.validateParameters();
+    try {
+      request.validateParameters();
+    } catch (error) {
+      request.error = error;
 
-    const error = request.error;
-    if (error != null) {
       process.nextTick(() => {
         this.debug.log(error.message);
         request.callback(error);
       });
+
       return;
     }
 


### PR DESCRIPTION
node-mssql tests have failed when I bumped from v11.0.5 -> v11.0.7 and one of those failures was because the error being emitted here wasn't being passed to the callback.

This fixes the problem