### PR TITLE
refactor: refactor `Connection` state implementation

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3368,7 +3368,11 @@ Connection.prototype.STATE = {
           this.emit('connect', new ConnectionError('Login failed.', 'ELOGIN'));
           this.transitionTo(this.STATE.FINAL);
         }
-      })();
+      })().catch((err) => {
+        process.nextTick(() => {
+          throw err;
+        });
+      });
     },
     events: {
       socketError: function() {
@@ -3434,7 +3438,11 @@ Connection.prototype.STATE = {
           }
         }
 
-      })();
+      })().catch((err) => {
+        process.nextTick(() => {
+          throw err;
+        });
+      });
     },
     events: {
       socketError: function() {
@@ -3564,7 +3572,11 @@ Connection.prototype.STATE = {
         this.transitionTo(this.STATE.LOGGED_IN);
         this.processedInitialSql();
 
-      })();
+      })().catch((err) => {
+        process.nextTick(() => {
+          throw err;
+        });
+      });
     },
     events: {
       socketError: function socketError() {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3196,7 +3196,7 @@ Connection.prototype.STATE = {
   SENT_PRELOGIN: {
     name: 'SentPrelogin',
     enter: function() {
-      (async function(this: Connection) {
+      (async () => {
         let messageBuffer = Buffer.alloc(0);
 
         let message;
@@ -3237,7 +3237,7 @@ Connection.prototype.STATE = {
             this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
           }
         }
-      }).call(this).catch((err) => {
+      })().catch((err) => {
         process.nextTick(() => {
           throw err;
         });


### PR DESCRIPTION
This refactors some of the state handling in the `Connection` class to make use of `async`/`await`.

The goal here is to gradually move us to a more readable, maintainable and overall more robust connection handling logic.

For now, this only focuses on the following states:

* `SENT_PRELOGIN`
* `SENT_TLSSSLNEGOTIATION`
* `SENT_LOGIN7_WITH_STANDARD_LOGIN`
* `SENT_LOGIN7_WITH_NTLM`
* `LOGGED_IN_SENDING_INITIAL_SQL`

The other states will be tackled in followup pull requests.