### PR TITLE
Support `text`/`ntext`/`image` in bulk loads

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -194,6 +194,7 @@ class RowTransform extends Transform {
         value: value
       };
 
+      if (c.type.name === 'Text' || c.type.name === 'Image' || c.type.name === 'NText') {
         if (value == null) {
           this.push(textPointerNullBuffer);
           continue;

--- a/src/data-types/image.ts
+++ b/src/data-types/image.ts
@@ -34,7 +34,7 @@ const Image: DataType = {
     }
 
     const buffer = Buffer.alloc(4);
-    buffer.writeInt32LE(parameter.length!, 0);
+    buffer.writeInt32LE(parameter.value.length!, 0);
     return buffer;
   },
 

--- a/src/data-types/text.ts
+++ b/src/data-types/text.ts
@@ -37,7 +37,7 @@ const Text: DataType = {
     }
 
     const buffer = Buffer.alloc(4);
-    buffer.writeInt32LE(parameter.length!, 0);
+    buffer.writeInt32LE(parameter.value.length!, 0);
     return buffer;
   },
 

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -428,6 +428,28 @@ describe('Parameterised Statements Test', function() {
     execSql(done, TYPES.NChar, null);
   });
 
+  describe('`ntext`', function() {
+    it('should handle `null` values', function(done) {
+      execSql(done, TYPES.NText, null);
+    });
+
+    it('should handle empty strings', function(done) {
+      execSql(done, TYPES.NText, '');
+    });
+
+    it('should handle short strings', function(done) {
+      execSql(done, TYPES.NText, 'small');
+    });
+
+    it('should handle large strings', function(done) {
+      execSql(done, TYPES.NText, new Array(500000).join('x'));
+    });
+
+    it('should handle multibyte characters', function(done) {
+      execSql(done, TYPES.NText, 'some text 中文');
+    });
+  });
+
   it('should test textNull', function(done) {
     execSql(done, TYPES.Text, null);
   });


### PR DESCRIPTION
While working on collation support, I noticed that we don't correctly support `text`/`ntext`/`image` column types in bulk loads, and we actually don't even support `ntext` for regular parameters either.

This adds support for these data types in bulk loads (and as regular parameters in case of `ntext` as well).