### PR TITLE
fix: clear connection timeout on connection error

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1904,6 +1904,7 @@ class Connection extends EventEmitter {
           this.connectOnPort(port, this.config.options.multiSubnetFailover, signal);
         });
       }, (err) => {
+        this.clearConnectTimer();
         if (err.name === 'AbortError') {
           // Ignore the AbortError for now, this is still handled by the connectTimer firing
           return;
@@ -1991,6 +1992,7 @@ class Connection extends EventEmitter {
         this.transitionTo(this.STATE.SENT_PRELOGIN);
       });
     }, (err) => {
+      this.clearConnectTimer();
       if (err.name === 'AbortError') {
         return;
       }

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const homedir = require('os').homedir();
 const assert = require('chai').assert;
 const os = require('os');
+const dns = require('dns');
 
 import Connection from '../../src/connection';
 import { ConnectionError, RequestError } from '../../src/errors';
@@ -276,6 +277,71 @@ describe('Initiate Connect Test', function() {
       connection.close();
     });
     connection.connect();
+  });
+
+  it('should clear timeouts when failing to connect', function(done) {
+    const lookup = dns.lookup;
+    // force the dns lookup to fail, thus triggering an error in the connection
+    // @ts-ignore
+    dns.lookup = () => {
+      throw new Error('synthetic error');
+    };
+    try {
+      const connection = new Connection({
+        server: 'localhost',
+        options: { connectTimeout: 30000 },
+      });
+
+      connection.on('connect', (err) => {
+        try {
+          assert.instanceOf(err, ConnectionError);
+          assert.strictEqual(/** @type {ConnectionError} */(err).code, 'ESOCKET');
+          assert.strictEqual(connection.connectTimer, undefined);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+      connection.on('error', done);
+      connection.connect();
+      assert.isOk(connection.connectTimer);
+    } finally {
+      dns.lookup = lookup;
+    }
+  });
+
+  it('should clear timeouts when failing to connect to named instance', function(done) {
+    const lookup = dns.lookup;
+    // force the dns lookup to fail, thus triggering an error in the connection
+    // @ts-ignore
+    dns.lookup = () => {
+      throw new Error('synthetic error');
+    };
+    try {
+      const connection = new Connection({
+        server: 'localhost',
+        options: {
+          instanceName: 'inst',
+          connectTimeout: 30000,
+        },
+      });
+
+      connection.on('connect', (err) => {
+        try {
+          assert.instanceOf(err, ConnectionError);
+          assert.strictEqual(/** @type {ConnectionError} */(err).code, 'EINSTLOOKUP');
+          assert.strictEqual(connection.connectTimer, undefined);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+      connection.on('error', done);
+      connection.connect();
+      assert.isOk(connection.connectTimer);
+    } finally {
+      dns.lookup = lookup;
+    }
   });
 
   it('should fail if no cipher can be negotiated', function(done) {


### PR DESCRIPTION
This fixes #1261 (at least under my test conditions).

I'm not sure if this is the best way to handle errors at connection time, but it seems that the time is not being cleared correctly if/when a connection errors before being established.