### PR TITLE
feat: remove `validateBulkLoadParameters` connection option

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -168,12 +168,10 @@ class RowTransform extends Transform {
       const c = this.columns[i];
       let value = Array.isArray(row) ? row[i] : row[c.objName];
 
-      if (this.bulkLoad.options.validateBulkLoadParameters) {
-        try {
-          value = c.type.validate(value);
-        } catch (error) {
-          return callback(error);
-        }
+      try {
+        value = c.type.validate(value);
+      } catch (error) {
+        return callback(error);
       }
 
       const parameter = {
@@ -473,23 +471,11 @@ class BulkLoad extends EventEmitter {
     // write each column
     if (Array.isArray(row)) {
       this.rowToPacketTransform.write(this.columns.map((column, i) => {
-        let value = row[i];
-
-        if (this.options.validateBulkLoadParameters) {
-          value = column.type.validate(value);
-        }
-
-        return value;
+        return column.type.validate(row[i]);
       }));
     } else {
       this.rowToPacketTransform.write(this.columns.map((column) => {
-        let value = row[column.objName];
-
-        if (this.options.validateBulkLoadParameters) {
-          value = column.type.validate(value);
-        }
-
-        return value;
+        return column.type.validate(row[column.objName]);
       }));
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -384,7 +384,6 @@ export interface InternalConnectionOptions {
   trustServerCertificate: boolean;
   useColumnNames: boolean;
   useUTC: boolean;
-  validateBulkLoadParameters: boolean;
   workstationId: undefined | string;
   lowerCaseGuids: boolean;
 }
@@ -823,13 +822,6 @@ export interface ConnectionOptions {
    * (default: `true`).
    */
   useUTC?: boolean;
-
-  /**
-   * A boolean determining whether BulkLoad parameters should be validated.
-   *
-   * (default: `true`).
-   */
-  validateBulkLoadParameters?: boolean;
 
   /**
    * The workstation ID (WSID) of the client, default os.hostname().
@@ -1276,7 +1268,6 @@ class Connection extends EventEmitter {
         trustServerCertificate: true,
         useColumnNames: false,
         useUTC: true,
-        validateBulkLoadParameters: true,
         workstationId: undefined,
         lowerCaseGuids: false
       }
@@ -1675,18 +1666,6 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.useUTC = config.options.useUTC;
-      }
-
-      if (config.options.validateBulkLoadParameters !== undefined) {
-        if (typeof config.options.validateBulkLoadParameters !== 'boolean') {
-          throw new TypeError('The "config.options.validateBulkLoadParameters" property must be of type boolean.');
-        }
-
-        if (config.options.validateBulkLoadParameters === false) {
-          deprecate('Setting the "config.options.validateBulkLoadParameters" to `false` is deprecated and will no longer work in the next major version of `tedious`. Set the value to `true` and update your use of BulkLoad functionality to silence this message.');
-        }
-
-        this.config.options.validateBulkLoadParameters = config.options.validateBulkLoadParameters;
       }
 
       if (config.options.workstationId !== undefined) {

--- a/test/unit/bulk-load-test.js
+++ b/test/unit/bulk-load-test.js
@@ -10,7 +10,7 @@ describe('BulkLoad', function() {
   });
 
   it('throws an error when adding row with a value has the wrong data type', function() {
-    const request = new BulkLoad('tablename', { tdsVersion: '7_2', validateBulkLoadParameters: true }, { });
+    const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
     request.addColumn('columnName', TYPES.Date, { nullable: true });
     assert.throws(() => {
       request.addRow({ columnName: 'Wrong Input' });

--- a/test/unit/connection-config-validation.js
+++ b/test/unit/connection-config-validation.js
@@ -94,13 +94,4 @@ describe('Connection configuration validation', function() {
       new Connection(config);
     });
   });
-
-  it('bad validateBulkLoadParameters value', () => {
-    const validateBulkLoadParametersVal = 'text';
-    config.options.validateBulkLoadParameters = validateBulkLoadParametersVal;
-    config.options.tdsVersion = '7_2';
-    assert.throws(() => {
-      new Connection(config);
-    });
-  });
 });


### PR DESCRIPTION
BREAKING CHANGE: This removes the `validateBulkLoadParameters` connection option and always enables validation of bulk load values.
