### PR TITLE
ci: drop Node.js 13.x builds from Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - nodejs_version: "10"
     - nodejs_version: "12"
-    - nodejs_version: "13"
     - nodejs_version: "14"
     - nodejs_version: "16"
 


### PR DESCRIPTION
Node.js 13.x is not maintained, so there's no point in us running tests against that version. 😅 
