### PR TITLE
refactor: further `Connection` state implementation refactor

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -11,7 +11,6 @@ import {
   DefaultAzureCredential,
   ClientSecretCredential,
   ManagedIdentityCredential,
-  TokenCredential,
   UsernamePasswordCredential,
 } from '@azure/identity';
 
@@ -3456,10 +3455,95 @@ Connection.prototype.STATE = {
   SENT_LOGIN7_WITH_FEDAUTH: {
     name: 'SentLogin7Withfedauth',
     enter: function() {
-      this.messageIo.readMessage().then((message) => {
-        this.dispatchEvent('message', message);
-      }, (err) => {
-        this.socketError(err);
+      (async () => {
+        let message;
+        try {
+          message = await this.messageIo.readMessage();
+        } catch (err: any) {
+          return this.socketError(err);
+        }
+
+        const handler = new Login7TokenHandler(this);
+        const tokenStreamParser = this.createTokenStreamParser(message, handler);
+        await once(tokenStreamParser, 'end');
+        if (handler.loginAckReceived) {
+          if (handler.routingData) {
+            this.routingData = handler.routingData;
+            this.transitionTo(this.STATE.REROUTING);
+          } else {
+            this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
+          }
+
+          return;
+        }
+
+        const fedAuthInfoToken = handler.fedAuthInfoToken;
+
+        if (fedAuthInfoToken && fedAuthInfoToken.stsurl && fedAuthInfoToken.spn) {
+          const authentication = this.config.authentication as AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryServicePrincipalSecret | AzureActiveDirectoryDefaultAuthentication;
+          const tokenScope = new URL('/.default', fedAuthInfoToken.spn).toString();
+
+          let credentials;
+
+          switch (authentication.type) {
+            case 'azure-active-directory-password':
+              credentials = new UsernamePasswordCredential(
+                authentication.options.tenantId ?? 'common',
+                authentication.options.clientId,
+                authentication.options.userName,
+                authentication.options.password
+              );
+              break;
+            case 'azure-active-directory-msi-vm':
+            case 'azure-active-directory-msi-app-service':
+              const msiArgs = authentication.options.clientId ? [authentication.options.clientId, {}] : [{}];
+              credentials = new ManagedIdentityCredential(...msiArgs);
+              break;
+            case 'azure-active-directory-default':
+              const args = authentication.options.clientId ? { managedIdentityClientId: authentication.options.clientId } : {};
+              credentials = new DefaultAzureCredential(args);
+              break;
+            case 'azure-active-directory-service-principal-secret':
+              credentials = new ClientSecretCredential(
+                authentication.options.tenantId,
+                authentication.options.clientId,
+                authentication.options.clientSecret
+              );
+              break;
+          }
+
+          let tokenResponse;
+          try {
+            tokenResponse = await credentials.getToken(tokenScope);
+          } catch (err) {
+            this.loginError = new AggregateError(
+              [new ConnectionError('Security token could not be authenticated or authorized.', 'EFEDAUTH'), err]);
+            this.emit('connect', this.loginError);
+            this.transitionTo(this.STATE.FINAL);
+            return;
+          }
+
+
+          const token = tokenResponse.token;
+          this.sendFedAuthTokenMessage(token);
+
+        } else if (this.loginError) {
+          if (isTransientError(this.loginError)) {
+            this.debug.log('Initiating retry on transient error');
+            this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
+          } else {
+            this.emit('connect', this.loginError);
+            this.transitionTo(this.STATE.FINAL);
+          }
+        } else {
+          this.emit('connect', new ConnectionError('Login failed.', 'ELOGIN'));
+          this.transitionTo(this.STATE.FINAL);
+        }
+
+      })().catch((err) => {
+        process.nextTick(() => {
+          throw err;
+        });
       });
     },
     events: {
@@ -3468,90 +3552,6 @@ Connection.prototype.STATE = {
       },
       connectTimeout: function() {
         this.transitionTo(this.STATE.FINAL);
-      },
-      message: function(message) {
-        const handler = new Login7TokenHandler(this);
-        const tokenStreamParser = this.createTokenStreamParser(message, handler);
-
-        tokenStreamParser.once('end', () => {
-          if (handler.loginAckReceived) {
-            if (handler.routingData) {
-              this.routingData = handler.routingData;
-              this.transitionTo(this.STATE.REROUTING);
-            } else {
-              this.transitionTo(this.STATE.LOGGED_IN_SENDING_INITIAL_SQL);
-            }
-
-            return;
-          }
-
-          const fedAuthInfoToken = handler.fedAuthInfoToken;
-
-          if (fedAuthInfoToken && fedAuthInfoToken.stsurl && fedAuthInfoToken.spn) {
-            const authentication = this.config.authentication as AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryServicePrincipalSecret | AzureActiveDirectoryDefaultAuthentication;
-            const tokenScope = new URL('/.default', fedAuthInfoToken.spn).toString();
-
-            const getToken = (callback: (error: Error | null, token?: string) => void) => {
-              const getTokenFromCredentials = (credentials: TokenCredential) => {
-                credentials.getToken(tokenScope).then((tokenResponse) => {
-                  callback(null, tokenResponse?.token);
-                }, callback);
-              };
-
-              if (authentication.type === 'azure-active-directory-password') {
-                const credentials = new UsernamePasswordCredential(
-                  authentication.options.tenantId ?? 'common',
-                  authentication.options.clientId,
-                  authentication.options.userName,
-                  authentication.options.password
-                );
-
-                getTokenFromCredentials(credentials);
-              } else if (authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service') {
-                const msiArgs = authentication.options.clientId ? [ authentication.options.clientId, {} ] : [ {} ];
-                const credentials = new ManagedIdentityCredential(...msiArgs);
-
-                getTokenFromCredentials(credentials);
-              } else if (authentication.type === 'azure-active-directory-default') {
-                const args = authentication.options.clientId ? { managedIdentityClientId: authentication.options.clientId } : {};
-                const credentials = new DefaultAzureCredential(args);
-
-                getTokenFromCredentials(credentials);
-              } else if (authentication.type === 'azure-active-directory-service-principal-secret') {
-                const credentials = new ClientSecretCredential(
-                  authentication.options.tenantId,
-                  authentication.options.clientId,
-                  authentication.options.clientSecret
-                );
-
-                getTokenFromCredentials(credentials);
-              }
-            };
-
-            getToken((err, token) => {
-              if (err) {
-                this.loginError = new AggregateError(
-                  [new ConnectionError('Security token could not be authenticated or authorized.', 'EFEDAUTH'), err]);
-                this.emit('connect', this.loginError);
-                this.transitionTo(this.STATE.FINAL);
-                return;
-              }
-
-              this.sendFedAuthTokenMessage(token!);
-            });
-          } else if (this.loginError) {
-            if (isTransientError(this.loginError)) {
-              this.debug.log('Initiating retry on transient error');
-              this.transitionTo(this.STATE.TRANSIENT_FAILURE_RETRY);
-            } else {
-              this.emit('connect', this.loginError);
-              this.transitionTo(this.STATE.FINAL);
-            }
-          } else {
-            this.emit('connect', new ConnectionError('Login failed.', 'ELOGIN'));
-            this.transitionTo(this.STATE.FINAL);
-          }
-        });
       }
     }
   },

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3310,12 +3310,21 @@ Connection.prototype.STATE = {
         this.sendLogin7Packet();
 
         const { authentication } = this.config;
-        if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service' || authentication.type === 'azure-active-directory-service-principal-secret' || authentication.type === 'azure-active-directory-default') {
-          this.transitionTo(this.STATE.SENT_LOGIN7_WITH_FEDAUTH);
-        } else if (authentication.type === 'ntlm') {
-          this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
-        } else {
-          this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+
+        switch (authentication.type) {
+          case 'azure-active-directory-password':
+          case 'azure-active-directory-msi-vm':
+          case 'azure-active-directory-msi-app-service':
+          case 'azure-active-directory-service-principal-secret':
+          case 'azure-active-directory-default':
+            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_FEDAUTH);
+            break;
+          case 'ntlm':
+            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_NTLM);
+            break;
+          default:
+            this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
+            break;
         }
       })().catch((err) => {
         process.nextTick(() => {


### PR DESCRIPTION
Continuation of #1437. 

This refactors some of the state handling in the Connection class to make use of async/await.

The goal here is to gradually move us to a more readable, maintainable and overall more robust connection handling logic.

This PR changes the following states:

- `SENT_LOGIN7_WITH_FEDAUTH`
- `SENT_ATTENTION`
- `SENT_CLIENT_REQUEST`