### PR TITLE
Emit deprecation warnings for deprecated functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6469,11 +6469,6 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "optional": true
     },
-    "depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@azure/keyvault-keys": "^4.3.0",
     "@js-joda/core": "^4.0.0",
     "bl": "^5.0.0",
-    "depd": "^2.0.0",
     "iconv-lite": "^0.6.3",
     "jsbi": "^3.2.1",
     "native-duplexpair": "^1.0.0",

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -488,6 +488,8 @@ class BulkLoad extends EventEmitter {
   addRow(row: unknown[]): void
 
   addRow(...input: [ { [key: string]: unknown } ] | unknown[]) {
+    emitAddRowDeprecationWarning();
+
     this.firstRowWritten = true;
 
     let row: any;
@@ -695,6 +697,8 @@ class BulkLoad extends EventEmitter {
    *   stream or an `AsyncGenerator`) when calling [[Connection.execBulkLoad]]. This method will be removed in the future.
    */
   getRowStream() {
+    emitGetRowStreamDeprecationWarning();
+
     if (this.firstRowWritten) {
       throw new Error('BulkLoad cannot be switched to streaming mode after first row has been written using addRow().');
     }
@@ -718,6 +722,38 @@ class BulkLoad extends EventEmitter {
     this.canceled = true;
     this.emit('cancel');
   }
+}
+
+let addRowDeprecationWarningEmitted = false;
+function emitAddRowDeprecationWarning() {
+  if (addRowDeprecationWarningEmitted) {
+    return;
+  }
+
+  addRowDeprecationWarningEmitted = true;
+
+  process.emitWarning(
+    'The BulkLoad.addRow method is deprecated. Please provide the row data for ' +
+    'the bulk load as the second argument to Connection.execBulkLoad instead.',
+    'DeprecationWarning',
+    BulkLoad.prototype.addRow
+  );
+}
+
+let getRowStreamDeprecationWarningEmitted = false;
+function emitGetRowStreamDeprecationWarning() {
+  if (getRowStreamDeprecationWarningEmitted) {
+    return;
+  }
+
+  getRowStreamDeprecationWarningEmitted = true;
+
+  process.emitWarning(
+    'The BulkLoad.getRowStream method is deprecated. You can pass an Iterable, AsyncIterable or ' +
+    'stream.Readable object containing the row data as a second argument to Connection.execBulkLoad instead.',
+    'DeprecationWarning',
+    BulkLoad.prototype.getRowStream
+  );
 }
 
 export default BulkLoad;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -37,7 +37,6 @@ import Message from './message';
 import { Metadata } from './metadata-parser';
 import { createNTLMRequest } from './ntlm';
 import { ColumnEncryptionAzureKeyVaultProvider } from './always-encrypted/keystore-provider-azure-key-vault';
-import depd from 'depd';
 
 import { AbortController, AbortSignal } from 'node-abort-controller';
 import { Parameter, TYPES } from './data-type';
@@ -47,9 +46,6 @@ import { Collation } from './collation';
 import { version } from '../package.json';
 import { URL } from 'url';
 import { AttentionTokenHandler, InitialSqlTokenHandler, Login7TokenHandler, RequestTokenHandler, TokenHandler } from './token/handler';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const deprecate = depd('tedious');
 
 type BeginTransactionCallback =
   /**
@@ -1837,6 +1833,7 @@ class Connection extends EventEmitter {
    * @private
    */
   emit(event: 'sspichallenge', token: import('./token/token').SSPIToken): boolean
+
   emit(event: string | symbol, ...args: any[]) {
     return super.emit(event, ...args);
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1769,7 +1769,18 @@ class Connection extends EventEmitter {
    */
   on(event: 'secure', listener: (cleartext: import('tls').TLSSocket) => void): this
 
+  /**
+   * A SSPI token was send by the server.
+   *
+   * @deprecated
+   */
+  on(event: 'sspichallenge', listener: (token: import('./token/token').SSPIToken) => void): this
+
   on(event: string | symbol, listener: (...args: any[]) => void) {
+    if (event === 'sspichallenge') {
+      emitSSPIChallengeEventDeprecationWarning();
+    }
+
     return super.on(event, listener);
   }
 
@@ -3115,6 +3126,21 @@ class Connection extends EventEmitter {
         return 'read committed';
     }
   }
+}
+
+let sspichallengeEventDeprecationWarningEmitted = false;
+function emitSSPIChallengeEventDeprecationWarning() {
+  if (sspichallengeEventDeprecationWarningEmitted) {
+    return;
+  }
+
+  sspichallengeEventDeprecationWarningEmitted = true;
+
+  process.emitWarning(
+    'The `sspichallenge` event is deprecated and will be removed.',
+    'DeprecationWarning',
+    Connection.prototype.on
+  );
 }
 
 export default Connection;


### PR DESCRIPTION
`BulkLoad.addRow` and `BulkLoad.getRowStream` will be removed in the next major version of `tedious`.

Additionally, the `sspichallenge` event on `Connection` is deprecated and will be removed.