### PR TITLE
refactor: refactor tls negotiation code

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3212,11 +3212,7 @@ Connection.prototype.STATE = {
 
           try {
             this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
-            await new Promise<void>((resolve, reject) => {
-              this.messageIo.startTls(this.secureContext, this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate, (err) => {
-                err ? reject(err) : resolve();
-              });
-            });
+            await this.messageIo.startTls(this.secureContext, this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
           } catch (err: any) {
             return this.socketError(err);
           }

--- a/test/unit/message-io-test.ts
+++ b/test/unit/message-io-test.ts
@@ -368,11 +368,7 @@ describe('MessageIO', function() {
         (async () => {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
-          await new Promise<void>((resolve, reject) => {
-            io.startTls(createSecureContext({}), 'localhost', true, (err) => {
-              err ? reject(err) : resolve();
-            });
-          });
+          await io.startTls(createSecureContext({}), 'localhost', true);
 
           assert(io.tlsNegotiationComplete);
         })(),
@@ -433,11 +429,7 @@ describe('MessageIO', function() {
         (async () => {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
-          await new Promise<void>((resolve, reject) => {
-            io.startTls(createSecureContext({}), 'localhost', true, (err) => {
-              err ? reject(err) : resolve();
-            });
-          });
+          await io.startTls(createSecureContext({}), 'localhost', true);
 
           // Send a request (via TLS)
           io.sendMessage(TYPE.LOGIN7, payload);
@@ -533,14 +525,10 @@ describe('MessageIO', function() {
 
           let hadError = false;
           try {
-            await new Promise<void>((resolve, reject) => {
-              io.startTls(createSecureContext({
-                // Use a cipher that causes an error immediately
-                ciphers: 'NULL'
-              }), 'localhost', true, (err) => {
-                err ? reject(err) : resolve();
-              });
-            });
+            await io.startTls(createSecureContext({
+              // Use a cipher that causes an error immediately
+              ciphers: 'NULL'
+            }), 'localhost', true);
           } catch (err: any) {
             hadError = true;
 
@@ -567,14 +555,10 @@ describe('MessageIO', function() {
 
           let hadError = false;
           try {
-            await new Promise<void>((resolve, reject) => {
-              io.startTls(createSecureContext({
-                // Use some cipher that's not supported on the server side
-                ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256'
-              }), 'localhost', true, (err) => {
-                err ? reject(err) : resolve();
-              });
-            });
+            await io.startTls(createSecureContext({
+              // Use some cipher that's not supported on the server side
+              ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256'
+            }), 'localhost', true);
           } catch (err: any) {
             hadError = true;
 


### PR DESCRIPTION
Currently, TLS negotiation happens via inside a "special" connection state called `SENT_TLSSSLNEGOTIATION`, and the logic for performing the handshake procedure is spread across two classes (`Connection` and `MessageIO`) and multiple methods.

This pull requests moves all of the tls negotation logic into `MessageIO#startTls`. It also improves TLS error handling during negotiation and adds multiple unit tests to ensure that the logic is covered and working correctly.