### PR TITLE
chore: clarify mininum compatible node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/tediousjs/tedious.git"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">=12.3.0"
   },
   "publishConfig": {
     "tag": "next"


### PR DESCRIPTION
Tedious code uses `stream.Readable.from`
https://nodejs.org/api/stream.html#streamreadablefromiterable-options
which was added in v12.3.0, v10.17.0.
