### PR TITLE
Refactor bulk load internals

### DIFF
--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,0 +1,33 @@
+import BulkLoad from './bulk-load';
+import { RequestError } from './errors';
+
+export class BulkLoadPayload implements AsyncIterable<Buffer> {
+  bulkLoad: BulkLoad;
+  iterator: AsyncIterableIterator<Buffer>;
+
+  constructor(bulkLoad: BulkLoad) {
+    this.bulkLoad = bulkLoad;
+
+    // We need to grab the iterator here so that `error` event handlers are set up
+    // as early as possible (and are not potentially lost).
+    this.iterator = this.bulkLoad.rowToPacketTransform[Symbol.asyncIterator]();
+
+    this.bulkLoad.rowToPacketTransform.once('finish', () => {
+      this.bulkLoad.removeListener('cancel', onCancel);
+    });
+
+    const onCancel = () => {
+      this.bulkLoad.rowToPacketTransform.destroy(new RequestError('Canceled.', 'ECANCEL'));
+    };
+
+    this.bulkLoad.once('cancel', onCancel);
+  }
+
+  [Symbol.asyncIterator]() {
+    return this.iterator;
+  }
+
+  toString(indent = '') {
+    return indent + ('BulkLoad');
+  }
+}

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -119,6 +119,8 @@ interface ColumnOptions {
   nullable?: boolean;
 }
 
