### PR TITLE
feat: deprecate azure authentication options that will be removed

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1141,6 +1141,13 @@ class Connection extends EventEmitter {
           throw new TypeError('The "config.authentication.options.msiEndpoint" property must be of type string.');
         }
 
+        if (options.msiEndpoint !== undefined && options.msiEndpoint !== process.env.MSI_ENDPOINT) {
+          deprecate(
+            'The `config.authentication.options.msiEndpoint` property is deprecated and will be removed in the next major release. ' +
+            'To silence this message, ensure that `process.env.MSI_ENDPOINT` and `config.authentication.options.msiEndpoint` are set to the same value.'
+          );
+        }
+
         authentication = {
           type: 'azure-active-directory-msi-vm',
           options: {
@@ -1159,6 +1166,20 @@ class Connection extends EventEmitter {
 
         if (options.msiSecret !== undefined && typeof options.msiSecret !== 'string') {
           throw new TypeError('The "config.authentication.options.msiSecret" property must be of type string.');
+        }
+
+        if (options.msiEndpoint !== undefined && options.msiEndpoint !== process.env.MSI_ENDPOINT) {
+          deprecate(
+            'The `config.authentication.options.msiEndpoint` property is deprecated and will be removed in the next major release. ' +
+            'To silence this message, ensure that `process.env.MSI_ENDPOINT` and `config.authentication.options.msiEndpoint` are set to the same value.'
+          );
+        }
+
+        if (options.msiSecret !== undefined && options.msiSecret !== process.env.MSI_SECRET) {
+          deprecate(
+            'The `config.authentication.options.msiSecret` property is deprecated and will be removed in the next major release. ' +
+            'To silence this message, ensure that `process.env.MSI_SECRET` and `config.authentication.options.msiSecret` are set to the same value.'
+          );
         }
 
         authentication = {


### PR DESCRIPTION
The `msiEndpoint` and `msiSecret` authentication options will no longer be supported once we switch over to `@azure/identity` for Azure authentication.

See https://github.com/tediousjs/tedious/pull/1328
