### PR TITLE
chore: always require `await`ing on promises before return

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@ parser: "@typescript-eslint/parser"
 
 parserOptions:
   sourceType: "module"
+  project: "./tsconfig.json"
 
 plugins:
   - "@typescript-eslint"
@@ -93,7 +94,7 @@ rules:
       message: "Use `new` keyword when throwing an `Error`.",
     }
   ]
-  no-return-await: "error"
+  no-return-await: "off"
   no-self-assign: "error"
   no-self-compare: "error"
   no-tabs: "error"
@@ -193,6 +194,7 @@ overrides:
       "@typescript-eslint/prefer-namespace-keyword": "error"
       "@typescript-eslint/triple-slash-reference": "error"
       "@typescript-eslint/type-annotation-spacing": "error"
+      "@typescript-eslint/return-await": ["error", "always"]
       "no-var": "error"
       "prefer-const": "error"
       "prefer-rest-params": "error"

--- a/src/always-encrypted/keystore-provider-azure-key-vault.ts
+++ b/src/always-encrypted/keystore-provider-azure-key-vault.ts
@@ -201,7 +201,7 @@ export class ColumnEncryptionAzureKeyVaultProvider {
 
     this.createKeyClient(keyParts.vaultUrl);
 
-    return (this.keyClient as KeyClient).getKey(keyParts.name, keyParts.version ? { version: keyParts.version } : {});
+    return await (this.keyClient as KeyClient).getKey(keyParts.name, keyParts.version ? { version: keyParts.version } : {});
   }
 
   private createKeyClient(keyVaultUrl: string): void {


### PR DESCRIPTION
Contrary to what one might believe, `await`ing on `Promise` value before returning from an `async` function actually has better performance than returning a `Promise` value directly in v8. This is due to optimizations that the engine can perform when using the `await` keyword.

On top of that, v8's async stack trace functionality only works correctly when `await` is used consistently here.