### PR TITLE
chore: remove codecov from CI tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -123,32 +123,32 @@ jobs:
     - run: npm ci
 
     - name: run unit tests
-      run: npx nyc --reporter=lcov npm run test && npx codecov
+      run: npx nyc --reporter=lcov npm run test
 
     - name: run integration tests (TDS 7.4)
       env:
         TEDIOUS_TDS_VERSION: 7_4
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
     - name: run integration tests (TDS 7.3B)
       env:
         TEDIOUS_TDS_VERSION: 7_3_B
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
     - name: run integration tests (TDS 7.3A)
       env:
         TEDIOUS_TDS_VERSION: 7_3_A
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
     - name: run integration tests (TDS 7.2)
       env:
         TEDIOUS_TDS_VERSION: 7_2
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
     - name: run integration tests (TDS 7.1)
       env:
         TEDIOUS_TDS_VERSION: 7_1
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
   azure:
     name: Azure SQL Server / Node.js 12.x
@@ -200,7 +200,7 @@ jobs:
         }' > ~/.tedious/test-connection.json
 
     - name: run integration tests
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
     - name: Set up CI configuration (AD Authentication)
       run: |
@@ -222,7 +222,7 @@ jobs:
         }' > ~/.tedious/test-connection.json
 
     - name: run integration tests
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
     - name: Set up CI configuration (AD Service Principal Authentication)
       run: |
@@ -245,7 +245,7 @@ jobs:
         }' > ~/.tedious/test-connection.json
 
     - name: run integration tests
-      run: npx nyc --reporter=lcov npm run test-integration && npx codecov
+      run: npx nyc --reporter=lcov npm run test-integration
 
   pre-release:
     name: Pre-Release


### PR DESCRIPTION
Removes codecov form CI tests as it doesn't seem to be accurate in its results. 