### PR TITLE
docs: update examples to deprecate old functionality

### DIFF
--- a/examples/bulk-load.js
+++ b/examples/bulk-load.js
@@ -60,12 +60,12 @@ function createTable() {
 //--------------------------------------------------------------------------------
 function loadBulkData() {
   const option = { keepNulls: true }; // option to enable null values
-  const bulkLoad = connection.newBulkLoad(table, option, (err, rowCont) => {
+  const bulkLoad = connection.newBulkLoad(table, option, (err, rowCount) => {
     if (err) {
       throw err;
     }
 
-    console.log('rows inserted :', rowCont);
+    console.log('rows inserted :', rowCount);
     console.log('DONE!');
     connection.close();
   });
@@ -74,10 +74,9 @@ function loadBulkData() {
   bulkLoad.addColumn('c1', TYPES.Int, { nullable: true });
   bulkLoad.addColumn('c2', TYPES.NVarChar, { length: 50, nullable: true });
 
-  // add rows
-  bulkLoad.addRow({ c1: 1 });
-  bulkLoad.addRow({ c1: 2, c2: 'hello' });
+  // add rows into an array
+  const rows = [{ c1: 1 }, { c1: 2, c2: 'hello' }];
 
   // perform bulk insert
-  connection.execBulkLoad(bulkLoad);
+  connection.execBulkLoad(bulkLoad, rows);
 }

--- a/examples/minimal.js
+++ b/examples/minimal.js
@@ -17,7 +17,7 @@ var config = {
 
 const connection = new Connection(config);
 
-connection.on('connect', (err) => {
+connection.connect((err) => {
   if (err) {
     console.log('Connection Failed');
     throw err;
@@ -25,8 +25,6 @@ connection.on('connect', (err) => {
 
   executeStatement();
 });
-
-connection.connect();
 
 function executeStatement() {
   const request = new Request('select * from MyTable', (err, rowCount) => {

--- a/examples/prepared.js
+++ b/examples/prepared.js
@@ -18,7 +18,7 @@ const connection = new Connection(config);
 
 const table = '[dbo].[test_prepared]';
 
-connection.on('connect', (err) => {
+connection.connect((err) => {
   if (err) {
     console.log('Connection Failed!');
     throw err;
@@ -53,7 +53,6 @@ function prepareSQL() {
       throw err;
     }
 
-    executePreparedSQL(request);
   });
 
   // Must add parameters
@@ -62,6 +61,7 @@ function prepareSQL() {
 
   request.on('prepared', () => {
     console.log('request prepared');
+    executePreparedSQL(request);
   });
 
   connection.prepare(request);

--- a/examples/table-valued-parameters.js
+++ b/examples/table-valued-parameters.js
@@ -21,7 +21,7 @@ const storedProcedure = '[dbo].[test_sp_tvp]';
 const table = '[dbo].[test_tvp]';
 const table_type = 'TableType';
 
-connection.on('connect', (err) => {
+connection.connect((err) => {
   if (err) {
     console.log('connection err');
     throw err;

--- a/examples/transaction.js
+++ b/examples/transaction.js
@@ -19,7 +19,7 @@ const connection = new Connection(config);
 
 const table = '[dbo].[test_transact]';
 
-connection.on('connect', (err) => {
+connection.connect((err) => {
   if (err) {
     console.log('connection err');
     throw err;


### PR DESCRIPTION
Changed the example files to use the callback function in `.connect()` instead of using the event handler.
Removed `addRow` from `bulk-load.js`
Executes SQL after it has been prepared in `prepared.js`