+const rowTokenBuffer = Buffer.from([ TOKEN_TYPE.ROW ]);
+
 // A transform that converts rows to packets.
 class RowTransform extends Transform {
   /**
@@ -160,9 +162,7 @@ class RowTransform extends Transform {
       this.columnMetadataWritten = true;
     }
 
-    const buf = new WritableTrackingBuffer(64, 'ucs2', true);
-    buf.writeUInt8(TOKEN_TYPE.ROW);
-    this.push(buf.data);
+    this.push(rowTokenBuffer);
 
     for (let i = 0; i < this.columns.length; i++) {
       const c = this.columns[i];

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -4,11 +4,8 @@ import Connection, { InternalConnectionOptions } from './connection';
 
 import { Transform } from 'readable-stream';
 import { TYPE as TOKEN_TYPE } from './token/token';
-import Message from './message';
-import { TYPE as PACKET_TYPE } from './packet';
 
 import { DataType, Parameter } from './data-type';
-import { RequestError } from './errors';
 
 /**
  * @private
@@ -170,6 +167,7 @@ class RowTransform extends Transform {
     for (let i = 0; i < this.columns.length; i++) {
       const c = this.columns[i];
       let value = row[i];
+
       if (this.bulkLoad.options.validateBulkLoadParameters) {
         try {
           value = c.type.validate(value);
@@ -177,6 +175,7 @@ class RowTransform extends Transform {
           return callback(error);
         }
       }
+
       const parameter = {
         length: c.length,
         scale: c.scale,
@@ -296,7 +295,6 @@ class BulkLoad extends EventEmitter {
    * @private
    */
   rowToPacketTransform: RowTransform;
-  message: Message;
 
   /**
    * @private
@@ -371,28 +369,6 @@ class BulkLoad extends EventEmitter {
     this.streamingMode = false;
 
     this.rowToPacketTransform = new RowTransform(this); // eslint-disable-line no-use-before-define
-    this.message = new Message({ type: PACKET_TYPE.BULK_LOAD });
-    this.rowToPacketTransform.pipe(this.message);
-
-    this.rowToPacketTransform.once('finish', () => {
-      this.removeListener('cancel', onCancel);
-    });
-
-    this.rowToPacketTransform.once('error', (err) => {
-      this.rowToPacketTransform.unpipe(this.message);
-
-      this.error = err;
-
-      this.message.ignore = true;
-      this.message.end();
-    });
-
-    const onCancel = () => {
-      this.rowToPacketTransform.emit('error', RequestError('Canceled.', 'ECANCEL'));
-      this.rowToPacketTransform.destroy();
-    };
-
-    this.once('cancel', onCancel);
 
     this.bulkOptions = { checkConstraints, fireTriggers, keepNulls, lockTable, order };
   }
@@ -697,13 +673,6 @@ class BulkLoad extends EventEmitter {
     this.streamingMode = true;
 
     return this.rowToPacketTransform;
-  }
-
-  /**
-   * @private
-   */
-  getMessageStream() {
-    return this.message;
   }
 
   /**


### PR DESCRIPTION
This refactors bulk load internals and prepares the code for future changes (see https://github.com/tediousjs/tedious/pull/1280).

This aligns the code internal code that handles sending `BulkLoad` and `Request` objects to the server, and makes them both follow the same structure.

Based on the benchmark code added in #1287, these refactorings also increase performance of the bulk loading code.

---

### Running `BulkLoad` benchmarks against `master`

```
root ➜ /workspaces/tedious (master ✗) $ node benchmarks/bulk-load/stream.js 
bulk-load/stream.js size=10 n=10: 272.78394483173855 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=100 n=10: 105.15348060071281 (minor: 1 - 0.713903ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=1000 n=10: 41.32809930037975 (minor: 3 - 2.5318110000000003ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=10000 n=10: 10.733008174417874 (minor: 26 - 75.287521ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=10 n=100: 371.85553521038895 (minor: 1 - 2.051209ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=100 n=100: 283.7590303331934 (minor: 3 - 4.398619ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=1000 n=100: 103.40782621492505 (minor: 25 - 20.675817ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=10000 n=100: 14.159323413461344 (minor: 239 - 690.2270799999999ms, major: 3 - 33.518572ms, incremental: 6 - 2.1941249999999997ms)
```

```
root ➜ /workspaces/tedious (master ✗) $ node benchmarks/bulk-load/sync.js 
bulk-load/sync.js size=10 n=10: 254.74258732824268 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=100 n=10: 111.00645915504015 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=1000 n=10: 38.05016235091072 (minor: 3 - 6.497869ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=10000 n=10: 10.703090980643408 (minor: 18 - 62.18155400000001ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=10 n=100: 372.7400055936347 (minor: 1 - 1.970021ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=100 n=100: 284.8296836553645 (minor: 3 - 5.07784ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=1000 n=100: 100.47874646124154 (minor: 20 - 30.045741000000003ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=10000 n=100: 15.597882440401879 (minor: 181 - 626.9647419999995ms, major: 2 - 26.958333ms, incremental: 4 - 2.203818ms)
```

### Running `BulkLoad` benchmarks with these changes

```
bulk-load/stream.js size=10 n=10: 306.76196943024945 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=100 n=10: 123.59937802815385 (minor: 1 - 1.335011ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=1000 n=10: 67.37531846965534 (minor: 2 - 2.242719ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=10000 n=10: 20.296664120862854 (minor: 17 - 13.093802999999998ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=10 n=100: 395.19255528044357 (minor: 1 - 2.49432ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=100 n=100: 306.5131431425819 (minor: 3 - 5.833845ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=1000 n=100: 170.7870356934333 (minor: 17 - 15.613124000000003ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/stream.js size=10000 n=100: 32.029677058843255 (minor: 159 - 115.85424499999995ms, major: 0 - 0ms, incremental: 0 - 0ms)
```

```
root ➜ /workspaces/tedious (arthur/refactor-bulk-load-internals ✗) $ node benchmarks/bulk-load/sync.js 
bulk-load/sync.js size=10 n=10: 295.4886885009365 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=100 n=10: 157.7094158277643 (minor: 0 - 0ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=1000 n=10: 73.95472210884553 (minor: 1 - 1.877714ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=10000 n=10: 26.048380772479426 (minor: 10 - 19.247259ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=10 n=100: 396.2240607758261 (minor: 1 - 2.846824ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=100 n=100: 303.7670974893142 (minor: 2 - 3.77963ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=1000 n=100: 195.91745214854845 (minor: 11 - 12.802204ms, major: 0 - 0ms, incremental: 0 - 0ms)
bulk-load/sync.js size=10000 n=100: 42.559246402402536 (minor: 100 - 231.6200930000001ms, major: 0 - 0ms, incremental: 0 - 0ms)
```

---

The more rows are written to the bulk load, the better the performance looks with these changes. 👍 Mainly, this is caused by the fact that we no longer allocate a new `WritableTrackingBuffer` per row being bulk loaded to hold the `ROW` token marker, but instead we allocate a buffer when `tedious` is loaded and re-use it for all bulk load rows.