### PR TITLE
revert: revert support for exotic table and column names in bulk loads

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -203,19 +203,6 @@ class RowTransform extends Transform {
 }
 
 /**
- * Escape an identifier according to SQL Server identifier naming rules.
- *
- * Does not perform validation of the identifier, only escapes the characters so it can safely be embedded into a
- * T-SQL statement.
- *
- * @param identifier a table name, column name, etc.
- * @returns the escaped identifier
- */
-function escapeIdentifier(identifier: string) {
-  return `"${identifier.replace(/"/g, '""')}"`;
-}
-
-/**
  * A BulkLoad instance is used to perform a bulk insert.
  *
  * Use [[Connection.newBulkLoad]] to create a new instance, and [[Connection.execBulkLoad]] to execute it.
@@ -514,7 +501,7 @@ class BulkLoad extends EventEmitter {
       const orderColumns = [];
 
       for (const [column, direction] of Object.entries(this.bulkOptions.order)) {
-        orderColumns.push(`${escapeIdentifier(column)} ${direction}`);
+        orderColumns.push(`${column} ${direction}`);
       }
 
       if (orderColumns.length) {
@@ -533,13 +520,13 @@ class BulkLoad extends EventEmitter {
    * @private
    */
   getBulkInsertSql() {
-    let sql = 'insert bulk ' + escapeIdentifier(this.table) + ' (';
+    let sql = 'insert bulk ' + this.table + '(';
     for (let i = 0, len = this.columns.length; i < len; i++) {
       const c = this.columns[i];
       if (i !== 0) {
         sql += ', ';
       }
-      sql += escapeIdentifier(c.name) + ' ' + (c.type.declaration(c));
+      sql += '[' + c.name + '] ' + (c.type.declaration(c));
     }
     sql += ')';
 
@@ -559,13 +546,13 @@ class BulkLoad extends EventEmitter {
    * you'll need to use the same connection and execute your requests using [[Connection.execSqlBatch]] instead of [[Connection.execSql]]
    */
   getTableCreationSql() {
-    let sql = 'CREATE TABLE ' + escapeIdentifier(this.table) + ' (\n';
+    let sql = 'CREATE TABLE ' + this.table + '(\n';
     for (let i = 0, len = this.columns.length; i < len; i++) {
       const c = this.columns[i];
       if (i !== 0) {
         sql += ',\n';
       }
-      sql += escapeIdentifier(c.name) + ' ' + (c.type.declaration(c));
+      sql += '[' + c.name + '] ' + (c.type.declaration(c));
       if (c.nullable !== undefined) {
         sql += ' ' + (c.nullable ? 'NULL' : 'NOT NULL');
       }

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -90,38 +90,6 @@ describe('BulkLoad', function() {
     connection.execSqlBatch(request);
   });
 
-  it('supports exotic table and column names', function(done) {
-    const bulkLoad = connection.newBulkLoad('#[😀]', (err, rowCount) => {
-      if (err) {
-        return done(err);
-      }
-
-      assert.strictEqual(rowCount, 5, 'Incorrect number of rows inserted.');
-
-      done();
-    });
-
-    bulkLoad.addColumn('column # @ []', TYPES.Int, { nullable: false });
-    bulkLoad.addColumn('foo"bar"baz', TYPES.NVarChar, { length: 50, nullable: true });
-    bulkLoad.addColumn('😀', TYPES.DateTime, { nullable: false });
-
-    const request = new Request(bulkLoad.getTableCreationSql(), (err) => {
-      if (err) {
-        return done(err);
-      }
-
-      bulkLoad.addRow({ 'column # @ []': 201, 'foo"bar"baz': 'one zero one', '😀': new Date(1986, 6, 20) });
-      bulkLoad.addRow([202, 'one zero two', new Date()]);
-      bulkLoad.addRow(203, 'one zero three', new Date(2013, 7, 12));
-      bulkLoad.addRow({ 'column # @ []': 204, 'foo"bar"baz': 'one zero four', '😀': new Date() });
-      bulkLoad.addRow({ 'column # @ []': 205, 'foo"bar"baz': 'one zero five', '😀': new Date() });
-
-      connection.execBulkLoad(bulkLoad);
-    });
-
-    connection.execSqlBatch(request);
-  });
-
   it('fails if the column definition does not match the target table format', function(done) {
     const bulkLoad = connection.newBulkLoad('#tmpTestTable2', (err, rowCount) => {
       assert.instanceOf(err, Error, 'An error should have been thrown to indicate the incorrect table format.');
@@ -475,43 +443,6 @@ describe('BulkLoad', function() {
         bulkLoad.addRow({ id: 6, name: 'Charizard' });
         bulkLoad.addRow({ id: 5, name: 'Charmeleon' });
         bulkLoad.addRow({ id: 4, name: 'Charmander' });
-
-        connection.execBulkLoad(bulkLoad);
-      });
-
-      connection.execSqlBatch(request);
-    });
-
-    it('supports exotic column names in the order option', function(done) {
-      const bulkLoad = connection.newBulkLoad('#tmpTestTable', { order: { '😀': 'ASC' } }, function(err, rowCount) {
-        if (err) {
-          return done(err);
-        }
-
-        assert.strictEqual(rowCount, 5, 'Incorrect number of rows inserted.');
-
-        done();
-      });
-
-      bulkLoad.addColumn('😀', TYPES.Int, { nullable: false });
-
-      const request = new Request(`
-        CREATE TABLE "#tmpTestTable" (
-          "😀" int NOT NULL
-          PRIMARY KEY CLUSTERED ("😀")
-        )
-      `, function(err) {
-        if (err) {
-          return done(err);
-        }
-
-        bulkLoad.addRow({ '😀': 1 });
-        bulkLoad.addRow({ '😀': 2 });
-        bulkLoad.addRow({ '😀': 3 });
-        bulkLoad.addRow({ '😀': 4 });
-        bulkLoad.addRow({ '😀': 5 });
-
-        assert.include(bulkLoad.getBulkInsertSql(), 'ORDER ("😀" ASC)');
 
         connection.execBulkLoad(bulkLoad);
       });


### PR DESCRIPTION
This reverts the changes introduced in commit a67c0ad65abdb58e3aabc1c58b2b765ca2214175. This caused existing code that referenced tables using their fully qualified name to break unexpectedly.

Fixes: https://github.com/tediousjs/tedious/issues/1292
References: https://github.com/tediousjs/node-mssql/issues/1276
