### PR TITLE
chore: update `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6700,7 +6700,8 @@
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",


### PR DESCRIPTION
Fixes a tiny mismatch in our `package-lock.json` that would show up when running `npm install`.