### PR TITLE
refactor: remove callbacks from metadataParse

### DIFF
--- a/src/metadata-parser.ts
+++ b/src/metadata-parser.ts
@@ -93,14 +93,12 @@ function readUInt32LE(parser: Parser): number {
 function readBVarChar(parser: Parser): string {
   const length = readUInt8(parser) * 2;
   const data = readFromBuffer(parser, length).toString('ucs2');
-  parser.position += length;
   return data;
 }
 
 function readUsVarChar(parser: Parser): string {
   const length = readUInt16LE(parser) * 2;
   const data = readFromBuffer(parser, length).toString('ucs2');
-  parser.position += length;
   return data;
 }
 

--- a/src/token/colmetadata-token-parser.ts
+++ b/src/token/colmetadata-token-parser.ts
@@ -63,11 +63,13 @@ function readColumnName(parser: Parser, options: ParserOptions, index: number, m
 
 function readColumn(parser: Parser, options: ParserOptions, index: number, callback: (column: ColumnMetadata) => void) {
   let metadata!: Metadata;
+  const offset = parser.position;
   try {
     metadata = metadataParse(parser, options);
   } catch (err) {
     if (err instanceof NotEnoughDataError) {
       return parser.suspend(() => {
+        parser.position = offset;
         readColumn(parser, options, index, callback);
       });
     }

--- a/src/token/returnvalue-token-parser.ts
+++ b/src/token/returnvalue-token-parser.ts
@@ -25,6 +25,7 @@ function returnParser(parser: Parser, options: ParserOptions, callback: (token: 
 
 function readValue(parser: Parser, options: ParserOptions, paramOrdinal: number, paramName: string, originalPosition: number, callback: (token: ReturnValueToken) => void) {
   let metadata!: Metadata;
+  parser.position = originalPosition;
   try {
     metadata = metadataParse(parser, options);
   } catch (err) {

--- a/src/token/returnvalue-token-parser.ts
+++ b/src/token/returnvalue-token-parser.ts
@@ -4,8 +4,10 @@ import Parser, { ParserOptions } from './stream-parser';
 
 import { ReturnValueToken } from './token';
 
-import metadataParse from '../metadata-parser';
+import metadataParse, { Metadata } from '../metadata-parser';
 import valueParse from '../value-parser';
+
+class NotEnoughDataError extends Error { }
 
 function returnParser(parser: Parser, options: ParserOptions, callback: (token: ReturnValueToken) => void) {
   parser.readUInt16LE((paramOrdinal) => {
@@ -13,21 +15,32 @@ function returnParser(parser: Parser, options: ParserOptions, callback: (token: 
       if (paramName.charAt(0) === '@') {
         paramName = paramName.slice(1);
       }
-
+      parser.position += 1;
       // status
-      parser.readUInt8(() => {
-        metadataParse(parser, options, (metadata) => {
-          valueParse(parser, metadata, options, (value) => {
-            callback(new ReturnValueToken({
-              paramOrdinal: paramOrdinal,
-              paramName: paramName,
-              metadata: metadata,
-              value: value
-            }));
-          });
-        });
-      });
+      readValue(parser, options, paramOrdinal, paramName, parser.position, callback);
+
     });
+  });
+}
+
+function readValue(parser: Parser, options: ParserOptions, paramOrdinal: number, paramName: string, originalPosition: number, callback: (token: ReturnValueToken) => void) {
+  let metadata!: Metadata;
+  try {
+    metadata = metadataParse(parser, options);
+  } catch (err) {
+    if (err instanceof NotEnoughDataError) {
+      return parser.suspend(() => {
+        readValue(parser, options, paramOrdinal, paramName, originalPosition, callback);
+      });
+    }
+  }
+  valueParse(parser, metadata, options, (value) => {
+    callback(new ReturnValueToken({
+      paramOrdinal: paramOrdinal,
+      paramName: paramName,
+      metadata: metadata,
+      value: value
+    }));
   });
 }
 

--- a/src/value-parser.ts
+++ b/src/value-parser.ts
@@ -458,17 +458,15 @@ function readVariant(parser: Parser, options: ParserOptions, dataLength: number,
         case 'VarChar':
         case 'Char':
           return parser.readUInt16LE((_maxLength) => {
-            readCollation(parser, (collation) => {
-              readChars(parser, dataLength, collation.codepage!, callback);
-            });
+            const collation = readCollation(parser);
+            readChars(parser, dataLength, collation.codepage!, callback);
           });
 
         case 'NVarChar':
         case 'NChar':
           return parser.readUInt16LE((_maxLength) => {
-            readCollation(parser, (_collation) => {
-              readNChars(parser, dataLength, callback);
-            });
+            readCollation(parser);
+            readNChars(parser, dataLength, callback);
           });
 
         default:


### PR DESCRIPTION
Would it be a good idea to create a new stream parser-style class to handle these parsers?

Planning to move the parser position reset upon retry into metadataParse. 