### PR TITLE
feat: deprecate calling `ConnectionError` or `RequestError` constructors without `new` keyword

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1878,7 +1878,7 @@ class Connection extends EventEmitter {
             return;
           }
 
-          this.emit('connect', ConnectionError(err.message, 'EINSTLOOKUP'));
+          this.emit('connect', new ConnectionError(err.message, 'EINSTLOOKUP'));
         } else {
           this.connectOnPort(port!, this.config.options.multiSubnetFailover, signal);
         }
@@ -1905,7 +1905,7 @@ class Connection extends EventEmitter {
 
       const request = this.request;
       if (request) {
-        const err = RequestError('Connection closed before request completed.', 'ECLOSE');
+        const err = new RequestError('Connection closed before request completed.', 'ECLOSE');
         request.callback(err);
         this.request = undefined;
       }
@@ -2032,7 +2032,7 @@ class Connection extends EventEmitter {
   connectTimeout() {
     const message = `Failed to connect to ${this.config.server}${this.config.options.port ? `:${this.config.options.port}` : `\\${this.config.options.instanceName}`} in ${this.config.options.connectTimeout}ms`;
     this.debug.log(message);
-    this.emit('connect', ConnectionError(message, 'ETIMEOUT'));
+    this.emit('connect', new ConnectionError(message, 'ETIMEOUT'));
     this.connectTimer = undefined;
     this.dispatchEvent('connectTimeout');
   }
@@ -2043,7 +2043,7 @@ class Connection extends EventEmitter {
   cancelTimeout() {
     const message = `Failed to cancel request in ${this.config.options.cancelTimeout}ms`;
     this.debug.log(message);
-    this.dispatchEvent('socketError', ConnectionError(message, 'ETIMEOUT'));
+    this.dispatchEvent('socketError', new ConnectionError(message, 'ETIMEOUT'));
   }
 
   /**
@@ -2055,7 +2055,7 @@ class Connection extends EventEmitter {
     request.cancel();
     const timeout = (request.timeout !== undefined) ? request.timeout : this.config.options.requestTimeout;
     const message = 'Timeout: Request failed to complete in ' + timeout + 'ms';
-    request.error = RequestError(message, 'ETIMEOUT');
+    request.error = new RequestError(message, 'ETIMEOUT');
   }
 
   /**
@@ -2161,11 +2161,11 @@ class Connection extends EventEmitter {
     if (this.state === this.STATE.CONNECTING || this.state === this.STATE.SENT_TLSSSLNEGOTIATION) {
       const message = `Failed to connect to ${this.config.server}:${this.config.options.port} - ${error.message}`;
       this.debug.log(message);
-      this.emit('connect', ConnectionError(message, 'ESOCKET'));
+      this.emit('connect', new ConnectionError(message, 'ESOCKET'));
     } else {
       const message = `Connection lost - ${error.message}`;
       this.debug.log(message);
-      this.emit('error', ConnectionError(message, 'ESOCKET'));
+      this.emit('error', new ConnectionError(message, 'ESOCKET'));
     }
     this.dispatchEvent('socketError', error);
   }
@@ -2710,7 +2710,7 @@ class Connection extends EventEmitter {
       if (name === 'handle') {
         request.handle = value;
       } else {
-        request.error = RequestError(`Tedious > Unexpected output parameter ${name} from sp_prepare`);
+        request.error = new RequestError(`Tedious > Unexpected output parameter ${name} from sp_prepare`);
       }
     });
 
@@ -3004,10 +3004,10 @@ class Connection extends EventEmitter {
     if (this.state !== this.STATE.LOGGED_IN) {
       const message = 'Requests can only be made in the ' + this.STATE.LOGGED_IN.name + ' state, not the ' + this.state.name + ' state';
       this.debug.log(message);
-      request.callback(RequestError(message, 'EINVALIDSTATE'));
+      request.callback(new RequestError(message, 'EINVALIDSTATE'));
     } else if (request.canceled) {
       process.nextTick(() => {
-        request.callback(RequestError('Canceled.', 'ECANCEL'));
+        request.callback(new RequestError('Canceled.', 'ECANCEL'));
       });
     } else {
       if (packetType === TYPE.SQL_BATCH) {
@@ -3200,7 +3200,7 @@ Connection.prototype.STATE = {
 
           if (preloginPayload.encryptionString === 'ON' || preloginPayload.encryptionString === 'REQ') {
             if (!this.config.options.encrypt) {
-              this.emit('connect', ConnectionError("Server requires encryption, set 'encrypt' config option to true.", 'EENCRYPT'));
+              this.emit('connect', new ConnectionError("Server requires encryption, set 'encrypt' config option to true.", 'EENCRYPT'));
               return this.close();
             }
 
@@ -3341,7 +3341,7 @@ Connection.prototype.STATE = {
               this.transitionTo(this.STATE.FINAL);
             }
           } else {
-            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
+            this.emit('connect', new ConnectionError('Login failed.', 'ELOGIN'));
             this.transitionTo(this.STATE.FINAL);
           }
         });
@@ -3407,7 +3407,7 @@ Connection.prototype.STATE = {
               this.transitionTo(this.STATE.FINAL);
             }
           } else {
-            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
+            this.emit('connect', new ConnectionError('Login failed.', 'ELOGIN'));
             this.transitionTo(this.STATE.FINAL);
           }
         });
@@ -3486,7 +3486,7 @@ Connection.prototype.STATE = {
 
             getToken((err, token) => {
               if (err) {
-                this.loginError = ConnectionError('Security token could not be authenticated or authorized.', 'EFEDAUTH');
+                this.loginError = new ConnectionError('Security token could not be authenticated or authorized.', 'EFEDAUTH');
                 this.emit('connect', this.loginError);
                 this.transitionTo(this.STATE.FINAL);
                 return;
@@ -3503,7 +3503,7 @@ Connection.prototype.STATE = {
               this.transitionTo(this.STATE.FINAL);
             }
           } else {
-            this.emit('connect', ConnectionError('Login failed.', 'ELOGIN'));
+            this.emit('connect', new ConnectionError('Login failed.', 'ELOGIN'));
             this.transitionTo(this.STATE.FINAL);
           }
         });
@@ -3676,7 +3676,7 @@ Connection.prototype.STATE = {
             if (sqlRequest.error && sqlRequest.error instanceof RequestError && sqlRequest.error.code === 'ETIMEOUT') {
               sqlRequest.callback(sqlRequest.error);
             } else {
-              sqlRequest.callback(RequestError('Canceled.', 'ECANCEL'));
+              sqlRequest.callback(new RequestError('Canceled.', 'ECANCEL'));
             }
           }
         });

--- a/src/errors.js
+++ b/src/errors.js
@@ -3,6 +3,8 @@ const util = require('util');
 module.exports.ConnectionError = ConnectionError;
 function ConnectionError(message, code) {
   if (!(this instanceof ConnectionError)) {
+    emitConnectionErrorWithoutNewWarning();
+
     if (message instanceof ConnectionError) {
       return message;
     }
@@ -25,6 +27,8 @@ ConnectionError.prototype.name = 'ConnectionError';
 module.exports.RequestError = RequestError;
 function RequestError(message, code) {
   if (!(this instanceof RequestError)) {
+    emitRequestErrorWithoutNewWarning();
+
     if (message instanceof RequestError) {
       return message;
     }
@@ -43,3 +47,35 @@ function RequestError(message, code) {
 util.inherits(RequestError, Error);
 
 RequestError.prototype.name = 'RequestError';
+
+let connectionErrorWithoutNewWarningEmitted = false;
+function emitConnectionErrorWithoutNewWarning() {
+  if (connectionErrorWithoutNewWarningEmitted) {
+    return;
+  }
+
+  connectionErrorWithoutNewWarningEmitted = true;
+
+  process.emitWarning(
+    'Calling the `ConnectionError` constructor function without new is deprecated ' +
+    'and will throw an error in a future release of `tedious`.',
+    'DeprecationWarning',
+    ConnectionError
+  );
+}
+
+let requestErrorWithoutNewWarningEmitted = false;
+function emitRequestErrorWithoutNewWarning() {
+  if (requestErrorWithoutNewWarningEmitted) {
+    return;
+  }
+
+  requestErrorWithoutNewWarningEmitted = true;
+
+  process.emitWarning(
+    'Calling the `RequestError` constructor function without new is deprecated ' +
+    'and will throw an error in a future release of `tedious`.',
+    'DeprecationWarning',
+    RequestError
+  );
+}

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -263,7 +263,7 @@ export class Login7TokenHandler extends TokenHandler {
   onErrorMessage(token: ErrorMessageToken) {
     this.connection.emit('errorMessage', token);
 
-    const error = ConnectionError(token.message, 'ELOGIN');
+    const error = new ConnectionError(token.message, 'ELOGIN');
 
     const isLoginErrorTransient = this.connection.transientErrorLookup.isTransientError(token.number);
     if (isLoginErrorTransient && this.connection.curTransientRetryCount !== this.connection.config.options.maxRetriesOnTransientErrors) {
@@ -307,27 +307,27 @@ export class Login7TokenHandler extends TokenHandler {
 
     if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-access-token' || authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service' || authentication.type === 'azure-active-directory-service-principal-secret') {
       if (token.fedAuth === undefined) {
-        this.connection.loginError = ConnectionError('Did not receive Active Directory authentication acknowledgement');
+        this.connection.loginError = new ConnectionError('Did not receive Active Directory authentication acknowledgement');
       } else if (token.fedAuth.length !== 0) {
-        this.connection.loginError = ConnectionError(`Active Directory authentication acknowledgment for ${authentication.type} authentication method includes extra data`);
+        this.connection.loginError = new ConnectionError(`Active Directory authentication acknowledgment for ${authentication.type} authentication method includes extra data`);
       }
     } else if (token.fedAuth === undefined && token.utf8Support === undefined) {
-      this.connection.loginError = ConnectionError('Received acknowledgement for unknown feature');
+      this.connection.loginError = new ConnectionError('Received acknowledgement for unknown feature');
     } else if (token.fedAuth) {
-      this.connection.loginError = ConnectionError('Did not request Active Directory authentication, but received the acknowledgment');
+      this.connection.loginError = new ConnectionError('Did not request Active Directory authentication, but received the acknowledgment');
     }
   }
 
   onLoginAck(token: LoginAckToken) {
     if (!token.tdsVersion) {
       // unsupported TDS version
-      this.connection.loginError = ConnectionError('Server responded with unknown TDS version.', 'ETDS');
+      this.connection.loginError = new ConnectionError('Server responded with unknown TDS version.', 'ETDS');
       return;
     }
 
     if (!token.interface) {
       // unsupported interface
-      this.connection.loginError = ConnectionError('Server responded with unsupported interface.', 'EINTERFACENOTSUPP');
+      this.connection.loginError = new ConnectionError('Server responded with unsupported interface.', 'EINTERFACENOTSUPP');
       return;
     }
 
@@ -492,7 +492,7 @@ export class RequestTokenHandler extends TokenHandler {
     if (!this.request.canceled) {
       if (token.sqlError && !this.request.error) {
         // check if the DONE_ERROR flags was set, but an ERROR token was not sent.
-        this.request.error = RequestError('An unknown error has occurred.', 'UNKNOWN');
+        this.request.error = new RequestError('An unknown error has occurred.', 'UNKNOWN');
       }
 
       this.request.emit('doneProc', token.rowCount, token.more, this.connection.procReturnStatusValue, this.request.rst);
@@ -527,7 +527,7 @@ export class RequestTokenHandler extends TokenHandler {
     if (!this.request.canceled) {
       if (token.sqlError && !this.request.error) {
         // check if the DONE_ERROR flags was set, but an ERROR token was not sent.
-        this.request.error = RequestError('An unknown error has occurred.', 'UNKNOWN');
+        this.request.error = new RequestError('An unknown error has occurred.', 'UNKNOWN');
       }
 
       this.request.emit('done', token.rowCount, token.more, this.request.rst);


### PR DESCRIPTION
I want to convert `ConnectionError` and `RequestError` to regular classes that extend `Error`, but regular JavaScript classes disallow constructor functions to be called without `new`.

As these two classes are exported and can in theory be used by users (e.g. for testing in their apps), I want to deprecate calling `ConnectionError` and `RequestError` without `new`.