### PR TITLE
feat: rename `domain` to `tenantId` when using `azure-active-director…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7400,9 +7400,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -247,10 +247,16 @@ interface AzureActiveDirectoryPasswordAuthentication {
      * A user need to provide `userName` asscoiate to their account.
      */
     userName: string;
+
     /**
      * A user need to provide `password` asscoiate to their account.
      */
     password: string;
+
+    /**
+     * A client id to use.
+     */
+    clientId: string;
 
     /**
      * Optional parameter for specific Azure tenant ID
@@ -1085,12 +1091,19 @@ class Connection extends EventEmitter {
           throw new TypeError('The "config.authentication.options.password" property must be of type string.');
         }
 
+        if (options.clientId !== undefined && typeof options.clientId !== 'string') {
+          throw new TypeError('The "config.authentication.options.clientId" property must be of type string.');
+        } else if (options.clientId === undefined) {
+          emitAzureADPasswordClientIdDeprecationWarning();
+        }
+
         authentication = {
           type: 'azure-active-directory-password',
           options: {
             userName: options.userName,
             password: options.password,
-            domain: options.domain,
+            domain: options.domain ?? 'common',
+            clientId: options.clientId ?? '7f98cb04-cd1e-40df-9140-3bf7e2cea4db'
           }
         };
       } else if (type === 'azure-active-directory-access-token') {
@@ -3085,6 +3098,22 @@ class Connection extends EventEmitter {
   }
 }
 
+let azureADPasswordClientIdDeprecationWarningEmitted = false;
+function emitAzureADPasswordClientIdDeprecationWarning() {
+  if (azureADPasswordClientIdDeprecationWarningEmitted) {
+    return;
+  }
+
+  azureADPasswordClientIdDeprecationWarningEmitted = true;
+
+  process.emitWarning(
+    'When using the `azure-active-directory-password` authentication method, please provide a value for the `clientId` option. ' +
+    'This option will be required in a future release.',
+    'DeprecationWarning',
+    Connection.prototype.on
+  );
+}
+
 export default Connection;
 module.exports = Connection;
 
@@ -3403,8 +3432,8 @@ Connection.prototype.STATE = {
 
               if (authentication.type === 'azure-active-directory-password') {
                 const credentials = new UsernamePasswordCredential(
-                  authentication.options.domain ?? 'common',  // tenantId
-                  '7f98cb04-cd1e-40df-9140-3bf7e2cea4db',     // clientId
+                  authentication.options.domain,
+                  authentication.options.clientId,
                   authentication.options.userName,
                   authentication.options.password
                 );


### PR DESCRIPTION
Renames `config.authenticaiton.options.domain` to `config.authenticaiton.options.tenantId`
when using the `azure-active-directory-password` authentication type.

`domain` can still currently be used but will emit a deprecation warning message if used.

Documentation changes: #1389 