### PR TITLE
feat: drop support for Node.js 10.x 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
       fail-fast: false
 
     services:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: "10"
     - nodejs_version: "12"
     - nodejs_version: "14"
     - nodejs_version: "16"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/tediousjs/tedious.git"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "publishConfig": {
     "tag": "next"


### PR DESCRIPTION
Security support for Node.js 10.x officially ended in April 2021. I think it's safe to drop support for it in `tedious` as well.