### PR TITLE
Support exotic table names in `BulkLoad`s

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -198,6 +198,19 @@ class RowTransform extends Transform {
 }
 
 /**
+ * Escape an identifier according to SQL Server identifier naming rules.
+ *
+ * Does not perform validation of the identifier, only escapes the characters so it can safely be embedded into a
+ * T-SQL statement.
+ *
+ * @param identifier a table name, column name, etc.
+ * @returns the escaped identifier
+ */
+function escapeIdentifier(identifier: string) {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+/**
  * A BulkLoad instance is used to perform a bulk insert.
  *
  * Use [[Connection.newBulkLoad]] to create a new instance, and [[Connection.execBulkLoad]] to execute it.
@@ -515,13 +528,13 @@ class BulkLoad extends EventEmitter {
    * @private
    */
   getBulkInsertSql() {
-    let sql = 'insert bulk ' + this.table + '(';
+    let sql = 'insert bulk ' + escapeIdentifier(this.table) + ' (';
     for (let i = 0, len = this.columns.length; i < len; i++) {
       const c = this.columns[i];
       if (i !== 0) {
         sql += ', ';
       }
-      sql += '[' + c.name + '] ' + (c.type.declaration(c));
+      sql += escapeIdentifier(c.name) + ' ' + (c.type.declaration(c));
     }
     sql += ')';
 
@@ -541,13 +554,13 @@ class BulkLoad extends EventEmitter {
    * you'll need to use the same connection and execute your requests using [[Connection.execSqlBatch]] instead of [[Connection.execSql]]
    */
   getTableCreationSql() {
-    let sql = 'CREATE TABLE ' + this.table + '(\n';
+    let sql = 'CREATE TABLE ' + escapeIdentifier(this.table) + ' (\n';
     for (let i = 0, len = this.columns.length; i < len; i++) {
       const c = this.columns[i];
       if (i !== 0) {
         sql += ',\n';
       }
-      sql += '[' + c.name + '] ' + (c.type.declaration(c));
+      sql += escapeIdentifier(c.name) + ' ' + (c.type.declaration(c));
       if (c.nullable !== undefined) {
         sql += ' ' + (c.nullable ? 'NULL' : 'NOT NULL');
       }

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -90,6 +90,38 @@ describe('BulkLoad', function() {
     connection.execSqlBatch(request);
   });
 
+  it('supports exotic table and column names', function(done) {
+    const bulkLoad = connection.newBulkLoad('#[😀]', (err, rowCount) => {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(rowCount, 5, 'Incorrect number of rows inserted.');
+
+      done();
+    });
+
+    bulkLoad.addColumn('column # @ []', TYPES.Int, { nullable: false });
+    bulkLoad.addColumn('foo"bar"baz', TYPES.NVarChar, { length: 50, nullable: true });
+    bulkLoad.addColumn('😀', TYPES.DateTime, { nullable: false });
+
+    const request = new Request(bulkLoad.getTableCreationSql(), (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      bulkLoad.addRow({ 'column # @ []': 201, 'foo"bar"baz': 'one zero one', '😀': new Date(1986, 6, 20) });
+      bulkLoad.addRow([202, 'one zero two', new Date()]);
+      bulkLoad.addRow(203, 'one zero three', new Date(2013, 7, 12));
+      bulkLoad.addRow({ 'column # @ []': 204, 'foo"bar"baz': 'one zero four', '😀': new Date() });
+      bulkLoad.addRow({ 'column # @ []': 205, 'foo"bar"baz': 'one zero five', '😀': new Date() });
+
+      connection.execBulkLoad(bulkLoad);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
   it('fails if the column definition does not match the target table format', function(done) {
     const bulkLoad = connection.newBulkLoad('#tmpTestTable2', (err, rowCount) => {
       assert.instanceOf(err, Error, 'An error should have been thrown to indicate the incorrect table format.');


### PR DESCRIPTION
This fixes an issue where bulk loads into tables with unusual names or column names (e.g. containing emoji or special characters like `"` or `[` and others) would fail, even though the names themselves would be seen as valid by SQL Server.

This changes the database statements generated by the bulk load code to escape these identifiers correctly.