### PR TITLE
refactor: remove callbacks from `metadata parser`

### DIFF
--- a/src/token/colmetadata-token-parser.ts
+++ b/src/token/colmetadata-token-parser.ts
@@ -191,6 +191,7 @@ function readCEKTableEntry(parser: Parser, callback: (cekEntry: CEKEntry) => voi
     });
   });
 }
+
 function readCEKValue(parser: Parser, cekEntry: CEKEntry, cekTableEntryMetadata: cekTableEntryMetadata, callback: () => void) {
   parser.readUInt16LE((encryptedCEKLength) => {
     parser.readBuffer(encryptedCEKLength, (encryptedCEK) => {
@@ -220,9 +221,9 @@ async function colMetadataParser(parser: Parser): Promise<ColMetadataToken> {
   }
   const columnCount = parser.buffer.readUInt16LE(parser.position);
   parser.position += 2;
-  let cekList: CEKEntry[] | undefined;
+  // let cekList: CEKEntry[] | undefined;
 
-  readCEKTable(parser, parser.options, (c?: CEKEntry[]) => { cekList = c; });
+  const cekList = await readCEKTable_async(parser, parser.options);
 
   while (parser.suspended) {
     await parser.streamBuffer.waitForChunk();
@@ -248,5 +249,83 @@ async function colMetadataParser(parser: Parser): Promise<ColMetadataToken> {
   }
   return new ColMetadataToken(columns);
 }
+
+// ---------- Remove Callbacks --------------
+async function readCEKTable_async(parser: Parser, options: InternalConnectionOptions) {
+  const cekList: CEKEntry[] = [];
+  if (options.serverSupportsColumnEncryption === true) {
+    const tableSize = await parser.readUInt16LE_async();
+    if (tableSize > 0) {
+      let i = 0;
+      while (i < tableSize) {
+        const cekEntry = await readCEKTableEntry_async(parser);
+        cekList.push(cekEntry);
+        i++;
+      }
+    }
+  }
+  return cekList;
+}
+
+async function readTableName_async(parser: Parser, options: InternalConnectionOptions, metadata: Metadata): Promise<string | string[] | undefined> {
+  if (metadata.type.hasTableName) {
+    if (options.tdsVersion >= '7_2') {
+      const numberOfTableNameParts = await parser.readUInt8_async();
+      const tableName: string[] = [];
+      let i = 0;
+      while (i < numberOfTableNameParts) {
+        const part = await parser.readUsVarChar_async();
+        tableName.push(part);
+        i++;
+      }
+      return tableName;
+    } else {
+      const tableName = await parser.readUsVarChar_async();
+      return tableName;
+    }
+  } else {
+    return undefined;
+  }
+}
+
+
+async function readCEKTableEntry_async(parser: Parser): Promise<CEKEntry> {
+  const databaseId = await parser.readUInt32LE_async();
+  const cekId = await parser.readUInt32LE_async();
+  const cekVersion = await parser.readUInt32LE_async();
+  const cekMdVersion = await parser.readBuffer_async(8);
+  const cekValueCount = await parser.readUInt8_async();
+  const cekEntry = new CEKEntry(cekValueCount);
+  let i = 0;
+  while (i < cekValueCount) {
+    readCEKValue_async(parser, cekEntry, {
+      databaseId,
+      cekId,
+      cekVersion,
+      cekMdVersion,
+    });
+    i++;
+  }
+  return cekEntry;
+}
+
+async function readCEKValue_async(parser: Parser, cekEntry: CEKEntry, cekTableEntryMetadata: cekTableEntryMetadata): Promise<void> {
+  const encryptedCEKLength = await parser.readUInt16LE_async();
+  const encryptedCEK = await parser.readBuffer_async(encryptedCEKLength);
+
+  const keyStoreNameLength = await parser.readUInt8_async();
+  const keyStoreNameBuffer = await parser.readBuffer_async(2 * keyStoreNameLength);
+  const keyStoreName = keyStoreNameBuffer.toString('ucs2');
+
+  const keyPathLength = await parser.readUInt8_async();
+  const keyPathBuffer = await parser.readBuffer_async(2 * keyPathLength);
+  const keyPath = keyPathBuffer.swap16().toString('ucs2');
+
+  const algorithmNameLength = await parser.readUInt16BE_async();
+  const algorithmNameBuffer = await parser.readBuffer_async(2 * algorithmNameLength);
+  const algorithmName = algorithmNameBuffer.toString('ucs2');
+  cekEntry.add(encryptedCEK, cekTableEntryMetadata.databaseId, cekTableEntryMetadata.cekId, cekTableEntryMetadata.cekVersion, cekTableEntryMetadata.cekMdVersion, keyPath, keyStoreName, algorithmName);
+}
+
 export default colMetadataParser;
 module.exports = colMetadataParser;

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -80,6 +80,9 @@ export interface IParser {
   readBVarByte(callback: (data: Buffer) => void): void;
 
   readUsVarByte(callback: (data: Buffer) => void): void;
+
+  readBuffer_async(length: number): Promise<Buffer>;
+
 }
 
 class StreamBuffer {

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -539,6 +539,7 @@ class Parser implements IParser {
   }
 
   // ------------------------ TEMP ASYNC ------------------------------
+  /*
   async suspend_async(next: () => void) {
     await this.streamBuffer.waitForChunk();
     next();
@@ -833,6 +834,270 @@ class Parser implements IParser {
     this.readUInt16LE((length) => {
       this.readBuffer(length, callback);
     });
+  }
+
+  */
+
+  // ------------------ Callback removal ---------------------
+
+  async awaitData_async(length: number): Promise<void> {
+    if (this.position + length > this.buffer.length) {
+      this.suspend(() => {});
+      await this.streamBuffer.waitForChunk();
+    }
+  }
+
+
+  async readInt8_async(): Promise<number> {
+    await this.awaitData_async(1);
+    const data = this.buffer.readInt8(this.position);
+    this.position += 1;
+    return data;
+  }
+
+  async readUInt8_async(): Promise<number> {
+    await this.awaitData_async(1);
+    const data = this.buffer.readUInt8(this.position);
+    this.position += 1;
+    return data;
+  }
+
+  async readInt16LE_async(): Promise<number> {
+    await this.awaitData_async(2);
+    const data = this.buffer.readInt16LE(this.position);
+    this.position += 2;
+    return data;
+  }
+
+  async readInt16BE_async(): Promise<number> {
+    await this.awaitData_async(2);
+    const data = this.buffer.readInt16BE(this.position);
+    this.position += 2;
+    return data;
+  }
+
+  async readUInt16LE_async(): Promise<number> {
+    await this.awaitData_async(2);
+    const data = this.buffer.readUInt16LE(this.position);
+    this.position += 2;
+    return data;
+  }
+
+  async readUInt16BE_async(): Promise<number> {
+    await this.awaitData_async(2);
+    const data = this.buffer.readUInt16BE(this.position);
+    this.position += 2;
+    return data;
+  }
+
+  async readInt32LE_async(): Promise<number> {
+    await this.awaitData_async(4);
+    const data = this.buffer.readInt32LE(this.position);
+    this.position += 4;
+    return data;
+  }
+
+  async readInt32BE_async(): Promise<number> {
+    await this.awaitData_async(4);
+    const data = this.buffer.readInt32BE(this.position);
+    this.position += 4;
+    return data;
+  }
+
+  async readUInt32LE_async(): Promise<number> {
+    await this.awaitData_async(4);
+    const data = this.buffer.readUInt32LE(this.position);
+    this.position += 4;
+    return data;
+
+  }
+
+  async readUInt32BE_async(): Promise<number> {
+    await this.awaitData_async(4);
+    const data = this.buffer.readUInt32BE(this.position);
+    this.position += 4;
+    return data;
+  }
+
+  async readBigInt64LE_async(): Promise<JSBI> {
+    await this.awaitData_async(8);
+    const result = JSBI.add(
+      JSBI.leftShift(
+        JSBI.BigInt(
+          this.buffer[this.position + 4] +
+          this.buffer[this.position + 5] * 2 ** 8 +
+          this.buffer[this.position + 6] * 2 ** 16 +
+          (this.buffer[this.position + 7] << 24) // Overflow
+        ),
+        JSBI.BigInt(32)
+      ),
+      JSBI.BigInt(
+        this.buffer[this.position] +
+        this.buffer[this.position + 1] * 2 ** 8 +
+        this.buffer[this.position + 2] * 2 ** 16 +
+        this.buffer[this.position + 3] * 2 ** 24
+      )
+    );
+
+    this.position += 8;
+
+    return result;
+  }
+
+  async readInt64LE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const data = Math.pow(2, 32) * this.buffer.readInt32LE(this.position + 4) + ((this.buffer[this.position + 4] & 0x80) === 0x80 ? 1 : -1) * this.buffer.readUInt32LE(this.position);
+    this.position += 8;
+    return data;
+  }
+
+  async readInt64BE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const data = Math.pow(2, 32) * this.buffer.readInt32BE(this.position) + ((this.buffer[this.position] & 0x80) === 0x80 ? 1 : -1) * this.buffer.readUInt32BE(this.position + 4);
+    this.position += 8;
+    return data;
+  }
+
+  async readBigUInt64LE_async(): Promise<JSBI> {
+    await this.awaitData_async(8);
+    const low = JSBI.BigInt(this.buffer.readUInt32LE(this.position));
+    const high = JSBI.BigInt(this.buffer.readUInt32LE(this.position + 4));
+
+    this.position += 8;
+
+    return JSBI.add(low, JSBI.leftShift(high, JSBI.BigInt(32)));
+  }
+
+  async readUInt64LE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const data = Math.pow(2, 32) * this.buffer.readUInt32LE(this.position + 4) + this.buffer.readUInt32LE(this.position);
+    this.position += 8;
+    return data;
+  }
+
+  async readUInt64BE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const data = Math.pow(2, 32) * this.buffer.readUInt32BE(this.position) + this.buffer.readUInt32BE(this.position + 4);
+    this.position += 8;
+    return data;
+  }
+
+  async readFloatLE_async(): Promise<number> {
+    await this.awaitData_async(4);
+    const data = this.buffer.readFloatLE(this.position);
+    this.position += 4;
+    return data;
+  }
+
+  async readFloatBE_async(): Promise<number> {
+    await this.awaitData_async(4);
+    const data = this.buffer.readFloatBE(this.position);
+    this.position += 4;
+    return data;
+  }
+
+  async readDoubleLE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const data = this.buffer.readDoubleLE(this.position);
+    this.position += 8;
+    return data;
+  }
+
+  async readDoubleBE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const data = this.buffer.readDoubleBE(this.position);
+    this.position += 8;
+    return data;
+  }
+
+  async readUInt24LE_async(): Promise<number> {
+    await this.awaitData_async(3);
+    const low = this.buffer.readUInt16LE(this.position);
+    const high = this.buffer.readUInt8(this.position + 2);
+
+    this.position += 3;
+
+    return low | (high << 16);
+  }
+
+  async readUInt40LE_async(): Promise<number> {
+    await this.awaitData_async(5);
+    const low = this.buffer.readUInt32LE(this.position);
+    const high = this.buffer.readUInt8(this.position + 4);
+
+    this.position += 5;
+
+    return (0x100000000 * high) + low;
+  }
+
+  async readUNumeric64LE_async(): Promise<number> {
+    await this.awaitData_async(8);
+    const low = this.buffer.readUInt32LE(this.position);
+    const high = this.buffer.readUInt32LE(this.position + 4);
+
+    this.position += 8;
+
+    return (0x100000000 * high) + low;
+  }
+
+  async readUNumeric96LE_async(): Promise<number> {
+    await this.awaitData_async(12);
+    const dword1 = this.buffer.readUInt32LE(this.position);
+    const dword2 = this.buffer.readUInt32LE(this.position + 4);
+    const dword3 = this.buffer.readUInt32LE(this.position + 8);
+
+    this.position += 12;
+
+    return dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3);
+  }
+
+  async readUNumeric128LE_async(): Promise<number> {
+    await this.awaitData_async(16);
+    const dword1 = this.buffer.readUInt32LE(this.position);
+    const dword2 = this.buffer.readUInt32LE(this.position + 4);
+    const dword3 = this.buffer.readUInt32LE(this.position + 8);
+    const dword4 = this.buffer.readUInt32LE(this.position + 12);
+
+    this.position += 16;
+
+    return dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3) + (0x100000000 * 0x100000000 * 0x100000000 * dword4);
+  }
+
+  // Variable length data
+
+  async readBuffer_async(length: number): Promise<Buffer> {
+    await this.awaitData_async(length);
+    const data = this.buffer.slice(this.position, this.position + length);
+    this.position += length;
+    return data;
+  }
+
+  // Read a Unicode String (BVARCHAR)
+  async readBVarChar_async(): Promise<string> {
+    const length = await this.readUInt8_async();
+    const data = await this.readBuffer_async(length * 2);
+    return data.toString('ucs2');
+  }
+
+  // Read a Unicode String (USVARCHAR)
+  async readUsVarChar_async(): Promise<string> {
+    const length = await this.readUInt16LE_async();
+    const data = await this.readBuffer_async(length * 2);
+    return data.toString('ucs2');
+  }
+
+  // Read binary data (BVARBYTE)
+  async readBVarByte_async(): Promise<Buffer> {
+    const length = await this.readUInt8_async();
+    const data = await this.readBuffer_async(length);
+    return data;
+  }
+
+  // Read binary data (USVARBYTE)
+  async readUsVarByte_async(): Promise<Buffer> {
+    const length = await this.readUInt16LE_async();
+    const data = await this.readBuffer_async(length);
+    return data;
   }
 }
 


### PR DESCRIPTION
Just an idea, converts callbacks to async/await for the column metadata parser-related classes. Would need to do more work to make all of the other tests pass if we want to continue with this approach.