### PR TITLE
fix: unpipe payload streams on cancel or error

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3244,6 +3244,8 @@ class Connection extends EventEmitter {
       request.rst! = [];
 
       const onCancel = () => {
+        payloadStream.unpipe(message);
+
         // set the ignore bit and end the message.
         message.ignore = true;
         message.end();
@@ -3274,6 +3276,8 @@ class Connection extends EventEmitter {
 
       const payloadStream = (Readable as any).from(payload!) as Stream;
       payloadStream.once('error', (error) => {
+        payloadStream.unpipe(message);
+
         // Only set a request error if no error was set yet.
         request.error ??= error;
 


### PR DESCRIPTION
This `unpipe`s the payload stream from the outgoing message when the current request is canceled, or an error happens in the payload stream.

This is in preparation for https://github.com/tediousjs/tedious/pull/1303, where not calling `unpipe` will cause `write after end` errors in newer Node.js versions (`16.x.x` and later).