### PR TITLE
feat: drop dependency on `readable-stream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "native-duplexpair": "^1.0.0",
     "node-abort-controller": "^2.0.0",
     "punycode": "^2.1.0",
-    "readable-stream": "^3.6.0",
     "sprintf-js": "^1.1.2"
   },
   "devDependencies": {
@@ -73,7 +72,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/mocha": "^8.2.3",
     "@types/node": "^14.14.20",
-    "@types/readable-stream": "^2.3.10",
     "@types/sprintf-js": "^1.1.2",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import Connection, { InternalConnectionOptions } from './connection';
 
-import { Transform } from 'readable-stream';
+import { Transform } from 'stream';
 import { TYPE as TOKEN_TYPE } from './token/token';
 
 import { DataType, Parameter } from './data-type';

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5,7 +5,7 @@ import { Socket } from 'net';
 import constants from 'constants';
 import { createSecureContext, SecureContext, SecureContextOptions } from 'tls';
 
-import { Readable, Stream } from 'readable-stream';
+import { Readable } from 'stream';
 
 import {
   loginWithVmMSI,
@@ -2639,7 +2639,7 @@ class Connection extends EventEmitter {
 
     const message = new Message({ type: TYPE.SQL_BATCH });
     this.messageIo.outgoingMessageStream.write(message);
-    (Readable as any).from(payload).pipe(message);
+    Readable.from(payload).pipe(message);
   }
 
   /**
@@ -3274,7 +3274,7 @@ class Connection extends EventEmitter {
         });
       });
 
-      const payloadStream = (Readable as any).from(payload!) as Stream;
+      const payloadStream = Readable.from(payload);
       payloadStream.once('error', (error) => {
         payloadStream.unpipe(message);
 

--- a/src/incoming-message-stream.ts
+++ b/src/incoming-message-stream.ts
@@ -1,5 +1,5 @@
 import BufferList from 'bl';
-import { Transform } from 'readable-stream';
+import { Transform } from 'stream';
 
 import Debug from './debug';
 import Message from './message';

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -47,8 +47,8 @@ class MessageIO extends EventEmitter {
 
     this.outgoingMessageStream = new OutgoingMessageStream(this.debug, { packetSize: packetSize });
 
-    this.socket.pipe(this.incomingMessageStream as unknown as NodeJS.WritableStream);
-    this.outgoingMessageStream.pipe(this.socket as unknown as import('readable-stream').Writable);
+    this.socket.pipe(this.incomingMessageStream);
+    this.outgoingMessageStream.pipe(this.socket);
   }
 
   packetSize(...args: [number]) {
@@ -107,14 +107,14 @@ class MessageIO extends EventEmitter {
     securePair.cleartext.setMaxSendFragment(this.outgoingMessageStream.packetSize);
     securePair.encrypted.removeAllListeners('data');
 
-    this.outgoingMessageStream.unpipe(this.socket as unknown as import('readable-stream').Writable);
-    this.socket.unpipe(this.incomingMessageStream as unknown as NodeJS.WritableStream);
+    this.outgoingMessageStream.unpipe(this.socket);
+    this.socket.unpipe(this.incomingMessageStream);
 
     this.socket.pipe(securePair.encrypted);
     securePair.encrypted.pipe(this.socket);
 
-    securePair.cleartext.pipe(this.incomingMessageStream as unknown as NodeJS.WritableStream);
-    this.outgoingMessageStream.pipe(securePair.cleartext as unknown as import('readable-stream').Writable);
+    securePair.cleartext.pipe(this.incomingMessageStream);
+    this.outgoingMessageStream.pipe(securePair.cleartext);
 
     this.tlsNegotiationComplete = true;
   }

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'readable-stream';
+import { PassThrough } from 'stream';
 
 class Message extends PassThrough {
   type: number;

--- a/src/outgoing-message-stream.ts
+++ b/src/outgoing-message-stream.ts
@@ -1,5 +1,5 @@
 import BufferList from 'bl';
-import { Duplex } from 'readable-stream';
+import { Duplex } from 'stream';
 
 import Debug from './debug';
 import Message from './message';

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -28,7 +28,7 @@ import {
   DoneProcToken,
   DoneToken
 } from './token';
-import { Readable } from 'readable-stream';
+import { Readable } from 'stream';
 import Message from '../message';
 
 export class Parser extends EventEmitter {
@@ -42,7 +42,7 @@ export class Parser extends EventEmitter {
     this.debug = debug;
     this.options = options;
 
-    this.parser = (Readable as any).from(StreamParser.parseTokens(message, this.debug, this.options)) as Readable;
+    this.parser = Readable.from(StreamParser.parseTokens(message, this.debug, this.options));
     this.parser.on('data', (token: Token) => {
       if (token.event) {
         this.emit(token.event, token);


### PR DESCRIPTION
The `readable-stream` module hasn't been updated for a long time, and it looks like it might not receive any updates in the future.

`readable-stream` was based on the `stream` core module as shipped with Node.js 10.x. As this is the oldest version of Node.js we support anyway, including `readable-stream` does not bring us anything. Newer Node.js versions ship with improved but fully backwards-compatible core streams, so we can just use them instead.
