### PR TITLE
ci: update mssql linux container to be pulled from MCR

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,7 +68,7 @@ jobs:
 
     services:
       sqlserver:
-        image: microsoft/mssql-server-linux
+        image: mcr.microsoft.com/mssql/server
         ports:
           - 1433:1433
         env:


### PR DESCRIPTION
It looks like microsoft has stopped publishing MSSQL for linux containers under the `microsoft/mssql-server-linux` name on dockerhub.

Fortunately, fixing this is simple, as we can just switch over to `mcr.microsoft.com/mssql/server` instead. 👍 
