### PR TITLE
fix: set maximum supported TLS version to 1.2

### DIFF
--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -61,7 +61,13 @@ class MessageIO extends EventEmitter {
   }
 
   // Negotiate TLS encryption.
-  startTls(secureContext: tls.SecureContext, hostname: string, trustServerCertificate: boolean) {
+  startTls(credentialsDetails: tls.SecureContextOptions, hostname: string, trustServerCertificate: boolean) {
+    if (!credentialsDetails.maxVersion || !['TLSv1.2', 'TLSv1.1', 'TLSv1'].includes(credentialsDetails.maxVersion)) {
+      credentialsDetails.maxVersion = 'TLSv1.2';
+    }
+
+    const secureContext = tls.createSecureContext(credentialsDetails);
+
     return new Promise<void>((resolve, reject) => {
       const duplexpair = new DuplexPair();
       const securePair = this.securePair = {

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -289,7 +289,6 @@ describe('Initiate Connect Test', function() {
 
     // Specify a cipher that should never be supported by SQL Server
     config.options.cryptoCredentialsDetails = {
-      maxVersion: 'TLSv1.2',
       ciphers: 'NULL'
     };
 

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -221,15 +221,10 @@ describe('Initiate Connect Test', function() {
     config.options.cryptoCredentialsDetails = {
       ciphers: '!ALL'
     };
-
-    try {
+    assert.throws(() => {
       const { createSecureContext } = require('tls');
       createSecureContext(config.options.cryptoCredentialsDetails);
-    } catch {
-      assert.throws(() => {
-        new Connection(config);
-      });
-    }
+    }, Error, new RegExp(/.*SSL routines.*no cipher match/));
 
     done();
   });

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -289,6 +289,7 @@ describe('Initiate Connect Test', function() {
 
     // Specify a cipher that should never be supported by SQL Server
     config.options.cryptoCredentialsDetails = {
+      maxVersion: 'TLSv1.2',
       ciphers: 'NULL'
     };
 

--- a/test/unit/message-io-test.ts
+++ b/test/unit/message-io-test.ts
@@ -527,6 +527,7 @@ describe('MessageIO', function() {
           try {
             await io.startTls(createSecureContext({
               // Use a cipher that causes an error immediately
+              maxVersion: 'TLSv1.2',
               ciphers: 'NULL'
             }), 'localhost', true);
           } catch (err: any) {

--- a/test/unit/message-io-test.ts
+++ b/test/unit/message-io-test.ts
@@ -3,7 +3,7 @@ import { once } from 'events';
 import { assert } from 'chai';
 import { promisify } from 'util';
 import DuplexPair from 'native-duplexpair';
-import { createSecureContext, TLSSocket } from 'tls';
+import { TLSSocket } from 'tls';
 import { readFileSync } from 'fs';
 import { Duplex } from 'stream';
 
@@ -368,7 +368,7 @@ describe('MessageIO', function() {
         (async () => {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
-          await io.startTls(createSecureContext({}), 'localhost', true);
+          await io.startTls({}, 'localhost', true);
 
           assert(io.tlsNegotiationComplete);
         })(),
@@ -429,7 +429,7 @@ describe('MessageIO', function() {
         (async () => {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
-          await io.startTls(createSecureContext({}), 'localhost', true);
+          await io.startTls({}, 'localhost', true);
 
           // Send a request (via TLS)
           io.sendMessage(TYPE.LOGIN7, payload);
@@ -525,10 +525,10 @@ describe('MessageIO', function() {
 
           let hadError = false;
           try {
-            await io.startTls(createSecureContext({
+            await io.startTls({
               // Use a cipher that causes an error immediately
               ciphers: 'NULL'
-            }), 'localhost', true);
+            }, 'localhost', true);
           } catch (err: any) {
             hadError = true;
 
@@ -555,10 +555,10 @@ describe('MessageIO', function() {
 
           let hadError = false;
           try {
-            await io.startTls(createSecureContext({
+            await io.startTls({
               // Use some cipher that's not supported on the server side
               ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256'
-            }), 'localhost', true);
+            }, 'localhost', true);
           } catch (err: any) {
             hadError = true;
 

--- a/test/unit/message-io-test.ts
+++ b/test/unit/message-io-test.ts
@@ -527,7 +527,6 @@ describe('MessageIO', function() {
           try {
             await io.startTls(createSecureContext({
               // Use a cipher that causes an error immediately
-              maxVersion: 'TLSv1.2',
               ciphers: 'NULL'
             }), 'localhost', true);
           } catch (err: any) {


### PR DESCRIPTION
Modifies tests to pass on Node 18.6.0+