### PR TITLE
fix: prevent bulkload values from being validated twice

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -181,10 +181,12 @@ class RowTransform extends Transform {
       const c = this.columns[i];
       let value = Array.isArray(row) ? row[i] : row[c.objName];
 
-      try {
-        value = c.type.validate(value, c.collation);
-      } catch (error: any) {
-        return callback(error);
+      if (!this.bulkLoad.firstRowWritten) {
+        try {
+          value = c.type.validate(value, c.collation);
+        } catch (error: any) {
+          return callback(error);
+        }
       }
 
       const parameter = {
@@ -699,6 +701,7 @@ class BulkLoad extends EventEmitter {
     if (this.executionStarted) {
       throw new Error('BulkLoad cannot be switched to streaming mode after execution has started.');
     }
+
     this.streamingMode = true;
 
     return this.rowToPacketTransform;


### PR DESCRIPTION
When calling `.addRow` on a `BulkLoad`, column values would get validated twice, once in the `.addRow` call and a second time in the `RowTransform` stream. This could lead to incorrect values being written (e.g. for `varchar` values).