### PR TITLE
feat: deprecate default value for trustServerCertificate

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -47,6 +47,15 @@ import { version } from '../package.json';
 import { URL } from 'url';
 import { AttentionTokenHandler, InitialSqlTokenHandler, Login7TokenHandler, RequestTokenHandler, TokenHandler } from './token/handler';
 
+let trustServerWarningEmitted = false;
+
+const emitTrustServerCertificateWarning = () => {
+  if (!trustServerWarningEmitted) {
+    trustServerWarningEmitted = true;
+    process.emitWarning('`config.options.trustServerCertificate` will default to false in the future. To silence this message, specify a value explicitly in the config options');
+  }
+};
+
 type BeginTransactionCallback =
   /**
    * The callback is called when the request to start the transaction has completed,
@@ -1604,6 +1613,8 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.trustServerCertificate = config.options.trustServerCertificate;
+      } else {
+        emitTrustServerCertificateWarning();
       }
 
       if (config.options.useColumnNames !== undefined) {


### PR DESCRIPTION
In preparation for fixing #1361. Emits a warning to deprecate in the future. Default value will be changed back to false.
