### PR TITLE
Allow type checking on JavaScript files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3362,6 +3362,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/async": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.7.tgz",
+      "integrity": "sha512-a+MBBfOTs3ShFMlbH9qsRVFkjIUunEtxrBT0gxRx1cntjKRg2WApuGmNYzHkwKaIhMi3SMbKktaD/rLObQMwIw==",
+      "dev": true
+    },
     "@types/bl": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
     "@commitlint/travis-cli": "^12.1.4",
+    "@types/async": "^3.2.7",
     "@types/bl": "^5.0.1",
     "@types/chai": "^4.2.20",
     "@types/depd": "^1.1.32",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1824,6 +1824,11 @@ class Connection extends EventEmitter {
   on(event: 'languageChange', listener: (languageName: string) => void): this
 
   /**
+   * The connection was reset.
+   */
+  on(event: 'resetConnection', listener: () => void): this
+
+  /**
    * A secure connection has been established.
    */
   on(event: 'secure', listener: (cleartext: import('tls').TLSSocket) => void): this

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2966,7 +2966,7 @@ class Connection extends EventEmitter {
    *   The object's values are passed as the parameters' values when the
    *   request is executed.
    */
-  execute(request: Request, parameters: { [key: string]: unknown }) {
+  execute(request: Request, parameters?: { [key: string]: unknown }) {
     const executeParameters: Parameter[] = [];
 
     executeParameters.push({
@@ -2986,7 +2986,7 @@ class Connection extends EventEmitter {
 
         executeParameters.push({
           ...parameter,
-          value: parameter.type.validate(parameters[parameter.name])
+          value: parameter.type.validate(parameters ? parameters[parameter.name] : null)
         });
       }
     } catch (error) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -488,7 +488,7 @@ interface AuthenticationOptions {
   options?: any;
 }
 
-interface ConnectionOptions {
+export interface ConnectionOptions {
   /**
    * A boolean determining whether to rollback a transaction automatically if any error is encountered
    * during the given transaction's execution. This sets the value for `SET XACT_ABORT` during the

--- a/src/request.ts
+++ b/src/request.ts
@@ -397,7 +397,7 @@ class Request extends EventEmitter {
    *   Additional type options. Optional.
    */
   // TODO: `type` must be a valid TDS value type
-  addParameter(name: string, type: DataType, value: unknown, options?: ParameterOptions) {
+  addParameter(name: string, type: DataType, value?: unknown, options?: ParameterOptions | null) {
     if (options == null) {
       options = {};
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -31,7 +31,7 @@ type CompletionCallback =
   // TODO: Figure out how to type the `rows` parameter here.
   (error: Error | null | undefined, rowCount?: number, rows?: any) => void;
 
-interface ParameterOptions {
+export interface ParameterOptions {
   output?: boolean;
   length?: number;
   precision?: number;

--- a/test/integration/binary-insert-test.js
+++ b/test/integration/binary-insert-test.js
@@ -1,9 +1,12 @@
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
-const TYPES = require('../../src/data-type').typeByName;
+// @ts-check
 
 const fs = require('fs');
 const { assert } = require('chai');
+
+const TYPES = require('../../src/data-type').typeByName;
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
 
 const config = JSON.parse(
   fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
@@ -47,7 +50,9 @@ describe('inserting binary data', function() {
           return done(err);
         }
 
+        /** @type {unknown[]} */
         const values = [];
+
         const request = new Request('SELECT [data] FROM #test', (err) => {
           if (err) {
             return done(err);

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -1,10 +1,14 @@
+// @ts-check
+
 const async = require('async');
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
 const fs = require('fs');
 const homedir = require('os').homedir();
 const assert = require('chai').assert;
 const os = require('os');
+
+import Connection from '../../src/connection';
+import { ConnectionError, RequestError } from '../../src/errors';
+import Request from '../../src/request';
 
 function getConfig() {
   const config = JSON.parse(
@@ -49,7 +53,7 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -86,7 +90,7 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -126,7 +130,7 @@ describe('Initiate Connect Test', function() {
       connection.close();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -161,7 +165,7 @@ describe('Initiate Connect Test', function() {
       connection.close();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -196,7 +200,7 @@ describe('Initiate Connect Test', function() {
       connection.close();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -290,8 +294,8 @@ describe('Initiate Connect Test', function() {
 
     const connection = new Connection(config);
     connection.connect(function(err) {
-      assert.ok(err);
-      assert.strictEqual(err.code, 'ESOCKET');
+      assert.instanceOf(err, ConnectionError);
+      assert.strictEqual(/** @type {ConnectionError} */(err).code, 'ESOCKET');
     });
 
     connection.on('end', function() {
@@ -386,7 +390,7 @@ describe('Initiate Connect Test', function() {
       conn.close();
 
       assert.instanceOf(err, Error);
-      assert.strictEqual(err.message, 'Failed to connect to 192.0.2.1:1433 in 3000ms');
+      assert.strictEqual(/** @type {Error} */(err).message, 'Failed to connect to 192.0.2.1:1433 in 3000ms');
 
       done();
     });
@@ -395,12 +399,21 @@ describe('Initiate Connect Test', function() {
 
 
 describe('Ntlm Test', function() {
+  /**
+   * @enum {number}
+   */
   const DomainCaseEnum = {
     AsIs: 0,
     Lower: 1,
     Upper: 2,
   };
 
+  /**
+   * @this {Mocha.Context}
+   * @param {Mocha.Done} done
+   * @param {DomainCaseEnum} domainCase
+   * @returns {void}
+   */
   function runNtlmTest(done, domainCase) {
     const ntlmConfig = getNtlmConfig();
 
@@ -429,7 +442,7 @@ describe('Ntlm Test', function() {
       connection.close();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -437,7 +450,7 @@ describe('Ntlm Test', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    return connection.on('debug', function(text) {
+    connection.on('debug', function(text) {
       // console.log(text)
     });
   }
@@ -468,7 +481,7 @@ describe('Encrypt Test', function() {
       connection.close();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -493,6 +506,7 @@ describe('Encrypt Test', function() {
 });
 
 describe('BeginTransaction Tests', function() {
+  /** @type {Connection} */
   let connection;
   beforeEach(function(done) {
     const config = getConfig();
@@ -512,7 +526,7 @@ describe('BeginTransaction Tests', function() {
   it('should validate isolation level is a number', function() {
     assert.throws(() => {
       const callback = () => { assert.fail('callback should not be executed'); };
-      connection.beginTransaction(callback, 'test', 'some string');
+      connection.beginTransaction(callback, 'test', /** @type {any} */('some string'));
     }, TypeError, 'The "isolationLevel" argument must be of type number. Received type string (some string)');
   });
 
@@ -564,7 +578,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -603,7 +617,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -647,7 +661,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -702,7 +716,7 @@ describe('Insertion Tests', function() {
       execSql();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -752,7 +766,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -784,7 +798,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -802,8 +816,8 @@ describe('Insertion Tests', function() {
     const config = getConfig();
 
     const request = new Request('select 8 as C1', function(err, rowCount) {
-      assert.ok(err);
-      assert.strictEqual(err.code, 'ECLOSE');
+      assert.instanceOf(err, RequestError);
+      assert.strictEqual(/** @type {RequestError} */(err).code, 'ECLOSE');
     });
 
     const connection = new Connection(config);
@@ -817,7 +831,7 @@ describe('Insertion Tests', function() {
       connection.close();
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -862,7 +876,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -898,7 +912,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -936,7 +950,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -964,6 +978,10 @@ describe('Insertion Tests', function() {
     });
 
     request.on('doneInProc', function(rowCount, more, rows) {
+      if (!rows) {
+        assert.fail('Did not expect `rows` to be undefined');
+      }
+
       assert.strictEqual(rows.length, 1);
 
       switch (++doneCount) {
@@ -984,7 +1002,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -1026,7 +1044,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -1042,14 +1060,24 @@ describe('Insertion Tests', function() {
   it('should reset Connection', function(done) {
     const config = getConfig();
 
+    /**
+     * @param {(err?: Error | null | undefined, result?: any) => void} callback
+     */
     function testAnsiNullsOptionOn(callback) {
       testAnsiNullsOption(true, callback);
     }
 
+    /**
+     * @param {(err?: Error | null | undefined, result?: any) => void} callback
+     */
     function testAnsiNullsOptionOff(callback) {
       testAnsiNullsOption(false, callback);
     }
 
+    /**
+     * @param {boolean} expectedOptionOn
+     * @param {(err?: Error | null | undefined, result?: any) => void} callback
+     */
     function testAnsiNullsOption(expectedOptionOn, callback) {
       const request = new Request('select @@options & 32', function(err, rowCount) {
         callback(err);
@@ -1063,6 +1091,9 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     }
 
+    /**
+     * @param {(err?: Error | null | undefined, result?: any) => void} callback
+     */
     function setAnsiNullsOptionOff(callback) {
       const request = new Request('set ansi_nulls off', function(err, rowCount) {
         callback(err);
@@ -1100,7 +1131,7 @@ describe('Insertion Tests', function() {
       ]);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -1116,11 +1147,12 @@ describe('Insertion Tests', function() {
   it('should support cancelling a request while it is processed on the server', function(done) {
     const config = getConfig();
 
+    /** @type {[number, number]} */
     let cancelledAt;
 
     const request = new Request("select 1 as C1; waitfor delay '00:00:05'; select 2 as C2", (err, rowCount, rows) => {
       assert.instanceOf(err, Error);
-      assert.strictEqual(err.message, 'Canceled.');
+      assert.strictEqual(/** @type {Error} */(err).message, 'Canceled.');
 
       assert.isUndefined(rowCount);
 
@@ -1172,7 +1204,7 @@ describe('Insertion Tests', function() {
       }, 2000);
     });
 
-    connection.on('end', (info) => {
+    connection.on('end', () => {
       done();
     });
 
@@ -1192,7 +1224,7 @@ describe('Insertion Tests', function() {
     const request = new Request(
       "select 1 as C1;waitfor delay '00:00:05';select 2 as C2",
       function(err, rowCount, rows) {
-        assert.equal(err.message, 'Timeout: Request failed to complete in 1000ms');
+        assert.equal(/** @type {Error} */(err).message, 'Timeout: Request failed to complete in 1000ms');
 
         connection.close();
       }
@@ -1224,7 +1256,7 @@ describe('Insertion Tests', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -1239,11 +1271,17 @@ describe('Insertion Tests', function() {
 });
 
 describe('Advanced Input Test', function() {
+  /**
+   * @param {Mocha.Done} done
+   * @param {import("../../src/connection").ConnectionConfiguration} config
+   * @param {string} sql
+   * @param {(error: Error | null | undefined, rowCount?: number) => void} requestCallback
+   */
   function runSqlBatch(done, config, sql, requestCallback) {
     const connection = new Connection(config);
 
-    const request = new Request(sql, function() {
-      requestCallback.apply(this, arguments);
+    const request = new Request(sql, function(err, rowCount) {
+      requestCallback(err, rowCount);
       connection.close();
     });
 
@@ -1252,7 +1290,7 @@ describe('Advanced Input Test', function() {
       connection.execSqlBatch(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
   }
@@ -1281,15 +1319,19 @@ describe('Advanced Input Test', function() {
     const config = getConfig();
     config.options.enableAnsiNullDefault = false;
 
-    runSqlBatch(done, config, sql, function(err) {
-      assert.ok(err instanceof Error);
-      assert.strictEqual(err != null ? err.number : undefined, 515);
+    runSqlBatch(done, config, sql, function(/** @type {RequestError | null | undefined} */err) {
+      assert.instanceOf(err, RequestError);
+      assert.strictEqual(/** @type {RequestError} */(err).number, 515);
     }); // Cannot insert the value NULL
   });
 });
 
 describe('Date Insert Test', function() {
-  const testDateFirstImpl = (done, datefirst) => {
+  /**
+   * @param {Mocha.Done} done
+   * @param {number | undefined} datefirst
+   */
+  function testDateFirstImpl(done, datefirst) {
     datefirst = datefirst || 7;
     const config = getConfig();
     config.options.datefirst = datefirst;
@@ -1311,10 +1353,10 @@ describe('Date Insert Test', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
-  };
+  }
 
   // Test that the default setting for DATEFIRST is 7
   it('should test date first default', function(done) {
@@ -1340,6 +1382,10 @@ describe('Date Insert Test', function() {
 });
 
 describe('Language Insert Test', function() {
+  /**
+   * @param {Mocha.Done} done
+   * @param {string | undefined} language
+   */
   function testLanguage(done, language) {
     language = language || 'us_english';
     const config = getConfig();
@@ -1362,7 +1408,7 @@ describe('Language Insert Test', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
   }
@@ -1378,6 +1424,10 @@ describe('Language Insert Test', function() {
 });
 
 describe('should test date format', function() {
+  /**
+   * @param {Mocha.Done} done
+   * @param {string | undefined} dateFormat
+   */
   function testDateFormat(done, dateFormat) {
     dateFormat = dateFormat || 'mdy';
     const config = getConfig();
@@ -1403,7 +1453,7 @@ describe('should test date format', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
   }
@@ -1419,6 +1469,13 @@ describe('should test date format', function() {
 });
 
 describe('Boolean Config Options Test', function() {
+  /**
+   * @param {Mocha.Done} done
+   * @param {string} optionName
+   * @param {boolean | undefined} optionValue
+   * @param {number} optionFlag
+   * @param {boolean} defaultOn
+   */
   function testBooleanConfigOption(done, optionName, optionValue, optionFlag, defaultOn) {
     const config = getConfig();
     config.options[optionName] = optionValue;
@@ -1457,12 +1514,15 @@ describe('Boolean Config Options Test', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
   }
 
-
+  /**
+   * @param {Mocha.Done} done
+   * @param {string} optionName
+   */
   function testBadBooleanConfigOption(done, optionName) {
     const config = getConfig();
     config.options[optionName] = 'on';

--- a/test/integration/instance-lookup-test.js
+++ b/test/integration/instance-lookup-test.js
@@ -1,8 +1,11 @@
+// @ts-check
+
 const fs = require('fs');
-const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
 const homedir = require('os').homedir();
 const assert = require('chai').assert;
-const AbortController = require('node-abort-controller');
+import AbortController from 'node-abort-controller';
+
+const InstanceLookup = require('../../src/instance-lookup').InstanceLookup;
 
 var RESERVED_IP_ADDRESS = '192.0.2.0'; // Can never be used, so guaranteed to fail.
 

--- a/test/integration/invalid-packet-stream-test.js
+++ b/test/integration/invalid-packet-stream-test.js
@@ -1,10 +1,20 @@
+// @ts-check
+
 const { assert } = require('chai');
 const net = require('net');
 const Connection = require('../../src/tedious').Connection;
 const ConnectionError = require('../../src/errors').ConnectionError;
 
 describe('Connecting to a server that sends invalid packet data', function() {
-  let server, sockets;
+  /**
+   * @type {net.Server}
+   */
+  let server;
+
+  /**
+   * @type {net.Socket[]}
+   */
+  let sockets;
 
   beforeEach(function(done) {
     sockets = [];
@@ -40,7 +50,7 @@ describe('Connecting to a server that sends invalid packet data', function() {
       socket.write(packet);
     });
 
-    const addressInfo = server.address();
+    const addressInfo = /** @type {net.AddressInfo} */(server.address());
     const connection = new Connection({
       server: addressInfo.address,
       options: {
@@ -50,7 +60,7 @@ describe('Connecting to a server that sends invalid packet data', function() {
 
     connection.connect((err) => {
       assert.instanceOf(err, ConnectionError);
-      assert.equal(err.message, 'Connection lost - Unable to process incoming packet');
+      assert.equal(/** @type {ConnectionError} */(err).message, 'Connection lost - Unable to process incoming packet');
 
       done();
     });

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -1,8 +1,11 @@
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
+// @ts-check
+
 const fs = require('fs');
-const TYPES = require('../../src/data-type').typeByName;
 const assert = require('chai').assert;
+const TYPES = require('../../src/data-type').typeByName;
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
 
 function getConfig() {
   const config = JSON.parse(
@@ -22,7 +25,21 @@ function getConfig() {
   return config;
 }
 
+/**
+ * @typedef {typeof import('../../src/data-type').typeByName} TYPES
+ */
 
+/**
+ * @param {Mocha.Done} done
+ * @param {TYPES[keyof TYPES]} type
+ * @param {unknown} value
+ * @param {'7_0' | '7_1' | '7_2' | '7_3_A' | '7_3_A' | '7_4' | null} [tdsVersion]
+ * @param {import('../../src/request').ParameterOptions | null} [options]
+ * @param {unknown} [expectedValue]
+ * @param {boolean} [cast]
+ * @param {import('../../src/connection').ConnectionOptions} [connectionOptions]
+ * @returns {void}
+ */
 function execSql(done, type, value, tdsVersion, options, expectedValue, cast, connectionOptions) {
   var config = getConfig();
   // config.options.packetSize = 32768
@@ -59,7 +76,7 @@ function execSql(done, type, value, tdsVersion, options, expectedValue, cast, co
     } else if (expectedValue instanceof Date) {
       assert.strictEqual(columns[0].value.getTime(), expectedValue.getTime());
     } else if (type === TYPES.BigInt) {
-      assert.strictEqual(columns[0].value, expectedValue.toString());
+      assert.strictEqual(columns[0].value, String(expectedValue));
     } else if (type === TYPES.UniqueIdentifier) {
       assert.deepEqual(columns[0].value, expectedValue);
     } else {
@@ -75,7 +92,7 @@ function execSql(done, type, value, tdsVersion, options, expectedValue, cast, co
     connection.execSql(request);
   });
 
-  connection.on('end', function(info) {
+  connection.on('end', function() {
     done();
   });
 
@@ -88,6 +105,14 @@ function execSql(done, type, value, tdsVersion, options, expectedValue, cast, co
   });
 }
 
+/**
+ * @param {Mocha.Done} done
+ * @param {TYPES[keyof TYPES]} type
+ * @param {unknown} value
+ * @param {unknown} [expectedValue]
+ * @param {import('../../src/connection').ConnectionOptions} [connectionOptions]
+ * @returns {void}
+ */
 function execSqlOutput(done, type, value, expectedValue, connectionOptions) {
   var config = getConfig();
 
@@ -112,10 +137,10 @@ function execSqlOutput(done, type, value, expectedValue, connectionOptions) {
       expectedValue = value;
     }
 
-    if (value instanceof Date) {
+    if (expectedValue instanceof Date && returnValue instanceof Date) {
       assert.strictEqual(returnValue.getTime(), expectedValue.getTime());
     } else if (type === TYPES.BigInt) {
-      assert.strictEqual(returnValue, expectedValue.toString());
+      assert.strictEqual(returnValue, String(expectedValue));
     } else if (type === TYPES.UniqueIdentifier) {
       assert.deepEqual(returnValue, expectedValue);
     } else {
@@ -133,7 +158,7 @@ function execSqlOutput(done, type, value, expectedValue, connectionOptions) {
     connection.execSql(request);
   });
 
-  connection.on('end', function(info) {
+  connection.on('end', function() {
     done();
   });
 
@@ -423,49 +448,49 @@ describe('Parameterised Statements Test', function() {
 
   describe('´time´', function() {
     it('should handle `null` values', function(done) {
-      execSql(done, TYPES.Time, null, '7_3', null);
+      execSql(done, TYPES.Time, null, '7_3_A', null);
     });
 
     it('ignores the date part of given `Date` values', function(done) {
-      execSql(done, TYPES.Time, new Date('2000-02-19T12:34:56Z'), '7_3', null, new Date('1970-01-01T12:34:56Z'));
+      execSql(done, TYPES.Time, new Date('2000-02-19T12:34:56Z'), '7_3_A', null, new Date('1970-01-01T12:34:56Z'));
     });
 
     it('should handle `string` values', function(done) {
-      execSql(done, TYPES.Time, '1970-01-01T12:34:56Z', '7_3', null, '12:34:56.0000000', true);
+      execSql(done, TYPES.Time, '1970-01-01T12:34:56Z', '7_3_A', null, '12:34:56.0000000', true);
     });
 
     const testTime = Object.assign(new Date('1970-01-01T00:00:00Z'), { nanosecondDelta: 0.1111111 });
 
     it('should test time', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', null, '00:00:00.1111111', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', null, '00:00:00.1111111', true);
     });
 
     it('should test time1', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 1 }, '00:00:00.1', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 1 }, '00:00:00.1', true);
     });
 
     it('should test time2', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 2 }, '00:00:00.11', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 2 }, '00:00:00.11', true);
     });
 
     it('should test time3', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 3 }, '00:00:00.111', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 3 }, '00:00:00.111', true);
     });
 
     it('should test time4', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 4 }, '00:00:00.1111', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 4 }, '00:00:00.1111', true);
     });
 
     it('should test time5', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 5 }, '00:00:00.11111', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 5 }, '00:00:00.11111', true);
     });
 
     it('should test time 6', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 6 }, '00:00:00.111111', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 6 }, '00:00:00.111111', true);
     });
 
     it('should test time7', function(done) {
-      execSql(done, TYPES.Time, testTime, '7_3', { scale: 7 }, '00:00:00.1111111', true);
+      execSql(done, TYPES.Time, testTime, '7_3_A', { scale: 7 }, '00:00:00.1111111', true);
     });
   });
 
@@ -972,7 +997,7 @@ describe('Parameterised Statements Test', function() {
       connection.execSql(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -1055,7 +1080,7 @@ end')\
       connection.execSqlBatch(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -1,7 +1,11 @@
+// @ts-check
+
 const fs = require('fs');
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
 const assert = require('chai').assert;
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
+import { RequestError } from '../../src/errors';
 
 function getConfig() {
   const config = JSON.parse(fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')).config;
@@ -13,6 +17,7 @@ function getConfig() {
 
 describe('Pause-Resume Test', function() {
   this.timeout(10000);
+  /** @type {Connection} */
   let connection;
 
   beforeEach(function(done) {
@@ -102,7 +107,10 @@ describe('Pause-Resume Test', function() {
       assert.ifError(err);
     });
 
-    const pauseAndCancelRequest = (next) => {
+    /**
+     * @param {() => void} next
+     */
+    function pauseAndCancelRequest(next) {
       const sql = `
             with cte1 as
               (select 1 as i union all select i + 1 from cte1 where i < 20000)
@@ -110,8 +118,8 @@ describe('Pause-Resume Test', function() {
           `;
 
       const request = new Request(sql, (error) => {
-        assert.ok(error);
-        assert.strictEqual(error.code, 'ECANCEL');
+        assert.instanceOf(error, RequestError);
+        assert.strictEqual(/** @type {RequestError} */(error).code, 'ECANCEL');
 
         next();
       });
@@ -129,7 +137,7 @@ describe('Pause-Resume Test', function() {
       });
 
       connection.execSql(request);
-    };
+    }
 
     pauseAndCancelRequest(() => {
       const request = new Request('SELECT 1', (error) => {

--- a/test/integration/prepare-execute-statements-test.js
+++ b/test/integration/prepare-execute-statements-test.js
@@ -1,8 +1,11 @@
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
+// @ts-check
+
 const fs = require('fs');
 const TYPES = require('../../src/data-type').typeByName;
 const assert = require('chai').assert;
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
 
 function getConfig() {
   const config = JSON.parse(
@@ -51,7 +54,7 @@ describe('Prepare Execute Statement', function() {
       connection.prepare(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -64,6 +67,10 @@ describe('Prepare Execute Statement', function() {
     const config = getConfig();
 
     let eventEmitterLeak = false;
+
+    /**
+     * @type {NodeJS.WarningListener}
+     */
     const onWarning = (warning) => {
       if (warning.name === 'MaxListenersExceededWarning') {
         eventEmitterLeak = true;
@@ -98,7 +105,7 @@ describe('Prepare Execute Statement', function() {
       connection.prepare(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       process.removeListener('warning', onWarning);
 
       if (eventEmitterLeak) {
@@ -128,7 +135,7 @@ describe('Prepare Execute Statement', function() {
       connection.prepare(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 

--- a/test/integration/rpc-test.js
+++ b/test/integration/rpc-test.js
@@ -1,8 +1,11 @@
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
+// @ts-check
+
 const TYPES = require('../../src/data-type').typeByName;
 const fs = require('fs');
 const assert = require('chai').assert;
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
 
 function getConfig() {
   const config = JSON.parse(
@@ -22,7 +25,12 @@ function getConfig() {
   return config;
 }
 
+/**
+ * @typedef {typeof import('../../src/data-type').typeByName} TYPES
+ */
+
 describe('RPC test', function() {
+  /** @type {Connection} */
   let connection;
 
   beforeEach(function(done) {
@@ -52,6 +60,11 @@ describe('RPC test', function() {
     }
   });
 
+  /**
+   * @param {Connection} connection
+   * @param {string} sql
+   * @param {() => void} done
+   */
   function execSqlBatch(connection, sql, done) {
     const request = new Request(sql, function(err) {
       if (err) {
@@ -65,6 +78,12 @@ describe('RPC test', function() {
     connection.execSqlBatch(request);
   }
 
+  /**
+   * @param {Mocha.Done} done
+   * @param {TYPES[keyof TYPES]} type
+   * @param {string} typeAsString
+   * @param {unknown} value
+   */
   function testProc(done, type, typeAsString, value) {
     const request = new Request('#test_proc', function(err) {
       assert.ifError(err);
@@ -105,8 +124,13 @@ select @param\
     );
   }
 
+  /**
+   * @param {Mocha.Done} done
+   * @param {TYPES[keyof TYPES]} type
+   * @param {string} typeAsString
+   * @param {unknown} value
+   */
   function testProcOutput(done, type, typeAsString, value) {
-
     const request = new Request('#test_proc', function(err) {
       assert.ifError(err);
 
@@ -127,7 +151,7 @@ select @param\
 
     request.on('returnValue', function(name, returnValue, metadata) {
       assert.strictEqual(name, 'paramOut');
-      if (value instanceof Date) {
+      if (value instanceof Date && returnValue instanceof Date) {
         assert.strictEqual(returnValue.getTime(), value.getTime());
       } else {
         assert.strictEqual(returnValue, value);
@@ -321,7 +345,7 @@ set @paramOut = @paramIn\
       connection.callProcedure(request);
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 
@@ -375,7 +399,7 @@ set @paramOut = @paramIn\
       );
     });
 
-    connection.on('end', function(info) {
+    connection.on('end', function() {
       done();
     });
 

--- a/test/integration/socket-error-test.js
+++ b/test/integration/socket-error-test.js
@@ -1,8 +1,10 @@
+// @ts-check
+
 const fs = require('fs');
 const { assert } = require('chai');
 
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
+import Connection from '../../src/connection';
+import Request from '../../src/request';
 
 function getConfig() {
   const config = JSON.parse(
@@ -22,7 +24,12 @@ function getConfig() {
   return config;
 }
 
+/**
+ * @typedef {import('net').Socket} Socket
+ */
+
 describe('A `error` on the network socket', function() {
+  /** @type {Connection} */
   let connection;
 
   beforeEach(function(done) {
@@ -52,7 +59,7 @@ describe('A `error` on the network socket', function() {
 
     connection.execSql(request);
     process.nextTick(() => {
-      connection.socket.emit('error', socketError);
+      /** @type {Socket} */(connection.socket).emit('error', socketError);
     });
   });
 
@@ -68,7 +75,7 @@ describe('A `error` on the network socket', function() {
 
     connection.execSql(request);
     process.nextTick(() => {
-      connection.socket.emit('error', socketError);
+      /** @type {Socket} */(connection.socket).emit('error', socketError);
     });
   });
 
@@ -92,7 +99,7 @@ describe('A `error` on the network socket', function() {
 
     connection.execSql(request);
     process.nextTick(() => {
-      connection.socket.emit('error', socketError);
+      /** @type {Socket} */(connection.socket).emit('error', socketError);
     });
   });
 });

--- a/test/integration/tvp-test.js
+++ b/test/integration/tvp-test.js
@@ -1,10 +1,13 @@
-const Connection = require('../../src/connection');
-const Request = require('../../src/request');
+// @ts-check
+
 const TYPES = require('../../src/tedious').TYPES;
 const fs = require('fs');
 const async = require('async');
 
 const { assert } = require('chai');
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
 
 function getConfig() {
   var config = JSON.parse(
@@ -27,6 +30,7 @@ function getConfig() {
 describe('calling a procedure that takes and returns a TVP', function() {
   this.timeout(5000);
 
+  /** @type {Connection} */
   let connection;
 
   beforeEach(function(done) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "moduleResolution": "node",
-    "allowJs": false,
+    "allowJs": true,
     "noEmit": true,
     "strict": true,
     "isolatedModules": true,
@@ -16,6 +16,7 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
+    "test/**/*.js",
   ],
 
   "typedocOptions": {


### PR DESCRIPTION
This enables the `allowJs` option in the typescript configuration, which allows the use of the typescript compiler to type check `.js`.

Type checking will be opt-in initially, and can be enabled for individual files by adding a `// @ts-check` comment. Having all test files type checked will ensure that the types defined in the TypeScript code are "correct" and is a first step to including TypeScript definition files in our npm packages in the future.