### PR TITLE
ci: lint pull request titles

### DIFF
--- a/.github/workflows/lint-pull-request-title.yml
+++ b/.github/workflows/lint-pull-request-title.yml
@@ -1,0 +1,17 @@
+name: "Lint Pull Request Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Lint Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want to lower the burden of contributions by switching away from the current workflow that requires each commit to be tagged according to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) rules.

Instead, we want to switch to a "squash and merge" based workflow, where a pull requests's title becomes the source of the final commit that will be merged. This will allow contributors not to have to care about their commit messages, and maintainers can just edit the pull request's title before merging a pull request to make it fit our contribution rules.
