### PR TITLE
New BulkLoad streaming API

### DIFF
--- a/benchmarks/bulk-load/iterable.js
+++ b/benchmarks/bulk-load/iterable.js
@@ -1,0 +1,61 @@
+// @ts-check
+
+const { createBenchmark, createConnection } = require('../common');
+
+const { Request, TYPES } = require('../../src/tedious');
+
+const bench = createBenchmark(main, {
+  n: [10, 100],
+  size: [
+    10,
+    100,
+    1000,
+    10000
+  ]
+});
+
+function main({ n, size }) {
+  createConnection((connection) => {
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL
+      )
+    `, (err) => {
+      if (err) {
+        throw err;
+      }
+
+      let i = 0;
+
+      bench.start();
+
+      (function cb() {
+        const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err) => {
+          if (err) {
+            throw err;
+          }
+
+          if (i++ === n) {
+            bench.end(n);
+
+            connection.close();
+
+            return;
+          }
+
+          cb();
+        });
+
+        bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+
+        const rows = [];
+        for (let j = 0; j < size; j++) {
+          rows.push([ j ]);
+        }
+        connection.execBulkLoad(bulkLoad, rows);
+      })();
+    });
+
+    connection.execSqlBatch(request);
+  });
+}

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -372,7 +372,7 @@ class BulkLoad extends EventEmitter {
    *
    * @param name The name of the column.
    * @param type One of the supported `data types`.
-   * @param __namedParameters Type [[ColumnOptions]]<p> Additional column type information. At a minimum, `nullable` must be set to true or false.
+   * @param __namedParameters Additional column type information. At a minimum, `nullable` must be set to true or false.
    * @param length For VarChar, NVarChar, VarBinary. Use length as `Infinity` for VarChar(max), NVarChar(max) and VarBinary(max).
    * @param nullable Indicates whether the column accepts NULL values.
    * @param objName  If the name of the column is different from the name of the property found on `rowObj` arguments passed to [[addRow]], then you can use this option to specify the property name.

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -222,12 +222,11 @@ class RowTransform extends Transform {
  * bulkLoad.addColumn('myInt', TYPES.Int, { nullable: false });
  * bulkLoad.addColumn('myString', TYPES.NVarChar, { length: 50, nullable: true });
  *
- * // add rows
- * bulkLoad.addRow({ myInt: 7, myString: 'hello' });
- * bulkLoad.addRow({ myInt: 23, myString: 'world' });
- *
  * // execute
- * connection.execBulkLoad(bulkLoad);
+ * connection.execBulkLoad(bulkLoad, [
+ *   { myInt: 7, myString: 'hello' },
+ *   { myInt: 23, myString: 'world' }
+ * ]);
  * ```
  */
 class BulkLoad extends EventEmitter {
@@ -375,7 +374,7 @@ class BulkLoad extends EventEmitter {
    * @param __namedParameters Additional column type information. At a minimum, `nullable` must be set to true or false.
    * @param length For VarChar, NVarChar, VarBinary. Use length as `Infinity` for VarChar(max), NVarChar(max) and VarBinary(max).
    * @param nullable Indicates whether the column accepts NULL values.
-   * @param objName  If the name of the column is different from the name of the property found on `rowObj` arguments passed to [[addRow]], then you can use this option to specify the property name.
+   * @param objName If the name of the column is different from the name of the property found on `rowObj` arguments passed to [[addRow]] or [[Connection.execBulkLoad]], then you can use this option to specify the property name.
    * @param precision For Numeric, Decimal.
    * @param scale For Numeric, Decimal, Time, DateTime2, DateTimeOffset.
   */
@@ -426,6 +425,9 @@ class BulkLoad extends EventEmitter {
    * ```
    *
    * @param row An object of key/value pairs representing column name (or objName) and value.
+   *
+   * @deprecated This method is deprecated. Instead of adding rows individually, you should pass
+   *   all row objects when calling [[Connection.execBulkLoad]]. This method will be removed in the future.
    */
   addRow(row: { [columnName: string]: unknown }): void
 
@@ -438,6 +440,9 @@ class BulkLoad extends EventEmitter {
    *
    * @param row If there are at least two columns, values can be passed as multiple arguments instead of an array. They
    *   must be in the same order the columns were added in.
+   *
+   * @deprecated This method is deprecated. Instead of adding rows individually, you should pass
+   *   all row objects when calling [[Connection.execBulkLoad]]. This method will be removed in the future.
    */
   addRow(...row: unknown[]): void
 
@@ -449,6 +454,9 @@ class BulkLoad extends EventEmitter {
    * ```
    *
    * @param row An array representing the values of each column in the same order which they were added to the bulkLoad object.
+   *
+   * @deprecated This method is deprecated. Instead of adding rows individually, you should pass
+   *   all row objects when calling [[Connection.execBulkLoad]]. This method will be removed in the future.
    */
   addRow(row: unknown[]): void
 
@@ -660,6 +668,11 @@ class BulkLoad extends EventEmitter {
    *
    * After that, the stream emits a ['drain' event](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_event_drain)
    * when it is ready to resume data transfer.
+   *
+   * @deprecated
+   *   This method is deprecated. Instead of writing rows to the stream returned by this method,
+   *   you can pass any object that implements the `Iterable` or `AsyncIterable` interface (e.g. a `Readable`
+   *   stream or an `AsyncGenerator`) when calling [[Connection.execBulkLoad]]. This method will be removed in the future.
    */
   getRowStream() {
     if (this.firstRowWritten) {

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -419,29 +419,40 @@ class BulkLoad extends EventEmitter {
   }
 
   /**
-   * Adds a row to the bulk insert. This method accepts arguments in three different formats:
+   * Adds a row to the bulk insert.
    *
    * ```js
-   * bulkLoad.addRow( rowObj )
-   * bulkLoad.addRow( columnArray )
-   * bulkLoad.addRow( col0, col1, ... colN )`
+   * bulkLoad.addRow({ first_name: 'Bill', last_name: 'Gates' });
    * ```
-   * * `rowObj`
    *
-   *    An object of key/value pairs representing column name (or objName) and value.
-   *
-   * * `columnArray`
-   *
-   *    An array representing the values of each column in the same order which they were added to the bulkLoad object.
-   *
-   * * `col0, col1, ... colN`
-   *
-   *    If there are at least two columns, values can be passed as multiple arguments instead of an array. They
-   *    must be in the same order the columns were added in.
-   *
-   * @param input
+   * @param row An object of key/value pairs representing column name (or objName) and value.
    */
-  addRow(...input: [{ [key: string]: any }] | Array<any>) {
+  addRow(row: { [columnName: string]: unknown }): void
+
+  /**
+   * Adds a row to the bulk insert.
+   *
+   * ```js
+   * bulkLoad.addRow('Bill', 'Gates');
+   * ```
+   *
+   * @param row If there are at least two columns, values can be passed as multiple arguments instead of an array. They
+   *   must be in the same order the columns were added in.
+   */
+  addRow(...row: unknown[]): void
+
+  /**
+   * Adds a row to the bulk insert.
+   *
+   * ```js
+   * bulkLoad.addRow(['Bill', 'Gates']);
+   * ```
+   *
+   * @param row An array representing the values of each column in the same order which they were added to the bulkLoad object.
+   */
+  addRow(row: unknown[]): void
+
+  addRow(...input: [ { [key: string]: unknown } ] | unknown[]) {
     this.firstRowWritten = true;
 
     let row: any;

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -538,6 +538,440 @@ describe('BulkLoad', function() {
     connection.execSqlBatch(request);
   });
 
+  it('supports streaming bulk load rows from a Stream', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      if (err) {
+        done(err);
+      }
+
+      assert.strictEqual(rowCount, 6);
+
+      /** @type {unknown[]} */
+      const results = [];
+      const request = new Request(`
+        SELECT id, name FROM #tmpTestTable ORDER BY id
+      `, (err) => {
+        if (err) {
+          done(err);
+        }
+
+        assert.deepEqual(results, [
+          { id: 1, name: 'Bulbasaur' },
+          { id: 2, name: 'Ivysaur' },
+          { id: 3, name: 'Venusaur' },
+
+          { id: 4, name: 'Charmander' },
+          { id: 5, name: 'Charmeleon' },
+          { id: 6, name: 'Charizard' }
+        ]);
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        results.push({ id: row[0].value, name: row[1].value });
+      });
+
+      connection.execSql(request);
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, Readable.from([
+        { id: 1, name: 'Bulbasaur' },
+        [2, 'Ivysaur'],
+        { id: 3, name: 'Venusaur' },
+
+        [4, 'Charmander'],
+        { id: 5, name: 'Charmeleon' },
+        [6, 'Charizard']
+      ]));
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('supports streaming bulk load rows from an Array', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      if (err) {
+        done(err);
+      }
+
+      assert.strictEqual(rowCount, 6);
+
+      /** @type {unknown[]} */
+      const results = [];
+      const request = new Request(`
+        SELECT id, name FROM #tmpTestTable ORDER BY id
+      `, (err) => {
+        if (err) {
+          done(err);
+        }
+
+        assert.deepEqual(results, [
+          { id: 1, name: 'Bulbasaur' },
+          { id: 2, name: 'Ivysaur' },
+          { id: 3, name: 'Venusaur' },
+
+          { id: 4, name: 'Charmander' },
+          { id: 5, name: 'Charmeleon' },
+          { id: 6, name: 'Charizard' }
+        ]);
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        results.push({ id: row[0].value, name: row[1].value });
+      });
+
+      connection.execSql(request);
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, [
+        { id: 1, name: 'Bulbasaur' },
+        [2, 'Ivysaur'],
+        { id: 3, name: 'Venusaur' },
+
+        [4, 'Charmander'],
+        { id: 5, name: 'Charmeleon' },
+        [6, 'Charizard']
+      ]);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('supports streaming bulk load rows from an Iterable', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      if (err) {
+        done(err);
+      }
+
+      assert.strictEqual(rowCount, 6);
+
+      /** @type {unknown[]} */
+      const results = [];
+      const request = new Request(`
+        SELECT id, name FROM #tmpTestTable ORDER BY id
+      `, (err) => {
+        if (err) {
+          done(err);
+        }
+
+        assert.deepEqual(results, [
+          { id: 1, name: 'Bulbasaur' },
+          { id: 2, name: 'Ivysaur' },
+          { id: 3, name: 'Venusaur' },
+
+          { id: 4, name: 'Charmander' },
+          { id: 5, name: 'Charmeleon' },
+          { id: 6, name: 'Charizard' }
+        ]);
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        results.push({ id: row[0].value, name: row[1].value });
+      });
+
+      connection.execSql(request);
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, (function*() {
+        yield { id: 1, name: 'Bulbasaur' };
+        yield [2, 'Ivysaur'];
+        yield { id: 3, name: 'Venusaur' };
+
+        yield [4, 'Charmander'];
+        yield { id: 5, name: 'Charmeleon' };
+        yield [6, 'Charizard'];
+      })());
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('supports streaming bulk load rows from an AsyncIterable', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      if (err) {
+        done(err);
+      }
+
+      assert.strictEqual(rowCount, 6);
+
+      /** @type {unknown[]} */
+      const results = [];
+      const request = new Request(`
+        SELECT id, name FROM #tmpTestTable ORDER BY id
+      `, (err) => {
+        if (err) {
+          done(err);
+        }
+
+        assert.deepEqual(results, [
+          { id: 1, name: 'Bulbasaur' },
+          { id: 2, name: 'Ivysaur' },
+          { id: 3, name: 'Venusaur' },
+
+          { id: 4, name: 'Charmander' },
+          { id: 5, name: 'Charmeleon' },
+          { id: 6, name: 'Charizard' }
+        ]);
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        results.push({ id: row[0].value, name: row[1].value });
+      });
+
+      connection.execSql(request);
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, (async function*() {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield { id: 1, name: 'Bulbasaur' };
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield [2, 'Ivysaur'];
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield { id: 3, name: 'Venusaur' };
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield [4, 'Charmander'];
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield { id: 5, name: 'Charmeleon' };
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield [6, 'Charizard'];
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+      })());
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('correctly handles errors being throw inside an AsyncIterable', function(done) {
+    const expectedError = new Error('fail');
+
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      assert.strictEqual(err, expectedError);
+      assert.strictEqual(rowCount, 0);
+
+      /** @type {unknown[]} */
+      const results = [];
+      const request = new Request(`
+        SELECT id, name FROM #tmpTestTable ORDER BY id
+      `, (err) => {
+        if (err) {
+          done(err);
+        }
+
+        assert.deepEqual(results, []);
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        results.push({ id: row[0].value, name: row[1].value });
+      });
+
+      connection.execSql(request);
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, (async function*() {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield { id: 1, name: 'Bulbasaur' };
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield [2, 'Ivysaur'];
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+
+        yield { id: 3, name: 'Venusaur' };
+
+        throw expectedError;
+      })());
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('throws an error when trying to execute the bulkload with an Iterable after adding rows', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      assert.fail('Unexpected callback execution');
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      bulkLoad.addRow({ id: 1, name: 'Bulbasaur' });
+      bulkLoad.addRow([2, 'Ivysaur']);
+      bulkLoad.addRow({ id: 3, name: 'Venusaur' });
+
+      assert.throws(() => {
+        connection.execBulkLoad(bulkLoad, [
+          [4, 'Charmander'],
+          { id: 5, name: 'Charmeleon' },
+          [6, 'Charizard']
+        ]);
+      }, Error, "Connection.execBulkLoad can't be called with a BulkLoad that already has rows written to it.");
+
+      done();
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+
+  it('throws an error when trying to execute the bulkload with an Iterable after switching to streaming mode', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      assert.fail('Unexpected callback execution');
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('name', TYPES.NVarChar, { nullable: false });
+
+    const request = new Request(`
+      CREATE TABLE "#tmpTestTable" (
+        "id" int NOT NULL,
+        "name" nvarchar(255) NOT NULL,
+        PRIMARY KEY CLUSTERED ("id")
+      )
+    `, (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      bulkLoad.getRowStream();
+
+      assert.throws(() => {
+        connection.execBulkLoad(bulkLoad, [
+          [4, 'Charmander'],
+          { id: 5, name: 'Charmeleon' },
+          [6, 'Charizard']
+        ]);
+      }, Error, "Connection.execBulkLoad can't be called with a BulkLoad that was put in streaming mode.");
+
+      done();
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+
   it('should not close the connection due to cancelTimeout if canceled after completion', function(done) {
     const bulkLoad = connection.newBulkLoad('#tmpTestTable5', { keepNulls: true }, (err, rowCount) => {
       if (err) {
@@ -607,7 +1041,7 @@ describe('BulkLoad', function() {
         }
       })(), { objectMode: true });
 
-      rowSource.pipe(/** @type {NodeJS.WritableStream} */(/** @type {any} */(rowStream)));
+      rowSource.pipe(rowStream);
     }
 
     /**
@@ -711,7 +1145,7 @@ describe('BulkLoad', function() {
         [ 4, 'Charmander' ],
         { id: 5, name: 'Charmeleon' },
         [ 6, 'Charizard' ]
-      ]).pipe(/** @type {NodeJS.WritableStream} */(/** @type {any} */(bulkLoad.getRowStream())));
+      ]).pipe(bulkLoad.getRowStream());
 
       connection.execBulkLoad(bulkLoad);
     });
@@ -745,7 +1179,7 @@ describe('BulkLoad', function() {
       const bulkLoad = connection.newBulkLoad('#stream_test', completeBulkLoad);
       bulkLoad.addColumn('i', TYPES.Int, { nullable: false });
 
-      const rowStream = /** @type {NodeJS.WritableStream} */(/** @type {any} */(bulkLoad.getRowStream()));
+      const rowStream = bulkLoad.getRowStream();
       connection.execBulkLoad(bulkLoad);
 
       let rowCount = 0;
@@ -828,7 +1262,7 @@ describe('BulkLoad', function() {
 
       bulkLoad.addColumn('i', TYPES.Int, { nullable: false });
 
-      const rowStream = /** @type {NodeJS.WritableStream} */(/** @type {any} */(bulkLoad.getRowStream()));
+      const rowStream = bulkLoad.getRowStream();
       connection.execBulkLoad(bulkLoad);
 
       let rowCount = 0;
@@ -947,7 +1381,7 @@ describe('BulkLoad', function() {
 
       bulkLoad.addColumn('i', TYPES.Int, { nullable: false });
 
-      const rowStream = /** @type {NodeJS.WritableStream} */(/** @type {any} */(bulkLoad.getRowStream()));
+      const rowStream = bulkLoad.getRowStream();
 
       connection.execBulkLoad(bulkLoad);
 
@@ -1026,7 +1460,7 @@ describe('Bulk Loads when `config.options.validateBulkLoadParameters` is `true`'
     const bulkLoad = connection.newBulkLoad('#stream_test', completeBulkLoad);
     bulkLoad.addColumn('value', TYPES.Date, { nullable: false });
 
-    const rowStream = /** @type {NodeJS.WritableStream} */(/** @type {any} */(bulkLoad.getRowStream()));
+    const rowStream = bulkLoad.getRowStream();
     connection.execBulkLoad(bulkLoad);
 
     const rowSource = Readable.from([
@@ -1054,7 +1488,7 @@ describe('Bulk Loads when `config.options.validateBulkLoadParameters` is `true`'
     const bulkLoad = connection.newBulkLoad('#stream_test', completeBulkLoad);
     bulkLoad.addColumn('value', TYPES.Date, { nullable: false });
 
-    const rowStream = /** @type {NodeJS.WritableStream} */(/** @type {any} */(bulkLoad.getRowStream()));
+    const rowStream = bulkLoad.getRowStream();
     connection.execBulkLoad(bulkLoad);
 
     const rowSource = Readable.from([ ['invalid date'] ]);

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -217,7 +217,9 @@ describe('BulkLoad', function() {
 
   it('fails if the column definition does not match the target table format', function(done) {
     const bulkLoad = connection.newBulkLoad('#tmpTestTable2', (err, rowCount) => {
-      assert.instanceOf(err, Error, 'An error should have been thrown to indicate the incorrect table format.');
+      assert.instanceOf(err, RequestError, 'An error should have been thrown to indicate the incorrect table format.');
+      assert.strictEqual(/** @type {RequestError} */(err).message, 'An unknown error has occurred. This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.');
+
       assert.isUndefined(rowCount);
 
       done();


### PR DESCRIPTION
This adds a new `BulkLoad` API that greatly simplifies streaming data for bulk loading.

Instead of having to access a `BulkLoad`'s via the `.getRowStream` method, we can now simply pass in an `Iterable` (like a regular `Array` or a `Generator`) or an `AsyncIterable` (like a `ReadableStream` or an `AsyncGenerator`) to the `.execBulkLoad` method on a `Connection`.

Here's a very basic example that streams data from a regular `Array`:

```js
const bulkLoad = connection.newBulkLoad('employees', (err, rowCount) => {
  // ...
});

bulkLoad.addColumn('first_name', TYPES.NVarchar, { nullable: false });
bulkLoad.addColumn('last_name', TYPES.NVarchar, { nullable: false });
bulkLoad.addColumn('date_of_birth', TYPES.Date, { nullable: false });

connection.execBulkLoad(bulkLoad, [
  { 'first_name': 'Steve', 'last_name': 'Jobs', 'day_of_birth': new Date('02-24-1955') },
  { 'first_name': 'Bill', 'last_name': 'Gates', 'day_of_birth': new Date('10-28-1955') }
]);
```

The main advantage over the old API is that the same API covers now streaming and non-streaming use cases, and the User does not have to decide between one or the other - they're both implemented and used in the same way.