### PR TITLE
fix: do not specify `handle` as an output parameter when calling `sp_execute`/`sp_unprepare`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3011,7 +3011,7 @@ class Connection extends EventEmitter {
       name: 'handle',
       // TODO: Abort if `request.handle` is not set
       value: request.handle,
-      output: true,
+      output: false,
       length: undefined,
       precision: undefined,
       scale: undefined
@@ -3037,7 +3037,7 @@ class Connection extends EventEmitter {
       name: 'handle',
       // TODO: Abort if `request.handle` is not set
       value: request.handle,
-      output: true,
+      output: false,
       length: undefined,
       precision: undefined,
       scale: undefined


### PR DESCRIPTION
This was causing unexpected `returnValue` events.

Fixes: #1344 