### PR TITLE
ci: enable GitHub Actions workflow for more branches

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,10 +2,10 @@ name: Node CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "master", "alpha", "beta", "*.x" ]
 
   pull_request:
-    branches: [ master ]
+    branches: [ "master", "alpha", "beta", "*.x" ]
 
 env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This enables GitHub Actions workflows for more branches, namely `alpha`, `beta` and all branches that follow the `*.x` naming pattern. This will allow us to manage alpha, beta, and maintenance releases in a much more straightforward fashion.
