### PR TITLE
Improve collation handling

### DIFF
--- a/src/always-encrypted/get-parameter-encryption-metadata.ts
+++ b/src/always-encrypted/get-parameter-encryption-metadata.ts
@@ -97,5 +97,5 @@ export const getParameterEncryptionMetadata = (connection: Connection, request: 
     resultRows.push(columns);
   });
 
-  connection.makeRequest(metadataRequest, TYPE.RPC_REQUEST, new RpcRequestPayload(metadataRequest.sqlTextOrProcedure!, metadataRequest.parameters, connection.currentTransactionDescriptor(), connection.config.options));
+  connection.makeRequest(metadataRequest, TYPE.RPC_REQUEST, new RpcRequestPayload(metadataRequest.sqlTextOrProcedure!, metadataRequest.parameters, connection.currentTransactionDescriptor(), connection.config.options, connection.databaseCollation));
 };

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -6,6 +6,7 @@ import { Transform } from 'stream';
 import { TYPE as TOKEN_TYPE } from './token/token';
 
 import { DataType, Parameter } from './data-type';
+import { Collation } from './collation';
 
 /**
  * @private
@@ -88,6 +89,7 @@ export type Callback =
 
 interface Column extends Parameter {
   objName: string;
+  collation: Collation | undefined;
 }
 
 interface ColumnOptions {
@@ -180,7 +182,7 @@ class RowTransform extends Transform {
       let value = Array.isArray(row) ? row[i] : row[c.objName];
 
       try {
-        value = c.type.validate(value);
+        value = c.type.validate(value, c.collation);
       } catch (error) {
         return callback(error);
       }
@@ -320,12 +322,14 @@ class BulkLoad extends EventEmitter {
   /**
    * @private
    */
-  rowCount?: number;;
+  rowCount?: number;
+
+  collation: Collation | undefined;
 
   /**
    * @private
    */
