### PR TITLE
feat: fail ntlm auth gracefully when md4 hashing is not available

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3433,11 +3433,6 @@ Connection.prototype.STATE = {
 
               this.ntlmpacket = undefined;
 
-              this.messageIo.readMessage().then((message) => {
-                this.dispatchEvent('message', message);
-              }, (err) => {
-                this.socketError(err);
-              });
             } catch (error: any) {
               if (error.code === 'ERR_OSSL_EVP_UNSUPPORTED') {
                 const node17Message = new ConnectionError('Node 17 now uses OpenSSL 3, which considers md4 encryption a legacy type.' +

--- a/test/integration/child-processes/ntlm-connect-node17.js
+++ b/test/integration/child-processes/ntlm-connect-node17.js
@@ -1,0 +1,23 @@
+const { Connection } = require('../../../');
+const fs = require('fs');
+const homedir = require('os').homedir();
+
+function getNtlmConfig() {
+  return JSON.parse(
+    fs.readFileSync(homedir + '/.tedious/test-connection.json', 'utf8')
+  ).ntlm;
+}
+const ntlmConfig = getNtlmConfig();
+
+const connection = new Connection(ntlmConfig);
+
+connection.connect(function(err) {
+  if (err) {
+    if (err instanceof AggregateError) {
+      throw err.errors;
+    } else {
+      throw err;
+    }
+  }
+  connection.close();
+});

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const homedir = require('os').homedir();
 const assert = require('chai').assert;
 const os = require('os');
+const childProcess = require('child_process');
 
 import Connection from '../../src/connection';
 import { ConnectionError, RequestError } from '../../src/errors';
@@ -455,17 +456,43 @@ describe('Ntlm Test', function() {
     });
   }
 
-  it('should ntlm', function(done) {
-    runNtlmTest.call(this, done, DomainCaseEnum.AsIs);
-  });
+  const nodeVersion = parseInt(process.versions.node.split('.')[0]);
+  if (nodeVersion <= 16 || (process.execArgv.includes('--openssl-legacy-provider') && nodeVersion >= 17)) {
+    it('should ntlm', function(done) {
+      runNtlmTest.call(this, done, DomainCaseEnum.AsIs);
+    });
 
-  it('should ntlm lower', function(done) {
-    runNtlmTest.call(this, done, DomainCaseEnum.Lower);
-  });
+    it('should ntlm lower', function(done) {
+      runNtlmTest.call(this, done, DomainCaseEnum.Lower);
+    });
 
-  it('should ntlm upper', function(done) {
-    runNtlmTest.call(this, done, DomainCaseEnum.Upper);
-  });
+    it('should ntlm upper', function(done) {
+      runNtlmTest.call(this, done, DomainCaseEnum.Upper);
+    });
+
+  } else {
+
+    it('should throw an aggregate error with node 17', () => {
+      const child = childProcess.spawnSync(process.execPath,
+                                           ['./test/integration/child-processes/ntlm-connect-node17.js'],
+                                           { encoding: 'utf8' });
+      const thrownError = child.stderr;
+      assert.isTrue(thrownError.includes('ERR_OSSL_EVP_UNSUPPORTED'));
+      assert.isTrue(thrownError.includes('ConnectionError'));
+      assert.isTrue(thrownError.includes('--openssl-legacy-provider'));
+      assert.strictEqual(child.status, 1);
+    });
+
+    it('should ntlm with node 17 when `--openssl-legacy-provider` flag enabled', () => {
+      const child = childProcess.spawnSync(process.execPath,
+                                           ['--openssl-legacy-provider',
+                                            './test/integration/child-processes/ntlm-connect-node17.js'],
+                                           { encoding: 'utf8' });
+      assert.strictEqual(child.status, 0);
+    });
+
+  }
+
 });
 
 describe('Encrypt Test', function() {

--- a/test/unit/child-processes/ntlm-payload-node17.js
+++ b/test/unit/child-processes/ntlm-payload-node17.js
@@ -1,0 +1,13 @@
+const NTLMPayload = require('../../../src/ntlm-payload');
+
+const challenge = {
+  domain: 'domain',
+  userName: 'username',
+  password: 'password',
+  ntlmpacket: {
+    target: Buffer.from([170, 170, 170, 170]), // aa aa aa aa
+    nonce: Buffer.from([187, 187, 187, 187, 187, 187, 187, 187])
+  }
+};
+
+new NTLMPayload(challenge);

--- a/test/unit/ntlm-payload-test.js
+++ b/test/unit/ntlm-payload-test.js
@@ -1,48 +1,70 @@
 const NTLMPayload = require('../../src/ntlm-payload');
 const assert = require('chai').assert;
+const childProcess = require('child_process');
+const nodeVersion = parseInt(process.versions.node.split('.')[0]);
 
-describe('ntlm payload test', function() {
-  it('should respond to challenge', function() {
-    const challenge = {
-      domain: 'domain',
-      userName: 'username',
-      password: 'password',
-      ntlmpacket: {
-        target: Buffer.from([170, 170, 170, 170]), // aa aa aa aa
-        nonce: Buffer.from([187, 187, 187, 187, 187, 187, 187, 187])
-      }
-    };
+const challenge = {
+  domain: 'domain',
+  userName: 'username',
+  password: 'password',
+  ntlmpacket: {
+    target: Buffer.from([170, 170, 170, 170]), // aa aa aa aa
+    nonce: Buffer.from([187, 187, 187, 187, 187, 187, 187, 187])
+  }
+};
 
-    const response = new NTLMPayload(challenge);
+if (nodeVersion <= 16 || (process.execArgv.includes('--openssl-legacy-provider') && nodeVersion >= 17)) {
+  describe('ntlm payload test', function() {
+    it('should respond to challenge', function() {
 
-    const expectedLength =
-      8 + // NTLM protocol header
-      4 + // NTLM message type
-      8 + // lmv index
-      8 + // ntlm index
-      8 + // domain index
-      8 + // user index
-      16 + // header index
-      4 + // flags
-      2 * 6 + // domain
-      2 * 8 + // username
-      24 + // lmv2 data
-      16 + // ntlmv2 data
-      8 + // flags
-      8 + // timestamp
-      8 + // client nonce
-      4 + // placeholder
-      4 + // target data
-      4; // placeholder
+      const response = new NTLMPayload(challenge);
 
-    const domainName = response.data.slice(64, 76).toString('ucs2');
-    const userName = response.data.slice(76, 92).toString('ucs2');
-    const targetData = response.data.slice(160, 164).toString('hex');
+      const expectedLength =
+        8 + // NTLM protocol header
+        4 + // NTLM message type
+        8 + // lmv index
+        8 + // ntlm index
+        8 + // domain index
+        8 + // user index
+        16 + // header index
+        4 + // flags
+        2 * 6 + // domain
+        2 * 8 + // username
+        24 + // lmv2 data
+        16 + // ntlmv2 data
+        8 + // flags
+        8 + // timestamp
+        8 + // client nonce
+        4 + // placeholder
+        4 + // target data
+        4; // placeholder
 
-    assert.strictEqual(domainName, 'domain');
-    assert.strictEqual(userName, 'username');
-    assert.strictEqual(targetData, 'aaaaaaaa');
+      const domainName = response.data.slice(64, 76).toString('ucs2');
+      const userName = response.data.slice(76, 92).toString('ucs2');
+      const targetData = response.data.slice(160, 164).toString('hex');
 
-    assert.strictEqual(expectedLength, response.data.length);
+      assert.strictEqual(domainName, 'domain');
+      assert.strictEqual(userName, 'username');
+      assert.strictEqual(targetData, 'aaaaaaaa');
+
+      assert.strictEqual(expectedLength, response.data.length);
+    });
   });
-});
+} else {
+  describe('ntlm payload test node 17 and newer', function() {
+
+    it('should throw error when `--openssl-legacy-provider` is not enabled', function() {
+      try {
+        new NTLMPayload(challenge);
+      } catch (err) {
+        assert.strictEqual(err.code, 'ERR_OSSL_EVP_UNSUPPORTED');
+      }
+    });
+
+    it('should respond to challenge when `--openssl-legacy-provider` is enabled`', function() {
+      const child = childProcess.spawnSync(process.execPath, ['node_modules/mocha/bin/mocha', '--openssl-legacy-provider',
+                                                              './test/unit/child-processes/ntlm-payload-node17.js'], { encoding: 'utf8' });
+      assert.strictEqual(child.status, 0);
+    });
+  });
+}


### PR DESCRIPTION
Emits an error explaining that the user needs to enable `--openssl-legacy-provider`. Also adds tests to test the flag's functionality. 

Document changes: #1399 (already merged)
CI Config testing node 17: #1396