### PR TITLE
docs: update README.md with link to mssql library

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Tedious is a pure-Javascript implementation of the [TDS protocol](http://msdn.microsoft.com/en-us/library/dd304523.aspx),
 which is used to interact with instances of Microsoft's SQL Server. It is intended to be a fairly slim implementation of the protocol, with not too much additional functionality. 
 
-If you're looking for a SQL Server client library, you can take a look [mssql](https://github.com/tediousjs/node-mssql).
+If you're looking for a more high level SQL Server client library, you can take a look [mssql](https://github.com/tediousjs/node-mssql).
 
 **NOTE: New columns are nullable by default as of version 1.11.0**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 
 Tedious is a pure-Javascript implementation of the [TDS protocol](http://msdn.microsoft.com/en-us/library/dd304523.aspx),
-which is used to interact with instances of Microsoft's SQL Server. It is intended to be a fairly slim implementation of the protocol, with not too much additional functionality.
+which is used to interact with instances of Microsoft's SQL Server. It is intended to be a fairly slim implementation of the protocol, with not too much additional functionality. 
+
+If you're looking for a SQL Server client library, you can take a look [mssql](https://github.com/tediousjs/node-mssql).
 
 **NOTE: New columns are nullable by default as of version 1.11.0**
 


### PR DESCRIPTION
It took me a while to discover that Tedious maybe isn't the preferred library for writing nodejs applications that use SQL Server. After figuring out that the mssql library is more high level (and uses Tedious), I thought it would be nice to make it clearer to new people coming looking for a way to interact with SQL Server from nodejs.

Maybe it's just because I'm not used to working in nodejs, but I found Tedious quite tedious (🥁 ) to work with as a client library. And since all the documentation for nodejs Azure Functions only ever mentions Tedious, I assumed that this was the way to do it. I might be wrong, but if not I think this would be a small change that can save others like me quite some time. 

I think a mention on https://tediousjs.github.io/tedious/ would be nice too, but I couldn't find the code anywhere. If you agree I'll gladly add it there also if you point me to the code 😄 
