### PR TITLE
feat: replace `JSBI` with native `BigInt`

### DIFF
--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -30,9 +30,7 @@ const BigInt: DataType = {
     if (parameter.value == null) {
       return;
     }
-    // const buffer = Buffer.alloc(8);
-    // buffer.writeBigInt64LE(parameter.value);
-    // buffer.
+
     const buffer = new WritableTrackingBuffer(8);
     buffer.writeInt64LE(Number(parameter.value));
     yield buffer.data;

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -30,7 +30,9 @@ const BigInt: DataType = {
     if (parameter.value == null) {
       return;
     }
-
+    // const buffer = Buffer.alloc(8);
+    // buffer.writeBigInt64LE(parameter.value);
+    // buffer.
     const buffer = new WritableTrackingBuffer(8);
     buffer.writeInt64LE(Number(parameter.value));
     yield buffer.data;

--- a/src/ntlm-payload.ts
+++ b/src/ntlm-payload.ts
@@ -1,6 +1,5 @@
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import * as crypto from 'crypto';
-import JSBI from 'jsbi';
 import md4 from 'js-md4';
 
 interface Options {
@@ -109,10 +108,10 @@ class NTLMResponsePayload {
   }
 
   createTimestamp(time: number) {
-    const tenthsOfAMicrosecond = JSBI.multiply(JSBI.add(JSBI.BigInt(time), JSBI.BigInt(11644473600)), JSBI.BigInt(10000000));
+    const tenthsOfAMicrosecond = (BigInt(time) + BigInt(11644473600)) * BigInt(10000000);
 
-    const lo = JSBI.toNumber(JSBI.bitwiseAnd(tenthsOfAMicrosecond, JSBI.BigInt(0xffffffff)));
-    const hi = JSBI.toNumber(JSBI.bitwiseAnd(JSBI.signedRightShift(tenthsOfAMicrosecond, JSBI.BigInt(32)), JSBI.BigInt(0xffffffff)));
+    const lo = Number(tenthsOfAMicrosecond & BigInt(0xffffffff));
+    const hi = Number((tenthsOfAMicrosecond >> BigInt(32)) & BigInt(0xffffffff));
 
     const result = Buffer.alloc(8);
     result.writeUInt32LE(lo, 0);

--- a/src/token/done-token-parser.ts
+++ b/src/token/done-token-parser.ts
@@ -1,5 +1,3 @@
-import JSBI from 'jsbi';
-
 import Parser, { ParserOptions } from './stream-parser';
 import { DoneToken, DoneInProcToken, DoneProcToken } from './token';
 
@@ -48,7 +46,7 @@ function parseToken(parser: Parser, options: ParserOptions, callback: (data: Tok
         parser.readUInt32LE(next);
       } else {
         parser.readBigUInt64LE((rowCount) => {
-          next(JSBI.toNumber(rowCount));
+          next(Number(rowCount));
         });
       }
     });

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -255,7 +255,7 @@ class Parser {
     });
   }
 
-  readBigInt64LE(callback: (data: BigInt) => void) {
+  readBigInt64LE(callback: (data: bigint) => void) {
     this.awaitData(8, () => {
       const data = this.buffer.readBigInt64LE(this.position);
       this.position += 8;
@@ -279,7 +279,7 @@ class Parser {
     });
   }
 
-  readBigUInt64LE(callback: (data: BigInt) => void) {
+  readBigUInt64LE(callback: (data: bigint) => void) {
     this.awaitData(8, () => {
       const data = this.buffer.readBigUInt64LE(this.position);
       this.position += 8;

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -1,6 +1,5 @@
 import Debug from '../debug';
 import { InternalConnectionOptions } from '../connection';
-import JSBI from 'jsbi';
 
 import { TYPE, Token, ColMetadataToken } from './token';
 
@@ -256,26 +255,22 @@ class Parser {
     });
   }
 
-  readBigInt64LE(callback: (data: JSBI) => void) {
+  readBigInt64LE(callback: (data: BigInt) => void) {
     this.awaitData(8, () => {
-      const result = JSBI.add(
-        JSBI.leftShift(
-          JSBI.BigInt(
-            this.buffer[this.position + 4] +
-            this.buffer[this.position + 5] * 2 ** 8 +
-            this.buffer[this.position + 6] * 2 ** 16 +
-            (this.buffer[this.position + 7] << 24) // Overflow
-          ),
-          JSBI.BigInt(32)
-        ),
-        JSBI.BigInt(
+      const result =
+        (BigInt(
+          this.buffer[this.position + 4] +
+          this.buffer[this.position + 5] * 2 ** 8 +
+          this.buffer[this.position + 6] * 2 ** 16 +
+          (this.buffer[this.position + 7] << 24) // Overflow
+        ) << BigInt(32)
+        ) +
+        BigInt(
           this.buffer[this.position] +
           this.buffer[this.position + 1] * 2 ** 8 +
           this.buffer[this.position + 2] * 2 ** 16 +
           this.buffer[this.position + 3] * 2 ** 24
-        )
-      );
-
+        );
       this.position += 8;
 
       callback(result);
@@ -298,14 +293,14 @@ class Parser {
     });
   }
 
-  readBigUInt64LE(callback: (data: JSBI) => void) {
+  readBigUInt64LE(callback: (data: BigInt) => void) {
     this.awaitData(8, () => {
-      const low = JSBI.BigInt(this.buffer.readUInt32LE(this.position));
-      const high = JSBI.BigInt(this.buffer.readUInt32LE(this.position + 4));
+      const low = BigInt(this.buffer.readUInt32LE(this.position));
+      const high = BigInt(this.buffer.readUInt32LE(this.position + 4));
 
       this.position += 8;
 
-      callback(JSBI.add(low, JSBI.leftShift(high, JSBI.BigInt(32))));
+      callback(low + (high << BigInt(32)));
     });
   }
 

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -257,23 +257,9 @@ class Parser {
 
   readBigInt64LE(callback: (data: BigInt) => void) {
     this.awaitData(8, () => {
-      const result =
-        (BigInt(
-          this.buffer[this.position + 4] +
-          this.buffer[this.position + 5] * 2 ** 8 +
-          this.buffer[this.position + 6] * 2 ** 16 +
-          (this.buffer[this.position + 7] << 24) // Overflow
-        ) << BigInt(32)
-        ) +
-        BigInt(
-          this.buffer[this.position] +
-          this.buffer[this.position + 1] * 2 ** 8 +
-          this.buffer[this.position + 2] * 2 ** 16 +
-          this.buffer[this.position + 3] * 2 ** 24
-        );
+      const data = this.buffer.readBigInt64LE(this.position);
       this.position += 8;
-
-      callback(result);
+      callback(data);
     });
   }
 
@@ -295,12 +281,9 @@ class Parser {
 
   readBigUInt64LE(callback: (data: BigInt) => void) {
     this.awaitData(8, () => {
-      const low = BigInt(this.buffer.readUInt32LE(this.position));
-      const high = BigInt(this.buffer.readUInt32LE(this.position + 4));
-
+      const data = this.buffer.readBigUInt64LE(this.position);
       this.position += 8;
-
-      callback(low + (high << BigInt(32)));
+      callback(data);
     });
   }
 

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -1,5 +1,3 @@
-import JSBI from 'jsbi';
-
 const SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
 const SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
 const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
@@ -106,36 +104,44 @@ class WritableTrackingBuffer {
     this.position += length;
   }
 
-  writeBigInt64LE(value: JSBI) {
+  writeBigInt64LE(value: number) {
     this.writeBigU_Int64LE(value);
   }
 
-  private writeBigU_Int64LE(value: JSBI) {
-    this.makeRoomFor(8);
-
-    let lo = JSBI.toNumber(JSBI.bitwiseAnd(value, JSBI.BigInt(0xffffffff)));
-
-    this.buffer[this.position++] = lo;
-    lo = lo >> 8;
-    this.buffer[this.position++] = lo;
-    lo = lo >> 8;
-    this.buffer[this.position++] = lo;
-    lo = lo >> 8;
-    this.buffer[this.position++] = lo;
-
-    let hi = JSBI.toNumber(JSBI.bitwiseAnd(JSBI.signedRightShift(value, JSBI.BigInt(32)), JSBI.BigInt(0xffffffff)));
-
-    this.buffer[this.position++] = hi;
-    hi = hi >> 8;
-    this.buffer[this.position++] = hi;
-    hi = hi >> 8;
-    this.buffer[this.position++] = hi;
-    hi = hi >> 8;
-    this.buffer[this.position++] = hi;
+  writeInt64LE(value: number) {
+    this.writeBigInt64LE(value);
   }
 
-  writeInt64LE(value: number) {
-    this.writeBigInt64LE(JSBI.BigInt(value));
+  writeUInt64LE(value: number) {
+    this.writeBigUInt64LE(value);
+  }
+
+  writeBigUInt64LE(value: number) {
+    this.writeBigU_Int64LE(value);
+  }
+
+  private writeBigU_Int64LE(value: number) {
+    this.makeRoomFor(8);
+
+    let lo = Number(BigInt(value) & BigInt(0xffffffff));
+
+    this.buffer[this.position++] = lo;
+    lo = lo >> 8;
+    this.buffer[this.position++] = lo;
+    lo = lo >> 8;
+    this.buffer[this.position++] = lo;
+    lo = lo >> 8;
+    this.buffer[this.position++] = lo;
+
+    let hi = Number((BigInt(value) >> BigInt(32)) & BigInt(0xffffffff));
+
+    this.buffer[this.position++] = hi;
+    hi = hi >> 8;
+    this.buffer[this.position++] = hi;
+    hi = hi >> 8;
+    this.buffer[this.position++] = hi;
+    hi = hi >> 8;
+    this.buffer[this.position++] = hi;
   }
 
   writeUInt32BE(value: number) {
@@ -149,14 +155,6 @@ class WritableTrackingBuffer {
     // inspired by https://github.com/dpw/node-buffer-more-ints
     this.writeInt32LE(value & -1);
     this.writeUInt8(Math.floor(value * SHIFT_RIGHT_32));
-  }
-
-  writeUInt64LE(value: number) {
-    this.writeBigUInt64LE(JSBI.BigInt(value));
-  }
-
-  writeBigUInt64LE(value: JSBI) {
-    this.writeBigU_Int64LE(value);
   }
 
   writeInt8(value: number) {

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -104,10 +104,10 @@ class WritableTrackingBuffer {
     this.position += length;
   }
 
-  writeBigInt64LE(value: BigInt) {
+  writeBigInt64LE(value: bigint) {
     const length = 8;
     this.makeRoomFor(length);
-    this.buffer.writeBigInt64LE(value.valueOf(), this.position);
+    this.buffer.writeBigInt64LE(value, this.position);
     this.position += length;
   }
 
@@ -119,10 +119,10 @@ class WritableTrackingBuffer {
     this.writeBigUInt64LE(BigInt(value));
   }
 
-  writeBigUInt64LE(value: BigInt) {
+  writeBigUInt64LE(value: bigint) {
     const length = 8;
     this.makeRoomFor(length);
-    this.buffer.writeBigUInt64LE(value.valueOf(), this.position);
+    this.buffer.writeBigUInt64LE(value, this.position);
     this.position += length;
   }
 

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -104,44 +104,26 @@ class WritableTrackingBuffer {
     this.position += length;
   }
 
-  writeBigInt64LE(value: number) {
-    this.writeBigU_Int64LE(value);
+  writeBigInt64LE(value: BigInt) {
+    const length = 8;
+    this.makeRoomFor(length);
+    this.buffer.writeBigInt64LE(value.valueOf(), this.position);
+    this.position += length;
   }
 
   writeInt64LE(value: number) {
-    this.writeBigInt64LE(value);
+    this.writeBigInt64LE(BigInt(value));
   }
 
   writeUInt64LE(value: number) {
-    this.writeBigUInt64LE(value);
+    this.writeBigUInt64LE(BigInt(value));
   }
 
-  writeBigUInt64LE(value: number) {
-    this.writeBigU_Int64LE(value);
-  }
-
-  private writeBigU_Int64LE(value: number) {
-    this.makeRoomFor(8);
-
-    let lo = Number(BigInt(value) & BigInt(0xffffffff));
-
-    this.buffer[this.position++] = lo;
-    lo = lo >> 8;
-    this.buffer[this.position++] = lo;
-    lo = lo >> 8;
-    this.buffer[this.position++] = lo;
-    lo = lo >> 8;
-    this.buffer[this.position++] = lo;
-
-    let hi = Number((BigInt(value) >> BigInt(32)) & BigInt(0xffffffff));
-
-    this.buffer[this.position++] = hi;
-    hi = hi >> 8;
-    this.buffer[this.position++] = hi;
-    hi = hi >> 8;
-    this.buffer[this.position++] = hi;
-    hi = hi >> 8;
-    this.buffer[this.position++] = hi;
+  writeBigUInt64LE(value: BigInt) {
+    const length = 8;
+    this.makeRoomFor(length);
+    this.buffer.writeBigUInt64LE(value.valueOf(), this.position);
+    this.position += length;
   }
 
   writeUInt32BE(value: number) {

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.js
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.js
@@ -115,7 +115,7 @@ describe('Wrtiable Tracking Buffer', () => {
     assertBuffer(buffer, [0x03, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00]);
   });
 
-  it('should write 64-bit signed BIGINTs', () => {
+  it('should write 64-bit signed `BigInt`s', () => {
     const buffer = new TrackingBuffer(8);
 
     buffer.writeBigInt64LE(BigInt('0x0807060504030201'));
@@ -123,7 +123,7 @@ describe('Wrtiable Tracking Buffer', () => {
     assertBuffer(buffer, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
   });
 
-  it('should write 64-bit unsigned BIGINTs', () => {
+  it('should write 64-bit unsigned `BigInt`s', () => {
     const buffer = new TrackingBuffer(8);
 
     buffer.writeBigUInt64LE(BigInt('0xdecafafecacefade'));

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.js
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.js
@@ -1,6 +1,5 @@
 const TrackingBuffer = require('../../../src/tracking-buffer/writable-tracking-buffer');
 const assert = require('chai').assert;
-const JSBI = require('jsbi');
 
 function assertBuffer(actual, expected) {
   actual = actual.data;
@@ -116,18 +115,18 @@ describe('Wrtiable Tracking Buffer', () => {
     assertBuffer(buffer, [0x03, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00]);
   });
 
-  it('should write 64-bit signed JSBIs', () => {
+  it('should write 64-bit signed BIGINTs', () => {
     const buffer = new TrackingBuffer(8);
 
-    buffer.writeBigInt64LE(JSBI.BigInt('0x0807060504030201'));
+    buffer.writeBigInt64LE(BigInt('0x0807060504030201'));
 
     assertBuffer(buffer, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
   });
 
-  it('should write 64-bit unsigned JSBIs', () => {
+  it('should write 64-bit unsigned BIGINTs', () => {
     const buffer = new TrackingBuffer(8);
 
-    buffer.writeBigUInt64LE(JSBI.BigInt('0xdecafafecacefade'));
+    buffer.writeBigUInt64LE(BigInt('0xdecafafecacefade'));
 
     assertBuffer(buffer, [0xde, 0xfa, 0xce, 0xca, 0xfe, 0xfa, 0xca, 0xde]);
   });


### PR DESCRIPTION
We used JSBI as a polyfill for BigInt on older Node.js versions. All versions of Node.js that we currently support also support BigInt out-of-the box, so we can drop the dependency on that. Resolving issue #1468