-  constructor(table: string, connectionOptions: InternalConnectionOptions, {
+  constructor(table: string, collation: Collation | undefined, connectionOptions: InternalConnectionOptions, {
     checkConstraints = false,
     fireTriggers = false,
     keepNulls = false,
@@ -363,6 +367,8 @@ class BulkLoad extends EventEmitter {
     this.error = undefined;
     this.canceled = false;
     this.executionStarted = false;
+
+    this.collation = collation;
 
     this.table = table;
     this.options = connectionOptions;
@@ -404,7 +410,7 @@ class BulkLoad extends EventEmitter {
       throw new Error('Columns cannot be added to bulk insert after execution has started.');
     }
 
-    const column = {
+    const column: Column = {
       type: type,
       name: name,
       value: null,
@@ -413,7 +419,8 @@ class BulkLoad extends EventEmitter {
       precision: precision,
       scale: scale,
       objName: objName,
-      nullable: nullable
+      nullable: nullable,
+      collation: this.collation
     };
 
     if ((type.id & 0x30) === 0x20) {
@@ -491,11 +498,11 @@ class BulkLoad extends EventEmitter {
     // write each column
     if (Array.isArray(row)) {
       this.rowToPacketTransform.write(this.columns.map((column, i) => {
-        return column.type.validate(row[i]);
+        return column.type.validate(row[i], column.collation);
       }));
     } else {
       this.rowToPacketTransform.write(this.columns.map((column) => {
-        return column.type.validate(row[column.objName]);
+        return column.type.validate(row[column.objName], column.collation);
       }));
     }
   }

--- a/src/collation.ts
+++ b/src/collation.ts
@@ -1,10 +1,14 @@
+type Encoding = 'utf-8' | 'CP437' | 'CP850' | 'CP874' | 'CP932' | 'CP936' | 'CP949' | 'CP950' | 'CP1250' | 'CP1251' | 'CP1252' | 'CP1253' | 'CP1254' | 'CP1255' | 'CP1256' | 'CP1257' | 'CP1258';
+
 // http://technet.microsoft.com/en-us/library/aa176553(v=sql.80).aspx
-export const codepageByLcid: { [key: number]: string | undefined } = {
+export const codepageByLanguageId: { [key: number]: Encoding } = {
   // Arabic_*
   [0x0401]: 'CP1256',
 
   // Chinese_Taiwan_Stroke_*
   // Chinese_Traditional_Stroke_Count_*
+  // Chinese_Taiwan_Bopomofo_*
+  // Chinese_Traditional_Bopomofo_*
   [0x0404]: 'CP950',
 
   // Czech_*
@@ -33,6 +37,7 @@ export const codepageByLcid: { [key: number]: string | undefined } = {
   [0x040D]: 'CP1255',
 
   // Hungarian_*
+  // Hungarian_Technical_*
   [0x040E]: 'CP1250',
 
   // Icelandic_*
@@ -40,6 +45,8 @@ export const codepageByLcid: { [key: number]: string | undefined } = {
 
   // Japanese_*
   // Japanese_XJIS_*
+  // Japanese_Unicode_*
+  // Japanese_Bushu_Kakusu_*
   [0x0411]: 'CP932',
 
   // Korean_*
@@ -88,204 +95,118 @@ export const codepageByLcid: { [key: number]: string | undefined } = {
   // Estonian_*
   [0x0425]: 'CP1257',
 
-  // Latvian_BIN
+  // Latvian_*
   [0x0426]: 'CP1257',
 
-  // Lithuanian_BIN
+  // Lithuanian_*
   [0x0427]: 'CP1257',
 
-  // Persian_100_BIN
+  // Persian_*
   [0x0429]: 'CP1256',
 
-  // Vietnamese_BIN
+  // Vietnamese_*
   [0x042A]: 'CP1258',
 
-  // Azeri_Latin_100_BIN
+  // Azeri_Latin_*
   [0x042C]: 'CP1254',
 
-  // Upper_Sorbian_100_BIN
+  // Upper_Sorbian_*
   [0x042E]: 'CP1252',
 
-  // Macedonian_FYROM_90_BIN
+  // Macedonian_FYROM_*
   [0x042F]: 'CP1251',
 
-  // Sami_Norway_100_BIN
+  // Sami_Norway_*
   [0x043B]: 'CP1252',
 
-  // Kazakh_90_BIN
+  // Kazakh_*
   [0x043F]: 'CP1251',
 
-  // Turkmen_100_BIN
+  // Turkmen_*
   [0x0442]: 'CP1250',
 
-  // Uzbek_Latin_90_BIN
+  // Uzbek_Latin_*
   [0x0443]: 'CP1254',
 
-  // Tatar_90_BIN
+  // Tatar_*
   [0x0444]: 'CP1251',
 
-  // Welsh_100_BIN
+  // Welsh_*
   [0x0452]: 'CP1252',
 
-  // Frisian_100_BIN
+  // Frisian_*
   [0x0462]: 'CP1252',
 
-  // Bashkir_100_BIN
+  // Bashkir_*
   [0x046D]: 'CP1251',
 
-  // Mapudungan_100_BIN
+  // Mapudungan_*
   [0x047A]: 'CP1252',
 
-  // Mohawk_100_BIN
+  // Mohawk_*
   [0x047C]: 'CP1252',
 
-  // Breton_100_BIN
+  // Breton_*
   [0x047E]: 'CP1252',
 
-  // Uighur_100_BIN
+  // Uighur_*
   [0x0480]: 'CP1256',
 
-  // Corsican_100_BIN
+  // Corsican_*
   [0x0483]: 'CP1252',
 
-  // Yakut_100_BIN
+  // Yakut_*
   [0x0485]: 'CP1251',
 
-  // Dari_100_BIN
+  // Dari_*
   [0x048C]: 'CP1256',
 
-  // Chinese_PRC_BIN
-  // Chinese_Simplified_Pinyin_100_BIN
+  // Chinese_PRC_*
+  // Chinese_Simplified_Pinyin_*
+  // Chinese_PRC_Stroke_*
+  // Chinese_Simplified_Stroke_Order_*
   [0x0804]: 'CP936',
 
-  // Serbian_Latin_100_BIN
+  // Serbian_Latin_*
   [0x081A]: 'CP1250',
 
-  // Azeri_Cyrillic_100_BIN
+  // Azeri_Cyrillic_*
   [0x082C]: 'CP1251',
 
-  // Sami_Sweden_Finland_100_BIN
+  // Sami_Sweden_Finland_*
   [0x083B]: 'CP1252',
 
-  // Tamazight_100_BIN
+  // Tamazight_*
   [0x085F]: 'CP1252',
 
-  // Chinese_Hong_Kong_Stroke_90_BIN
+  // Chinese_Hong_Kong_Stroke_*
   [0x0C04]: 'CP950',
 
-  // Modern_Spanish_BIN
+  // Modern_Spanish_*
   [0x0C0A]: 'CP1252',
 
-  // Serbian_Cyrillic_100_BIN
+  // Serbian_Cyrillic_*
   [0x0C1A]: 'CP1251',
 
-  // Chinese_Traditional_Pinyin_100_BIN
+  // Chinese_Traditional_Pinyin_*
+  // Chinese_Traditional_Stroke_Order_*
   [0x1404]: 'CP950',
 
-  // Bosnian_Latin_100_BIN
+  // Bosnian_Latin_*
   [0x141A]: 'CP1250',
 
-  // Bosnian_Cyrillic_100_BIN
+  // Bosnian_Cyrillic_*
   [0x201A]: 'CP1251',
 
   // German
+  // German_PhoneBook_*
   [0x0407]: 'CP1252',
 
-  // German_PhoneBook_BIN
-  [0x10407]: 'CP1252',
-
-  // Hungarian_Technical_BIN
-  [0x1040E]: 'CP1250',
-
-  // Japanese_Unicode_BIN
-  [0x10411]: 'CP932',
-
-  // Georgian_Modern_Sort_BIN
-  [0x10437]: 'CP1252',
-
-  // Chinese_PRC_Stroke_BIN
-  // Chinese_Simplified_Stroke_Order_100_BIN
-  [0x20804]: 'CP936',
-
-  // Chinese_Traditional_Stroke_Order_100_BIN
-  [0x21404]: 'CP950',
-
-  // Chinese_Taiwan_Bopomofo_BIN
-  // Chinese_Traditional_Bopomofo_100_BIN
-  [0x30404]: 'CP950',
-
-  // Japanese_Bushu_Kakusu_100_BIN
-  [0x40411]: 'CP932',
-
-  // These LCIDs might not actually be supported by SQL Server
-
-  [0x0436]: 'CP1252',
-  [0x0801]: 'CP1256',
-  [0x0C01]: 'CP1256',
-  [0x1001]: 'CP1256',
-  [0x1401]: 'CP1256',
-  [0x1801]: 'CP1256',
-  [0x1C01]: 'CP1256',
-  [0x2001]: 'CP1256',
-  [0x2401]: 'CP1256',
-  [0x2801]: 'CP1256',
-  [0x2C01]: 'CP1256',
-  [0x3001]: 'CP1256',
-  [0x3401]: 'CP1256',
-  [0x3801]: 'CP1256',
-  [0x3C01]: 'CP1256',
-  [0x4001]: 'CP1256',
-  [0x42D]: 'CP1252',
-  [0x423]: 'CP1251',
-  [0x402]: 'CP1251',
-  [0x403]: 'CP1252',
-  [0x1004]: 'CP936',
-  [0x413]: 'CP1252',
-  [0x813]: 'CP1252',
-  [0x809]: 'CP1252',
-  [0x1009]: 'CP1252',
-  [0x1409]: 'CP1252',
-  [0xC09]: 'CP1252',
-  [0x1809]: 'CP1252',
-  [0x1C09]: 'CP1252',
-  [0x2409]: 'CP1252',
-  [0x2009]: 'CP1252',
-  [0x0438]: 'CP1252',
-  [0x80C]: 'CP1252',
-  [0x100C]: 'CP1252',
-  [0xC0C]: 'CP1252',
-  [0x140C]: 'CP1252',
-  [0x807]: 'CP1252',
-  [0xC07]: 'CP1252',
-  [0x1007]: 'CP1252',
-  [0x1407]: 'CP1252',
-  [0x439]: 'CPUTF8',
-  [0x104E]: 'CP1250',
-  [0x421]: 'CP1252',
-  [0x410]: 'CP1252',
-  [0x810]: 'CP1252',
-  [0x827]: 'CP1257',
-  [0x814]: 'CP1252',
-  [0x816]: 'CP1252',
-  [0x416]: 'CP1252',
-  [0x80A]: 'CP1252',
-  [0x100A]: 'CP1252',
-  [0x140A]: 'CP1252',
-  [0x180A]: 'CP1252',
-  [0x1C0A]: 'CP1252',
-  [0x200A]: 'CP1252',
-  [0x240A]: 'CP1252',
-  [0x280A]: 'CP1252',
-  [0x2C0A]: 'CP1252',
-  [0x300A]: 'CP1252',
-  [0x340A]: 'CP1252',
-  [0x380A]: 'CP1252',
-  [0x3C0A]: 'CP1252',
-  [0x400A]: 'CP1252',
-  [0x41D]: 'CP1252',
+  // Georgian_Modern_Sort_*
+  [0x0437]: 'CP1252'
 };
 
-export const codepageBySortId: { [key: number]: string | undefined } = {
+export const codepageBySortId: { [key: number]: Encoding } = {
   [30]: 'CP437', // SQL_Latin1_General_CP437_BIN
   [31]: 'CP437', // SQL_Latin1_General_CP437_CS_AS
   [32]: 'CP437', // SQL_Latin1_General_CP437_CI_AS
@@ -360,3 +281,74 @@ export const codepageBySortId: { [key: number]: string | undefined } = {
   [185]: 'CP1252', // SQL_SwedishStd_Pref_Cp1_CI_AS_KI_WI
   [186]: 'CP1252' // SQL_Icelandic_Pref_Cp1_CI_AS_KI_WI
 };
+
+export const Flags = {
+  IGNORE_CASE: 1 << 0,
+  IGNORE_ACCENT: 1 << 1,
+  IGNORE_KANA: 1 << 2,
+  IGNORE_WIDTH: 1 << 3,
+  BINARY: 1 << 4,
+  BINARY2: 1 << 5,
+  UTF8: 1 << 6,
+};
+
+export class Collation {
+  readonly lcid: number;
+  readonly flags: number;
+  readonly version: number;
+  readonly sortId: number;
+  readonly codepage: Encoding | undefined;
+
+  private buffer: Buffer | undefined;
+
+  static fromBuffer(buffer: Buffer, offset = 0) {
+    let lcid = (buffer[offset + 2] & 0x0F) << 16;
+    lcid |= buffer[offset + 1] << 8;
+    lcid |= buffer[offset + 0];
+
+    let flags = (buffer[offset + 3] & 0x0F) << 4;
+    flags |= (buffer[offset + 2] & 0xF0) >>> 4;
+
+    const version = (buffer[offset + 3] & 0xF0) >>> 4;
+
+    const sortId = buffer[offset + 4];
+
+    return new this(lcid, flags, version, sortId);
+  }
+
+  constructor(lcid: number, flags: number, version: number, sortId: number) {
+    this.buffer = undefined;
+
+    this.lcid = lcid;
+    this.flags = flags;
+    this.version = version;
+    this.sortId = sortId;
+
+    if (this.flags & Flags.UTF8) {
+      this.codepage = 'utf-8';
+    } else if (this.sortId) {
+      this.codepage = codepageBySortId[this.sortId];
+    } else {
+      // The last 16 bits of the LCID are the language id.
+      // The first 4 bits define additional sort orders.
+      const languageId = this.lcid & 0xFFFF;
+      this.codepage = codepageByLanguageId[languageId];
+    }
+  }
+
+  toBuffer(): Buffer {
+    if (this.buffer) {
+      return this.buffer;
+    }
+
+    this.buffer = Buffer.alloc(5);
+
+    this.buffer[0] = this.lcid & 0xFF;
+    this.buffer[1] = (this.lcid >>> 8) & 0xFF;
+    this.buffer[2] = ((this.lcid >>> 16) & 0x0F) | ((this.flags & 0x0F) << 4);
+    this.buffer[3] = ((this.flags & 0xF0) >>> 4) | ((this.version & 0x0F) << 4);
+    this.buffer[4] = this.sortId & 0xFF;
+
+    return this.buffer;
+  }
+}

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2808,7 +2808,7 @@ class Connection extends EventEmitter {
       parameters.push(...request.parameters);
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_executesql', parameters, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_executesql', parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3022,7 +3022,7 @@ class Connection extends EventEmitter {
       }
     });
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_prepare', parameters, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_prepare', parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3046,7 +3046,7 @@ class Connection extends EventEmitter {
       scale: undefined
     });
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_unprepare', parameters, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_unprepare', parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3092,7 +3092,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_execute', executeParameters, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_execute', executeParameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3114,7 +3114,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2770,7 +2770,7 @@ class Connection extends EventEmitter {
    */
   execSql(request: Request) {
     try {
-      request.validateParameters();
+      request.validateParameters(this.databaseCollation);
     } catch (error) {
       request.error = error;
 
@@ -2832,7 +2832,7 @@ class Connection extends EventEmitter {
     if (typeof options !== 'object') {
       throw new TypeError('"options" argument must be an object');
     }
-    return new BulkLoad(table, this.config.options, options, callback);
+    return new BulkLoad(table, this.databaseCollation, this.config.options, options, callback);
   }
 
   /**
@@ -3078,7 +3078,7 @@ class Connection extends EventEmitter {
 
         executeParameters.push({
           ...parameter,
-          value: parameter.type.validate(parameters ? parameters[parameter.name] : null)
+          value: parameter.type.validate(parameters ? parameters[parameter.name] : null, this.databaseCollation)
         });
       }
     } catch (error) {
@@ -3102,7 +3102,7 @@ class Connection extends EventEmitter {
    */
   callProcedure(request: Request) {
     try {
-      request.validateParameters();
+      request.validateParameters(this.databaseCollation);
     } catch (error) {
       request.error = error;
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -47,6 +47,7 @@ import { MemoryCache } from 'adal-node';
 import AbortController, { AbortSignal } from 'node-abort-controller';
 import { Parameter, TYPES } from './data-type';
 import { BulkLoadPayload } from './bulk-load-payload';
+import { Collation } from './collation';
 
 import { version } from '../package.json';
 
@@ -1020,6 +1021,11 @@ class Connection extends EventEmitter {
    * @private
    */
   _cancelAfterRequestSent: () => void;
+
+  /**
+   * @private
+   */
+  databaseCollation: Collation | undefined;
 
   /**
    * Note: be aware of the different options field:
@@ -2021,6 +2027,10 @@ class Connection extends EventEmitter {
 
     tokenStreamParser.on('charsetChange', (token) => {
       this.emit('charsetChange', token.newValue);
+    });
+
+    tokenStreamParser.on('sqlCollationChange', (token) => {
+      this.databaseCollation = token.newValue;
     });
 
     tokenStreamParser.on('fedAuthInfo', (token) => {

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -80,7 +80,7 @@ export interface DataType {
   generateTypeInfo(parameter: ParameterData, options: InternalConnectionOptions): Buffer;
   generateParameterLength(parameter: ParameterData, options: InternalConnectionOptions): Buffer;
   generateParameterData(parameter: ParameterData, options: InternalConnectionOptions): Generator<Buffer, void>;
-  validate(value: any): any; // TODO: Refactor 'any' and replace with more specific type.
+  validate(value: any, collation: Collation | undefined): any; // TODO: Refactor 'any' and replace with more specific type.
 
   hasTableName?: boolean;
 

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -40,6 +40,7 @@ import Variant from './data-types/sql-variant';
 import { CryptoMetadata } from './always-encrypted/types';
 
 import { InternalConnectionOptions } from './connection';
+import { Collation } from './collation';
 
 export interface Parameter {
   type: DataType;
@@ -51,12 +52,6 @@ export interface Parameter {
   length?: number;
   precision?: number;
   scale?: number;
-  collation?: {
-    lcid: number;
-    flags: number;
-    version: number;
-    sortId: number;
-  };
 
   nullable?: boolean;
 
@@ -70,6 +65,8 @@ export interface ParameterData<T = any> {
   length?: number;
   scale?: number;
   precision?: number;
+
+  collation?: Collation;
 
   value: T;
 }

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -50,6 +50,11 @@ const Char: { maximumLength: number } & DataType = {
     const buffer = Buffer.alloc(8);
     buffer.writeUInt8(this.id, 0);
     buffer.writeUInt16LE(parameter.length!, 1);
+
+    if (parameter.collation) {
+      parameter.collation.toBuffer().copy(buffer, 3, 0, 5);
+    }
+
     return buffer;
   },
 

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -10,14 +10,13 @@ const Char: { maximumLength: number } & DataType = {
   maximumLength: 8000,
 
   declaration: function(parameter) {
-    // const value = parameter.value as null | string | { toString(): string };
-    const value = parameter.value as any; // Temporary solution. Remove 'any' later.
+    const value = parameter.value as Buffer | null;
 
     let length;
     if (parameter.length) {
       length = parameter.length;
     } else if (value != null) {
-      length = value.toString().length || 1;
+      length = value.length || 1;
     } else if (value === null && !parameter.output) {
       length = 1;
     } else {
@@ -33,15 +32,12 @@ const Char: { maximumLength: number } & DataType = {
 
   // ParameterData<any> is temporary solution. TODO: need to understand what type ParameterData<...> can be.
   resolveLength: function(parameter) {
-    const value = parameter.value as any; // Temporary solution. Remove 'any' later.
+    const value = parameter.value as Buffer | null;
+
     if (parameter.length != null) {
       return parameter.length;
     } else if (value != null) {
-      if (Buffer.isBuffer(value)) {
-        return value.length || 1;
-      } else {
-        return value.toString().length || 1;
-      }
+      return value.length || 1;
     } else {
       return this.maximumLength;
     }
@@ -60,14 +56,14 @@ const Char: { maximumLength: number } & DataType = {
   },
 
   generateParameterLength(parameter, options) {
-    if (parameter.value == null) {
+    const value = parameter.value as Buffer | null;
+
+    if (value == null) {
       return NULL_LENGTH;
     }
 
-    const length = Buffer.byteLength(parameter.value.toString(), 'ascii');
-
     const buffer = Buffer.alloc(2);
-    buffer.writeUInt16LE(length, 0);
+    buffer.writeUInt16LE(value.length, 0);
     return buffer;
   },
 
@@ -79,7 +75,7 @@ const Char: { maximumLength: number } & DataType = {
     yield Buffer.from(parameter.value, 'ascii');
   },
 
-  validate: function(value, collation): null | Buffer {
+  validate: function(value, collation): Buffer | null {
     if (value == null) {
       return null;
     }

--- a/src/data-types/char.ts
+++ b/src/data-types/char.ts
@@ -1,3 +1,4 @@
+import iconv from 'iconv-lite';
 import { DataType } from '../data-type';
 
 const NULL_LENGTH = Buffer.from([0xFF, 0xFF]);
@@ -78,17 +79,27 @@ const Char: { maximumLength: number } & DataType = {
     yield Buffer.from(parameter.value, 'ascii');
   },
 
-  validate: function(value): null | string {
+  validate: function(value, collation): null | Buffer {
     if (value == null) {
       return null;
     }
+
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
         throw new TypeError('Invalid string.');
       }
       value = value.toString();
     }
-    return value;
+
+    if (!collation) {
+      throw new Error('No collation was set by the server for the current connection.');
+    }
+
+    if (!collation.codepage) {
+      throw new Error('The collation set by the server has no associated encoding.');
+    }
+
+    return iconv.encode(value, collation.codepage);
   }
 };
 

--- a/src/data-types/nchar.ts
+++ b/src/data-types/nchar.ts
@@ -51,6 +51,11 @@ const NChar: DataType & { maximumLength: number } = {
     const buffer = Buffer.alloc(8);
     buffer.writeUInt8(this.id, 0);
     buffer.writeUInt16LE(parameter.length! * 2, 1);
+
+    if (parameter.collation) {
+      parameter.collation.toBuffer().copy(buffer, 3, 0, 5);
+    }
+
     return buffer;
   },
 

--- a/src/data-types/ntext.ts
+++ b/src/data-types/ntext.ts
@@ -27,7 +27,11 @@ const NText: DataType = {
     const buffer = Buffer.alloc(10);
     buffer.writeUInt8(this.id, 0);
     buffer.writeInt32LE(parameter.length!, 1);
-    // TODO: Collation handling
+
+    if (parameter.collation) {
+      parameter.collation.toBuffer().copy(buffer, 5, 0, 5);
+    }
+
     return buffer;
   },
 

--- a/src/data-types/nvarchar.ts
+++ b/src/data-types/nvarchar.ts
@@ -59,6 +59,10 @@ const NVarChar: { maximumLength: number } & DataType = {
       buffer.writeUInt16LE(MAX, 1);
     }
 
+    if (parameter.collation) {
+      parameter.collation.toBuffer().copy(buffer, 3, 0, 5);
+    }
+
     return buffer;
   },
 

--- a/src/data-types/text.ts
+++ b/src/data-types/text.ts
@@ -16,7 +16,7 @@ const Text: DataType = {
   },
 
   resolveLength: function(parameter) {
-    const value = parameter.value as any; // Temporary solution. Remove 'any' later.
+    const value = parameter.value as Buffer | null;
 
     if (value != null) {
       return value.length;
@@ -38,27 +38,25 @@ const Text: DataType = {
   },
 
   generateParameterLength(parameter, options) {
-    if (parameter.value == null) {
+    const value = parameter.value as Buffer | null;
+
+    if (value == null) {
       return NULL_LENGTH;
     }
 
     const buffer = Buffer.alloc(4);
-    buffer.writeInt32LE(parameter.value.length!, 0);
+    buffer.writeInt32LE(value.length, 0);
     return buffer;
   },
 
   generateParameterData: function*(parameter, options) {
-    if (parameter.value == null) {
+    const value = parameter.value as Buffer | null;
+
+    if (value == null) {
       return;
     }
 
-    const value = parameter.value;
-
-    if (Buffer.isBuffer(value)) {
-      yield value;
-    } else {
-      yield Buffer.from(value.toString(), 'ascii');
-    }
+    yield value;
   },
 
   validate: function(value, collation): Buffer | null {

--- a/src/data-types/text.ts
+++ b/src/data-types/text.ts
@@ -27,7 +27,11 @@ const Text: DataType = {
     const buffer = Buffer.alloc(10);
     buffer.writeUInt8(this.id, 0);
     buffer.writeInt32LE(parameter.length!, 1);
-    // TODO: Collation handling
+
+    if (parameter.collation) {
+      parameter.collation.toBuffer().copy(buffer, 5, 0, 5);
+    }
+
     return buffer;
   },
 
@@ -53,6 +57,7 @@ const Text: DataType = {
     if (value == null) {
       return null;
     }
+
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
         throw new TypeError('Invalid string.');

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -60,6 +60,10 @@ const VarChar: { maximumLength: number } & DataType = {
       buffer.writeUInt16LE(MAX, 1);
     }
 
+    if (parameter.collation) {
+      parameter.collation.toBuffer().copy(buffer, 3, 0, 5);
+    }
+
     return buffer;
   },
 

--- a/src/data-types/varchar.ts
+++ b/src/data-types/varchar.ts
@@ -1,3 +1,5 @@
+import iconv from 'iconv-lite';
+
 import { DataType } from '../data-type';
 
 const MAX = (1 << 16) - 1;
@@ -128,17 +130,28 @@ const VarChar: { maximumLength: number } & DataType = {
     }
   },
 
-  validate: function(value): string | null {
+  validate: function(value, collation): Buffer | null {
     if (value == null) {
       return null;
     }
+
     if (typeof value !== 'string') {
       if (typeof value.toString !== 'function') {
         throw new TypeError('Invalid string.');
       }
+
       value = value.toString();
     }
-    return value;
+
+    if (!collation) {
+      throw new Error('No collation was set by the server for the current connection.');
+    }
+
+    if (!collation.codepage) {
+      throw new Error('The collation set by the server has no associated encoding.');
+    }
+
+    return iconv.encode(value, collation.codepage);
   }
 };
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,7 @@ import Connection from './connection';
 import { Metadata } from './metadata-parser';
 import { SQLServerStatementColumnEncryptionSetting } from './always-encrypted/types';
 import { ColumnMetadata } from './token/colmetadata-token-parser';
+import { Collation } from './collation';
 
 /**
  * The callback is called when the request has completed, either successfully or with an error.
@@ -462,12 +463,12 @@ class Request extends EventEmitter {
   /**
    * @private
    */
-  validateParameters() {
+  validateParameters(collation: Collation | undefined) {
     for (let i = 0, len = this.parameters.length; i < len; i++) {
       const parameter = this.parameters[i];
 
       try {
-        parameter.value = parameter.type.validate(parameter.value);
+        parameter.value = parameter.type.validate(parameter.value, collation);
       } catch (error) {
         throw new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + error.message, 'EPARAM');
       }

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -2,6 +2,7 @@ import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import { writeToTrackingBuffer } from './all-headers';
 import { Parameter, ParameterData } from './data-type';
 import { InternalConnectionOptions } from './connection';
+import { Collation } from './collation';
 
 // const OPTION = {
 //   WITH_RECOMPILE: 0x01,
@@ -23,12 +24,14 @@ class RpcRequestPayload implements Iterable<Buffer> {
 
   options: InternalConnectionOptions;
   txnDescriptor: Buffer;
+  collation: Collation | undefined;
 
-  constructor(procedure: string | number, parameters: Parameter[], txnDescriptor: Buffer, options: InternalConnectionOptions) {
+  constructor(procedure: string | number, parameters: Parameter[], txnDescriptor: Buffer, options: InternalConnectionOptions, collation: Collation | undefined) {
     this.procedure = procedure;
     this.parameters = parameters;
     this.options = options;
     this.txnDescriptor = txnDescriptor;
+    this.collation = collation;
   }
 
   [Symbol.iterator]() {
@@ -97,6 +100,10 @@ class RpcRequestPayload implements Iterable<Buffer> {
       param.scale = parameter.scale;
     } else if (type.resolveScale) {
       param.scale = type.resolveScale(parameter);
+    }
+
+    if (this.collation) {
+      param.collation = this.collation;
     }
 
     yield type.generateTypeInfo(param, this.options);

--- a/src/token/env-change-token-parser.ts
+++ b/src/token/env-change-token-parser.ts
@@ -1,5 +1,6 @@
 import Parser from './stream-parser';
 import { InternalConnectionOptions } from '../connection';
+import { Collation } from '../collation';
 
 import {
   DatabaseEnvChangeToken,
@@ -114,8 +115,12 @@ function readNewAndOldValue(parser: Parser, length: number, type: { name: string
       return parser.readBVarByte((newValue) => {
         parser.readBVarByte((oldValue) => {
           switch (type.name) {
-            case 'SQL_COLLATION':
-              return callback(new CollationChangeToken(newValue, oldValue));
+            case 'SQL_COLLATION': {
+              const newCollation = newValue.length ? Collation.fromBuffer(newValue) : undefined;
+              const oldCollation = oldValue.length ? Collation.fromBuffer(oldValue) : undefined;
+
+              return callback(new CollationChangeToken(newCollation, oldCollation));
+            }
 
             case 'BEGIN_TXN':
               return callback(new BeginTransactionEnvChangeToken(newValue, oldValue));

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -26,7 +26,8 @@ import {
   ReturnValueToken,
   DoneInProcToken,
   DoneProcToken,
-  DoneToken
+  DoneToken,
+  CollationChangeToken
 } from './token';
 import { Readable } from 'stream';
 import Message from '../message';
@@ -65,6 +66,7 @@ export class Parser extends EventEmitter {
     ((event: 'databaseChange', listener: (token: DatabaseEnvChangeToken) => void) => this) &
     ((event: 'languageChange', listener: (token: LanguageEnvChangeToken) => void) => this) &
     ((event: 'charsetChange', listener: (token: CharsetEnvChangeToken) => void) => this) &
+    ((event: 'sqlCollationChange', listener: (token: CollationChangeToken) => void) => this) &
     ((event: 'fedAuthInfo', listener: (token: FedAuthInfoToken) => void) => this) &
     ((event: 'featureExtAck', listener: (token: FeatureExtAckToken) => void) => this) &
     ((event: 'loginack', listener: (token: LoginAckToken) => void) => this) &

--- a/src/token/token.ts
+++ b/src/token/token.ts
@@ -1,3 +1,4 @@
+import { Collation } from '../collation';
 import { Metadata } from '../metadata-parser';
 import { ColumnMetadata } from './colmetadata-token-parser';
 
@@ -281,10 +282,10 @@ export class CollationChangeToken extends Token {
   declare event: 'sqlCollationChange';
 
   type: 'SQL_COLLATION';
-  oldValue: Buffer;
-  newValue: Buffer;
+  oldValue: Collation | undefined;
+  newValue: Collation | undefined;
 
-  constructor(newValue: Buffer, oldValue: Buffer) {
+  constructor(newValue: Collation | undefined, oldValue: Collation | undefined) {
     super('ENVCHANGE', 'sqlCollationChange');
 
     this.type = 'SQL_COLLATION';

--- a/src/value-parser.ts
+++ b/src/value-parser.ts
@@ -163,7 +163,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
 
     case 'VarChar':
     case 'Char':
-      const codepage = metadata.collation!.codepage;
+      const codepage = metadata.collation!.codepage!;
       if (metadata.dataLength === MAX) {
         return readMaxChars(parser, codepage, callback);
       } else {
@@ -213,7 +213,7 @@ function valueParse(parser: Parser, metadata: Metadata, options: InternalConnect
         parser.readBuffer(textPointerLength, (_textPointer) => {
           parser.readBuffer(8, (_timestamp) => {
             parser.readUInt32LE((dataLength) => {
-              readChars(parser, dataLength!, metadata.collation!.codepage, callback);
+              readChars(parser, dataLength!, metadata.collation!.codepage!, callback);
             });
           });
         });
@@ -460,7 +460,7 @@ function readVariant(parser: Parser, options: InternalConnectionOptions, dataLen
         case 'Char':
           return parser.readUInt16LE((_maxLength) => {
             readCollation(parser, (collation) => {
-              readChars(parser, dataLength, collation!.codepage, callback);
+              readChars(parser, dataLength, collation.codepage!, callback);
             });
           });
 

--- a/test/integration/collation-test.ts
+++ b/test/integration/collation-test.ts
@@ -1,0 +1,234 @@
+import fs from 'fs';
+import { homedir } from 'os';
+import { assert } from 'chai';
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
+import { Flags } from '../../src/collation';
+import { TYPES } from '../../src/data-type';
+
+function getConfig() {
+  const { config } = JSON.parse(
+    fs.readFileSync(homedir() + '/.tedious/test-connection.json', 'utf8')
+  );
+
+  config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
+
+  return config;
+}
+
+describe('Database Collation Support', function() {
+  let connection: Connection;
+  let originalDatabaseName: string;
+
+  before(function() {
+    // Creating new databases on Azure SQL is a bit of a headache.
+    if (/\w+\.database\.windows\.net/.test(getConfig().server)) {
+      this.skip();
+    }
+  });
+
+  beforeEach(function(done) {
+    connection = new Connection(getConfig());
+    connection.once('databaseChange', (databaseName) => {
+      originalDatabaseName = databaseName;
+    });
+    connection.connect(done);
+  });
+
+  beforeEach(function(done) {
+    const request = new Request('DROP DATABASE IF EXISTS __tedious_collation_1', done);
+    connection.execSqlBatch(request);
+  });
+
+  beforeEach(function(done) {
+    const request = new Request('CREATE DATABASE __tedious_collation_1 COLLATE Chinese_PRC_CI_AS', done);
+    connection.execSqlBatch(request);
+  });
+
+  afterEach(function(done) {
+    const request = new Request('USE ' + originalDatabaseName, done);
+    connection.execSqlBatch(request);
+  });
+
+  afterEach(function(done) {
+    const request = new Request('DROP DATABASE __tedious_collation_1', done);
+    connection.execSqlBatch(request);
+  });
+
+  afterEach(function(done) {
+    if (!connection.closed) {
+      connection.on('end', done);
+      connection.close();
+    } else {
+      done();
+    }
+  });
+
+  it('tracks the current database\'s collation', function(done) {
+    const request = new Request('USE __tedious_collation_1', (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      const collation = connection.databaseCollation;
+      assert.strictEqual(collation?.lcid, 2052);
+      assert.strictEqual(collation?.flags, Flags.IGNORE_CASE | Flags.IGNORE_KANA | Flags.IGNORE_WIDTH);
+      assert.strictEqual(collation?.version, 0);
+      assert.strictEqual(collation?.sortId, 0);
+      assert.strictEqual(collation?.codepage, 'CP936');
+
+      done();
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('converts `varchar` parameters with the current collation\'s encoding', function(done) {
+    const request = new Request('USE __tedious_collation_1', (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      let result: string;
+      const request = new Request('SELECT @p1', function(err) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.strictEqual(result, '中文');
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        result = row[0].value;
+      });
+
+      request.addParameter('p1', TYPES.VarChar, '中文');
+
+      connection.execSql(request);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('converts `char` parameters with the current collation\'s encoding', function(done) {
+    const request = new Request('USE __tedious_collation_1', (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      let result: string;
+      const request = new Request('SELECT @p1', function(err) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.strictEqual(result, '中文');
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        result = row[0].value;
+      });
+
+      request.addParameter('p1', TYPES.Char, '中文');
+
+      connection.execSql(request);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('converts `text` parameters with the current collation\'s encoding', function(done) {
+    const request = new Request('USE __tedious_collation_1', (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      let result: string;
+      const request = new Request('SELECT @p1', function(err) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.strictEqual(result, '中文');
+
+        done();
+      });
+
+      request.on('row', (row) => {
+        result = row[0].value;
+      });
+
+      request.addParameter('p1', TYPES.Text, '中文');
+
+      connection.execSql(request);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  describe('bulk loads', function() {
+    beforeEach(function(done) {
+      const request = new Request('USE __tedious_collation_1', done);
+      connection.execSqlBatch(request);
+    });
+
+    beforeEach(function(done) {
+      const request = new Request('DROP TABLE IF EXISTS collation_test', done);
+      connection.execSqlBatch(request);
+    });
+
+    beforeEach(function(done) {
+      const request = new Request(`
+        CREATE TABLE collation_test (
+          one varchar(10) NOT NULL,
+          two char(10) NOT NULL,
+          three text NOT NULL
+        )
+      `, done);
+      connection.execSqlBatch(request);
+    });
+
+    afterEach(function(done) {
+      const request = new Request('DROP TABLE IF EXISTS collation_test', done);
+      connection.execSqlBatch(request);
+    });
+
+    it('encodes values with the current database encoding', function(done) {
+      const bulkLoad = connection.newBulkLoad('collation_test', (err) => {
+        if (err) {
+          return done(err);
+        }
+
+        let values: [string, string, string];
+        const request = new Request('SELECT * FROM collation_test', (err) => {
+          if (err) {
+            return done(err);
+          }
+
+          assert.deepEqual(values, ['中文', '中文      ', '中文']);
+
+          done();
+        });
+
+        request.on('row', (row) => {
+          values = [row[0].value, row[1].value, row[2].value];
+        });
+
+        connection.execSql(request);
+      });
+
+      bulkLoad.addColumn('one', TYPES.VarChar, { length: 255, nullable: false });
+      bulkLoad.addColumn('two', TYPES.Char, { length: 10, nullable: false });
+      bulkLoad.addColumn('three', TYPES.Text, { nullable: false });
+
+      connection.execBulkLoad(bulkLoad, [
+        { one: '中文', two: '中文', three: '中文' }
+      ]);
+    });
+  });
+});

--- a/test/unit/bulk-load-test.js
+++ b/test/unit/bulk-load-test.js
@@ -5,12 +5,12 @@ const TYPES = require('../../src/data-type').typeByName;
 
 describe('BulkLoad', function() {
   it('starts out as not being canceled', function() {
-    const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+    const request = new BulkLoad('tablename', undefined, { tdsVersion: '7_2' }, { });
     assert.strictEqual(request.canceled, false);
   });
 
   it('throws an error when adding row with a value has the wrong data type', function() {
-    const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+    const request = new BulkLoad('tablename', undefined, { tdsVersion: '7_2' }, { });
     request.addColumn('columnName', TYPES.Date, { nullable: true });
     assert.throws(() => {
       request.addRow({ columnName: 'Wrong Input' });
@@ -19,13 +19,13 @@ describe('BulkLoad', function() {
 
   describe('#cancel', function() {
     it('marks the request as canceled', function() {
-      const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+      const request = new BulkLoad('tablename', undefined, { tdsVersion: '7_2' }, { });
       request.cancel();
       assert.strictEqual(request.canceled, true);
     });
 
     it('emits a `cancel` event', function() {
-      const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+      const request = new BulkLoad('tablename', undefined, { tdsVersion: '7_2' }, { });
 
       let eventEmitted = false;
       request.on('cancel', () => { eventEmitted = true; });
@@ -35,7 +35,7 @@ describe('BulkLoad', function() {
     });
 
     it('only emits the `cancel` event on the first call', function() {
-      const request = new BulkLoad('tablename', { tdsVersion: '7_2' }, { });
+      const request = new BulkLoad('tablename', undefined, { tdsVersion: '7_2' }, { });
       request.cancel();
 
       let eventEmitted = false;

--- a/test/unit/collation-test.ts
+++ b/test/unit/collation-test.ts
@@ -1,0 +1,176 @@
+import { assert } from 'chai';
+import { Collation, Flags } from '../../src/collation';
+
+describe('Collation', function() {
+  describe('.fromBuffer', function() {
+    it('parses a Collation from a Buffer', function() {
+      // Chinese_PRC_CI_AS
+      {
+        const collationBuffer = Buffer.from([ 0x04, 0x08, 0xd0, 0x00, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 2052);
+        assert.strictEqual(collation.flags, 13);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), Flags.IGNORE_CASE);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), Flags.IGNORE_KANA);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), Flags.IGNORE_WIDTH);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), 0);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 0);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'CP936');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // Japanese_Bushu_Kakusu_100_CS_AS_KS_WS
+      {
+        const collationBuffer = Buffer.from([ 0x11, 0x04, 0x04, 0x20, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 263185);
+        assert.strictEqual(collation.flags, 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), 0);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 2);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'CP932');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // Japanese_Bushu_Kakusu_140_CI_AI_KS_WS
+      {
+        const collationBuffer = Buffer.from([ 0x11, 0x04, 0x34, 0x30, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 263185);
+        assert.strictEqual(collation.flags, 3);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), Flags.IGNORE_CASE);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), Flags.IGNORE_ACCENT);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), 0);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 3);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'CP932');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // Japanese_BIN
+      {
+        const collationBuffer = Buffer.from([ 0x11, 0x04, 0x00, 0x01, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 1041);
+        assert.strictEqual(collation.flags, 16);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY), Flags.BINARY);
+        assert.strictEqual((collation.flags & Flags.BINARY2), 0);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 0);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'CP932');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // Japanese_BIN2
+      {
+        const collationBuffer = Buffer.from([ 0x11, 0x04, 0x00, 0x02, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 1041);
+        assert.strictEqual(collation.flags, 32);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), Flags.BINARY2);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 0);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'CP932');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // SQL_Latin1_General_CP1_CI_AS
+      {
+        const collationBuffer = Buffer.from([ 0x09, 0x04, 0xd0, 0x00, 0x34 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 1033);
+        assert.strictEqual(collation.flags, 13);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), Flags.IGNORE_CASE);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), Flags.IGNORE_KANA);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), Flags.IGNORE_WIDTH);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), 0);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 0);
+        assert.strictEqual(collation.sortId, 52);
+        assert.strictEqual(collation.codepage, 'CP1252');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // Latin1_General_100_CI_AS_SC
+      {
+        const collationBuffer = Buffer.from([ 0x09, 0x04, 0xd0, 0x20, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 1033);
+        assert.strictEqual(collation.flags, 13);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), Flags.IGNORE_CASE);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), Flags.IGNORE_KANA);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), Flags.IGNORE_WIDTH);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), 0);
+        assert.strictEqual((collation.flags & Flags.UTF8), 0);
+        assert.strictEqual(collation.version, 2);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'CP1252');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+
+      // Latin1_General_100_BIN2_UTF8
+      {
+        const collationBuffer = Buffer.from([ 0x09, 0x04, 0x00, 0x26, 0x00 ]);
+        const collation = Collation.fromBuffer(collationBuffer);
+
+        assert.strictEqual(collation.lcid, 1033);
+        assert.strictEqual(collation.flags, 96);
+        assert.strictEqual((collation.flags & Flags.IGNORE_CASE), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_ACCENT), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_KANA), 0);
+        assert.strictEqual((collation.flags & Flags.IGNORE_WIDTH), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY), 0);
+        assert.strictEqual((collation.flags & Flags.BINARY2), Flags.BINARY2);
+        assert.strictEqual((collation.flags & Flags.UTF8), Flags.UTF8);
+        assert.strictEqual(collation.version, 2);
+        assert.strictEqual(collation.sortId, 0);
+        assert.strictEqual(collation.codepage, 'utf-8');
+
+        assert.deepEqual(collation.toBuffer(), collationBuffer);
+      }
+    });
+  });
+});

--- a/test/unit/data-type.js
+++ b/test/unit/data-type.js
@@ -1284,7 +1284,8 @@ describe('VarBinary', function() {
     it('correctly converts `number` values (Length <= Maximum Length)', function() {
       const value = 1;
       const length = 1;
-      const expected = Buffer.from('3100', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from('3100', 'hex');
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarBinary.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1350,19 +1351,21 @@ describe('VarChar', function() {
   });
 
   describe('.generateParameterData', function() {
-    it('correctly converts `string` values (Length <= Maximum Length)', function() {
-      const value = 'hello world';
+    it('correctly converts `Buffer` values (Length <= Maximum Length)', function() {
+      const value = Buffer.from('hello world');
       const length = 1;
-      const expected = Buffer.from('68656c6c6f20776f726c64', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from('68656c6c6f20776f726c64', 'hex');
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
     });
 
-    it('correctly converts `string` values (Length > Maximum Length)', function() {
-      const value = 'hello world';
+    it('correctly converts `Buffer` values (Length > Maximum Length)', function() {
+      const value = Buffer.from('hello world');
       const length = 9000;
-      const expected = Buffer.from('0b00000068656c6c6f20776f726c6400000000', 'hex'); const parameterValue = { value, length };
+      const expected = Buffer.from('0b00000068656c6c6f20776f726c6400000000', 'hex');
+      const parameterValue = { value, length };
 
       const buffer = Buffer.concat([...TYPES.VarChar.generateParameterData(parameterValue, { useUTC: false })]);
       assert.deepEqual(buffer, expected);
@@ -1378,7 +1381,7 @@ describe('VarChar', function() {
       assert.deepEqual(buffer, expected);
     });
 
-    it('correctly converts `string` values (Length > Maximum Length)', function() {
+    it('correctly converts `null` values (Length > Maximum Length)', function() {
       const value = null;
       const length = 9000;
       const expected = Buffer.from([]);

--- a/test/unit/token/colmetadata-token-parser-test.js
+++ b/test/unit/token/colmetadata-token-parser-test.js
@@ -108,8 +108,8 @@ describe('Colmetadata Token Parser', () => {
     assert.strictEqual(token.columns[0].type.name, 'VarChar');
     assert.strictEqual(token.columns[0].collation.lcid, 0x0409);
     assert.strictEqual(token.columns[0].collation.codepage, 'CP1257');
-    assert.strictEqual(token.columns[0].collation.flags, 0x57);
-    assert.strictEqual(token.columns[0].collation.version, 0x8);
+    assert.strictEqual(token.columns[0].collation.flags, 0x85);
+    assert.strictEqual(token.columns[0].collation.version, 0x7);
     assert.strictEqual(token.columns[0].collation.sortId, 0x9a);
     assert.strictEqual(token.columns[0].colName, 'name');
     assert.strictEqual(token.columns[0].dataLength, length);

--- a/test/unit/validations.js
+++ b/test/unit/validations.js
@@ -1,3 +1,4 @@
+const { Collation } = require('../../src/collation');
 const TYPE = require('../../src/data-type').typeByName;
 const assert = require('chai').assert;
 
@@ -290,32 +291,38 @@ describe('Validations', function() {
   });
 
   it('Text', () => {
-    let value = TYPE.Text.validate(null);
-    assert.strictEqual(value, null);
+    // SQL_Latin1_General_CP1_CI_AS
+    const collation = Collation.fromBuffer(Buffer.from([ 0x09, 0x04, 0xd0, 0x00, 0x34 ]));
 
-    value = TYPE.Text.validate('asdf');
-    assert.strictEqual(value, 'asdf');
+    let value = TYPE.Text.validate(null, collation);
+    assert.isNull(value);
 
-    value = TYPE.Text.validate(Buffer.from('asdf', 'utf8'));
-    assert.strictEqual(value, 'asdf');
+    value = TYPE.Text.validate('asdf', collation);
+    assert.deepEqual(value, Buffer.from('asdf', 'ascii'));
+
+    value = TYPE.Text.validate(Buffer.from('asdf'), collation);
+    assert.deepEqual(value, Buffer.from('asdf'));
 
     assert.throws(() => {
-      TYPE.Text.validate({ toString: null });
+      TYPE.Text.validate({ toString: null }, collation);
     }, TypeError, 'Invalid string.');
   });
 
   it('VarChar', () => {
-    let value = TYPE.VarChar.validate(null);
-    assert.strictEqual(value, null);
+    // SQL_Latin1_General_CP1_CI_AS
+    const collation = Collation.fromBuffer(Buffer.from([ 0x09, 0x04, 0xd0, 0x00, 0x34 ]));
 
-    value = TYPE.VarChar.validate('asdf');
-    assert.strictEqual(value, 'asdf');
+    let value = TYPE.VarChar.validate(null, collation);
+    assert.isNull(value);
 
-    value = TYPE.VarChar.validate(Buffer.from('asdf', 'utf8'));
-    assert.strictEqual(value, 'asdf');
+    value = TYPE.VarChar.validate('asdf', collation);
+    assert.deepEqual(value, Buffer.from('asdf', 'ascii'));
+
+    value = TYPE.VarChar.validate(Buffer.from('asdf'), collation);
+    assert.deepEqual(value, Buffer.from('asdf'));
 
     assert.throws(() => {
-      TYPE.VarChar.validate({ toString: null });
+      TYPE.VarChar.validate({ toString: null }, collation);
     }, TypeError, 'Invalid string.');
   });
 
@@ -335,17 +342,20 @@ describe('Validations', function() {
   });
 
   it('Char', () => {
-    let value = TYPE.Char.validate(null);
-    assert.strictEqual(value, null);
+    // SQL_Latin1_General_CP1_CI_AS
+    const collation = Collation.fromBuffer(Buffer.from([ 0x09, 0x04, 0xd0, 0x00, 0x34 ]));
 
-    value = TYPE.Char.validate('asdf');
-    assert.strictEqual(value, 'asdf');
+    let value = TYPE.Char.validate(null, collation);
+    assert.isNull(value);
 
-    value = TYPE.Char.validate(Buffer.from('asdf', 'utf8'));
-    assert.strictEqual(value, 'asdf');
+    value = TYPE.Char.validate('asdf', collation);
+    assert.deepEqual(value, Buffer.from('asdf', 'ascii'));
+
+    value = TYPE.Char.validate(Buffer.from('asdf'), collation);
+    assert.deepEqual(value, Buffer.from('asdf'));
 
     assert.throws(() => {
-      TYPE.Char.validate({ toString: null });
+      TYPE.Char.validate({ toString: null }, collation);
     }, TypeError, 'Invalid string.');
   });
 


### PR DESCRIPTION
This refactors the collation parsing logic and fixes some issues around parsing the different collation flags.

It also adds tracking of collation information on the connection, and also ensures we write back the collation for `varchar` / `nvarchar` / `char` / `nchar` / `text` / `ntext` values.