### PR TITLE
Refactor RPC parameter handling

### DIFF
--- a/src/always-encrypted/get-parameter-encryption-metadata.ts
+++ b/src/always-encrypted/get-parameter-encryption-metadata.ts
@@ -86,10 +86,9 @@ export const getParameterEncryptionMetadata = (connection: Connection, request: 
     });
   });
 
-  metadataRequest.originalParameters = request.parameters;
   metadataRequest.addParameter('tsql', TYPES.NVarChar, request.sqlTextOrProcedure);
-  if (metadataRequest.originalParameters && metadataRequest.originalParameters.length) {
-    metadataRequest.addParameter('params', TYPES.NVarChar, metadataRequest.makeParamsParameter(metadataRequest.originalParameters));
+  if (request.parameters.length) {
+    metadataRequest.addParameter('params', TYPES.NVarChar, metadataRequest.makeParamsParameter(request.parameters));
   }
 
   const resultRows: any[] = [];
@@ -98,5 +97,5 @@ export const getParameterEncryptionMetadata = (connection: Connection, request: 
     resultRows.push(columns);
   });
 
-  connection.makeRequest(metadataRequest, TYPE.RPC_REQUEST, new RpcRequestPayload(metadataRequest, connection.currentTransactionDescriptor(), connection.config.options));
+  connection.makeRequest(metadataRequest, TYPE.RPC_REQUEST, new RpcRequestPayload(metadataRequest.sqlTextOrProcedure!, metadataRequest.parameters, connection.currentTransactionDescriptor(), connection.config.options));
 };

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2770,7 +2770,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options));
   }
 
   /**
@@ -2844,7 +2844,7 @@ class Connection extends EventEmitter {
    */
   prepare(request: Request) {
     request.transformIntoPrepareRpc();
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options));
   }
 
   /**
@@ -2856,7 +2856,7 @@ class Connection extends EventEmitter {
    */
   unprepare(request: Request) {
     request.transformIntoUnprepareRpc();
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options));
   }
 
   /**
@@ -2882,7 +2882,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options));
   }
 
   /**
@@ -2904,7 +2904,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options));
   }
 
   /**

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -1,6 +1,5 @@
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import { writeToTrackingBuffer } from './all-headers';
-import Request from './request';
 import { Parameter, ParameterData } from './data-type';
 import { InternalConnectionOptions } from './connection';
 
@@ -19,15 +18,15 @@ const STATUS = {
   s2.2.6.5
  */
 class RpcRequestPayload implements Iterable<Buffer> {
-  request: Request;
   procedure: string | number;
+  parameters: Parameter[];
 
   options: InternalConnectionOptions;
   txnDescriptor: Buffer;
 
-  constructor(request: Request, txnDescriptor: Buffer, options: InternalConnectionOptions) {
-    this.request = request;
-    this.procedure = this.request.sqlTextOrProcedure!;
+  constructor(procedure: string | number, parameters: Parameter[], txnDescriptor: Buffer, options: InternalConnectionOptions) {
+    this.procedure = procedure;
+    this.parameters = parameters;
     this.options = options;
     this.txnDescriptor = txnDescriptor;
   }
@@ -54,9 +53,9 @@ class RpcRequestPayload implements Iterable<Buffer> {
     buffer.writeUInt16LE(optionFlags);
     yield buffer.data;
 
-    const parameters = this.request.parameters;
-    for (let i = 0; i < parameters.length; i++) {
-      yield * this.generateParameterData(parameters[i]);
+    const parametersLength = this.parameters.length;
+    for (let i = 0; i < parametersLength; i++) {
+      yield * this.generateParameterData(this.parameters[i]);
     }
   }
 


### PR DESCRIPTION
This refactors how RPC request parameters are handled. There's two main changes here:

* https://github.com/tediousjs/tedious/commit/fc80fa6df79ee1aa0d820a8115965fb870d6bbc9 removes the dependence of `RPCRequestPayload` on `Request` instances, instead it now takes a stored procedure name or id, and the list of parameters explicitly.
* https://github.com/tediousjs/tedious/commit/f4e26f2f0c29de9578a16c033b16196e6207a601 removes a tiny bit of mutability from `Request` objects. Previously, when calling `Connection.execSql`, `Connection.prepare`, `Connection.unprepare` or `Connection.execute`, the passed `Request` object's parameters were modified in-place, and original parameters were copied over to an internal `originalParameters` property. Instead of doing that, we now build the final parameter list inside the respective methods on `Connection` and don't modify the parameters at all.

Both these changes should be backwards compatible - the `Request.parameters` and `Request.originalParameters` properties are both private and I can't really imagine any code depending on them directly. 🤷 

These two changes are in preparation for getting https://github.com/tediousjs/tedious/pull/1180 into a mergeable state.