### PR TITLE
fix: only destroy with error when in streaming mode

### DIFF
--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -16,9 +16,16 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       this.bulkLoad.removeListener('cancel', onCancel);
     });
 
-    const onCancel = () => {
-      this.bulkLoad.rowToPacketTransform.destroy(new RequestError('Canceled.', 'ECANCEL'));
-    };
+    let onCancel: () => void;
+    if (this.bulkLoad.streamingMode) {
+      onCancel = () => {
+        this.bulkLoad.rowToPacketTransform.destroy(new RequestError('Canceled.', 'ECANCEL'));
+      };
+    } else {
+      onCancel = () => {
+        this.bulkLoad.rowToPacketTransform.destroy();
+      };
+    }
 
     this.bulkLoad.once('cancel', onCancel);
   }


### PR DESCRIPTION
This changes the `.destroy` call on the row transform stream when a bulk load is cancelled to only be called with an error if the request is in streaming mode.

This change is in preparation of dropping the dependency on the `readable-stream` module.