### PR TITLE
refactor: cleanup `Connection` internals

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -3,17 +3,7 @@ import dns from 'dns';
 
 import * as punycode from 'punycode';
 import { AbortSignal } from 'node-abort-controller';
-
-class AbortError extends Error {
-  code: string;
-
-  constructor() {
-    super('The operation was aborted');
-
-    this.code = 'ABORT_ERR';
-    this.name = 'AbortError';
-  }
-}
+import { AbortError } from './util/abort-error';
 
 export class ParallelConnectionStrategy {
   addresses: dns.LookupAddress[];

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -2,6 +2,7 @@ import dns from 'dns';
 import { AbortController, AbortSignal } from 'node-abort-controller';
 
 import { Sender } from './sender';
+import { AbortError } from './util/abort-error';
 
 const SQL_SERVER_BROWSER_PORT = 1434;
 const TIMEOUT = 2 * 1000;
@@ -10,17 +11,6 @@ const RETRIES = 3;
 const MYSTERY_HEADER_LENGTH = 3;
 
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
-
-class AbortError extends Error {
-  code: string;
-
-  constructor() {
-    super('The operation was aborted');
-
-    this.code = 'ABORT_ERR';
-    this.name = 'AbortError';
-  }
-}
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
 export class InstanceLookup {

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -3,19 +3,9 @@ import dns from 'dns';
 import net from 'net';
 import * as punycode from 'punycode';
 import { AbortSignal } from 'node-abort-controller';
+import { AbortError } from './util/abort-error';
 
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
-
-class AbortError extends Error {
-  code: string;
-
-  constructor() {
-    super('The operation was aborted');
-
-    this.code = 'ABORT_ERR';
-    this.name = 'AbortError';
-  }
-}
 
 export class ParallelSendStrategy {
   addresses: dns.LookupAddress[];

--- a/src/util/abort-error.ts
+++ b/src/util/abort-error.ts
@@ -1,0 +1,10 @@
+export class AbortError extends Error {
+  code: string;
+
+  constructor() {
+    super('The operation was aborted');
+
+    this.code = 'ABORT_ERR';
+    this.name = 'AbortError';
+  }
+}

--- a/src/util/add-abort-signal.ts
+++ b/src/util/add-abort-signal.ts
@@ -1,0 +1,17 @@
+import { AbortSignal } from 'node-abort-controller';
+import { finished, Readable, Writable } from 'stream';
+import { AbortError } from './abort-error';
+
+/**
+ * Attaches an AbortSignal to a readable or writeable stream.
+ *
+ * Inspired by `stream.addAbortSignal` that was added in NodeJS v15.4.0.
+ */
+export function addAbortSignal(signal: AbortSignal, stream: Readable | Writable) {
+  const onAbort = () => { stream.destroy(new AbortError()); };
+
+  signal.addEventListener('abort', onAbort, { once: true });
+  finished(stream, () => { signal.removeEventListener('abort', onAbort); });
+
+  return stream;
+}

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -283,6 +283,22 @@ describe('Initiate Connect Test', function() {
     connection.connect();
   });
 
+  it('should allow closing a connection while it is connecting', function(done) {
+    const config = getConfig();
+
+    const connection = new Connection(config);
+    connection.connect((err) => {
+      assert.instanceOf(err, Error);
+      assert.strictEqual(err?.message, 'The operation was aborted');
+
+      done();
+    });
+
+    process.nextTick(() => {
+      connection.close();
+    });
+  });
+
   it('should fail if no cipher can be negotiated', function(done) {
     const config = getConfig();
     config.options.encrypt = true;

--- a/test/unit/message-io-test.js
+++ b/test/unit/message-io-test.js
@@ -3,7 +3,8 @@ const Duplex = require('stream').Duplex;
 const MessageIO = require('../../src/message-io');
 const Message = require('../../src/message');
 const Packet = require('../../src/packet').Packet;
-const assert = require('chai').assert;
+const { assert } = require('chai');
+const { AbortController } = require('node-abort-controller');
 
 class Connection extends Duplex {
   _read(size) { }
@@ -85,7 +86,8 @@ describe('Message IO', function() {
     const connection = new Connection();
 
     const io = new MessageIO(connection, packetSize, new Debug());
-    io.readMessage().then((message) => {
+    const controller = new AbortController();
+    io.readMessage(controller.signal).then((message) => {
       assert.instanceOf(message, Message);
 
       message.on('data', (data) => {
@@ -108,7 +110,8 @@ describe('Message IO', function() {
     const connection = new Connection();
 
     const io = new MessageIO(connection, packetSize, new Debug());
-    io.readMessage().then((message) => {
+    const controller = new AbortController();
+    io.readMessage(controller.signal).then((message) => {
       message.on('data', (data) => {
         assert.isOk(data.equals(payload));
       });
@@ -134,7 +137,8 @@ describe('Message IO', function() {
     let receivedPacketCount = 0;
 
     const io = new MessageIO(connection, packetSize, new Debug());
-    io.readMessage().then((message) => {
+    const controller = new AbortController();
+    io.readMessage(controller.signal).then((message) => {
       message.on('data', function(data) {
         receivedPacketCount++;
 
@@ -170,7 +174,8 @@ describe('Message IO', function() {
     let receivedPacketCount = 0;
 
     const io = new MessageIO(connection, packetSize, new Debug());
-    io.readMessage().then((message) => {
+    const controller = new AbortController();
+    io.readMessage(controller.signal).then((message) => {
       message.on('data', function(data) {
         receivedPacketCount++;
 
@@ -207,7 +212,8 @@ describe('Message IO', function() {
     let receivedData = Buffer.alloc(0);
 
     const io = new MessageIO(connection, packetSize, new Debug());
-    io.readMessage().then((message) => {
+    const controller = new AbortController();
+    io.readMessage(controller.signal).then((message) => {
       message.on('data', function(data) {
         receivedData = Buffer.concat([receivedData, data]);
       });


### PR DESCRIPTION
This refactors the `Connection` internals, so far focusing on the functionality around connection establishing.

This replaces the state machine, state switching and event based logic. Instead, we now use `async` methods.

This has the following advantages:

* The flow of execution is easier to understand. E.g. `.connect` calls `.establishConnection`, which calls `.handlePreloginResponse`, which calls one of the `LOGIN7` response handling methods like `.handleLogin7WithStandardLoginResponse`.
* Error handling is much improved. Previously, errors could happen _anywhere_ in the flow. Either low level socket errors, or higher level "login failure" errors. They were passed to `.socketError`, which in turn needed to have state specific logic for error handling and cleanup. Now, errors just get `throw`n and handled inside of the `.connect` method in a consistent fashion.
* Cancellation and connect timeout handling are also now explicitly handled via `AbortSignal`s. Previously, e.g. connection timeout was handled by having a timer emit the `connectTimeout` state event, which each state then tried to handle correctly (but mostly failed). Now, each `async` method takes an `signal` argument that is used to detect whether the current operation has been cancelled or not, and can act accordingly.

There's still some state handling code, for the `SENT_ATTENTION` and `SENT_CLIENT_REQUEST` states, and this probably should be refactored as well.

I left the state transition calls in place (`.transitionTo`), mostly for debug output purposes, but I think this can be completely removed at some later time.

This is a very large set of changes, and I feel like it's a bit risky. It probably warrants adding more extensive test cases (especially for failure conditions like timeouts or invalid messages being sent from the server).

@mShan0 @MichaelSun90 What do you think?