### PR TITLE
feat: better error handling with aggregate error

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@azure/keyvault-keys": "^4.3.0",
     "@js-joda/core": "^4.0.0",
     "bl": "^5.0.0",
+    "es-aggregate-error": "^1.0.7",
     "iconv-lite": "^0.6.3",
     "jsbi": "^3.2.1",
     "native-duplexpair": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@azure/keyvault-keys": "^4.3.0",
     "@js-joda/core": "^4.0.0",
     "bl": "^5.0.0",
-    "es-aggregate-error": "^1.0.7",
     "iconv-lite": "^0.6.3",
     "jsbi": "^3.2.1",
     "native-duplexpair": "^1.0.0",

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -270,7 +270,7 @@ export class Login7TokenHandler extends TokenHandler {
       error.isTransient = true;
     }
 
-    this.connection.loginError = error;
+    this.connection.loginError = new AggregateError([error]);
   }
 
   onSSPI(token: SSPIToken) {
@@ -305,27 +305,27 @@ export class Login7TokenHandler extends TokenHandler {
 
     if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-access-token' || authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service' || authentication.type === 'azure-active-directory-service-principal-secret') {
       if (token.fedAuth === undefined) {
-        this.connection.loginError = new ConnectionError('Did not receive Active Directory authentication acknowledgement');
+        this.connection.loginError = new AggregateError([new ConnectionError('Did not receive Active Directory authentication acknowledgement')]);
       } else if (token.fedAuth.length !== 0) {
-        this.connection.loginError = new ConnectionError(`Active Directory authentication acknowledgment for ${authentication.type} authentication method includes extra data`);
+        this.connection.loginError = new AggregateError([new ConnectionError(`Active Directory authentication acknowledgment for ${authentication.type} authentication method includes extra data`)]);
       }
     } else if (token.fedAuth === undefined && token.utf8Support === undefined) {
-      this.connection.loginError = new ConnectionError('Received acknowledgement for unknown feature');
+      this.connection.loginError = new AggregateError([new ConnectionError('Received acknowledgement for unknown feature')]);
     } else if (token.fedAuth) {
-      this.connection.loginError = new ConnectionError('Did not request Active Directory authentication, but received the acknowledgment');
+      this.connection.loginError = new AggregateError([new ConnectionError('Did not request Active Directory authentication, but received the acknowledgment')]);
     }
   }
 
   onLoginAck(token: LoginAckToken) {
     if (!token.tdsVersion) {
       // unsupported TDS version
-      this.connection.loginError = new ConnectionError('Server responded with unknown TDS version.', 'ETDS');
+      this.connection.loginError = new AggregateError([new ConnectionError('Server responded with unknown TDS version.', 'ETDS')]);
       return;
     }
 
     if (!token.interface) {
       // unsupported interface
-      this.connection.loginError = new ConnectionError('Server responded with unsupported interface.', 'EINTERFACENOTSUPP');
+      this.connection.loginError = new AggregateError([new ConnectionError('Server responded with unsupported interface.', 'EINTERFACENOTSUPP')]);
       return;
     }
 

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -1354,9 +1354,12 @@ describe('Advanced Input Test', function() {
     const config = getConfig();
     config.options.enableAnsiNullDefault = false;
 
-    runSqlBatch(done, config, sql, function(/** @type {Error | null | undefined} */err) {
-      assert.instanceOf(err, RequestError);
-      assert.strictEqual(/** @type {RequestError} */(err).number, 515);
+    runSqlBatch(done, config, sql, function(/** @type {Error | null | undefined } */err) {
+      assert.instanceOf(err, AggregateError);
+      if (err instanceof AggregateError) {
+        assert.strictEqual(err.errors.length, 1);
+        assert.strictEqual(err.errors[0].number, 515);
+      }
     }); // Cannot insert the value NULL
   });
 });

--- a/test/integration/transactions-test.js
+++ b/test/integration/transactions-test.js
@@ -298,8 +298,10 @@ describe('Transactions Test', function() {
             });
 
             req = new Request("insert into #temp values ('asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasd')", function(err) {
-              assert.match(err.message, /^String or binary data would be truncated/);
-
+              if (err instanceof AggregateError) {
+                assert.strictEqual(err.errors.length, 1);
+                assert.match(err.errors[0].message, /^String or binary data would be truncated/);
+              }
               connection.close();
             });
             connection.execSqlBatch(req);
@@ -463,7 +465,7 @@ describe('Transactions Test', function() {
             request = new Request('create table #temp (id int)', function(err) {
               innerDone(err, outerDone, function(err) {
                 assert.equal(
-                  err.message,
+                  err.errors[0].message,
                   "There is already an object named '#temp' in the database."
                 );
 


### PR DESCRIPTION
Added better error handling for request errors. The aggregate error will catch all the errors emitted along the process, so the user will get the whole picture.

Also, added an aggregate error for catching AAD token retrieve error, so not only the generic error message will be emitted but also the original server-side error. 