### PR TITLE
feat: support TVP parameters in `Connection.execSql`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -48,6 +48,7 @@ import AbortController, { AbortSignal } from 'node-abort-controller';
 import { Parameter, TYPES } from './data-type';
 import { BulkLoadPayload } from './bulk-load-payload';
 import { Collation } from './collation';
+import Procedures from './special-stored-procedure';
 
 import { version } from '../package.json';
 
@@ -2808,7 +2809,7 @@ class Connection extends EventEmitter {
       parameters.push(...request.parameters);
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_executesql', parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_ExecuteSql, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3013,6 +3014,7 @@ class Connection extends EventEmitter {
     });
 
     request.preparing = true;
+
     // TODO: We need to clean up this event handler, otherwise this leaks memory
     request.on('returnValue', (name: string, value: any) => {
       if (name === 'handle') {
@@ -3022,7 +3024,7 @@ class Connection extends EventEmitter {
       }
     });
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_prepare', parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Prepare, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3040,13 +3042,13 @@ class Connection extends EventEmitter {
       name: 'handle',
       // TODO: Abort if `request.handle` is not set
       value: request.handle,
-      output: true,
+      output: false,
       length: undefined,
       precision: undefined,
       scale: undefined
     });
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_unprepare', parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Unprepare, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**
@@ -3063,10 +3065,10 @@ class Connection extends EventEmitter {
 
     executeParameters.push({
       type: TYPES.Int,
-      name: 'handle',
+      name: '',
       // TODO: Abort if `request.handle` is not set
       value: request.handle,
-      output: true,
+      output: false,
       length: undefined,
       precision: undefined,
       scale: undefined
@@ -3092,7 +3094,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload('sp_execute', executeParameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Execute, executeParameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 
   /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -56,7 +56,7 @@ class Request extends EventEmitter {
   /**
    * @private
    */
-  sqlTextOrProcedure?: string;
+  sqlTextOrProcedure?: string | number;
   /**
    * @private
    */

--- a/src/request.ts
+++ b/src/request.ts
@@ -56,7 +56,7 @@ class Request extends EventEmitter {
   /**
    * @private
    */
-  sqlTextOrProcedure?: string | number;
+  sqlTextOrProcedure: string | undefined;
   /**
    * @private
    */

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -68,7 +68,12 @@ class RpcRequestPayload implements Iterable<Buffer> {
 
   * generateParameterData(parameter: Parameter) {
     const buffer = new WritableTrackingBuffer(1 + 2 + Buffer.byteLength(parameter.name, 'ucs-2') + 1);
-    buffer.writeBVarchar('@' + parameter.name);
+
+    if (parameter.name) {
+      buffer.writeBVarchar('@' + parameter.name);
+    } else {
+      buffer.writeBVarchar('');
+    }
 
     let statusFlags = 0;
     if (parameter.output) {


### PR DESCRIPTION
This takes the changes from @mastodon0 over at https://github.com/tediousjs/tedious/pull/1180 and updates them to match recent updates to `tedious`.

Switching to use stored procedure ids instead of stored procedure names comes with the advantage that TVP parameters can be used with `Connection.execSql`.