### PR TITLE
feat: add support for server name

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -780,6 +780,14 @@ export interface ConnectionOptions {
   rowCollectionOnRequestCompletion?: boolean;
 
   /**
+   * A string, that will allow user to provide their custom Common Name (CN) which matches a Common Name (CN)
+   * present in the server certificate.
+   *
+   * (no default)
+   */
+  serverName?: string;
+
+  /**
    * The version of TDS to use. If server doesn't support specified version, negotiated version is used instead.
    *
    * The versions are available from `require('tedious').TDS_VERSION`.
@@ -1618,6 +1626,13 @@ class Connection extends EventEmitter {
         }
 
         this.config.options.rowCollectionOnRequestCompletion = config.options.rowCollectionOnRequestCompletion;
+      }
+
+      if (config.options.serverName !== undefined) {
+        if (typeof config.options.serverName !== 'string') {
+          throw new TypeError('The "config.options.serverName" property must be of type string.');
+        }
+        this.config.options.serverName = config.options.serverName;
       }
 
       if (config.options.tdsVersion !== undefined) {
@@ -3170,7 +3185,7 @@ Connection.prototype.STATE = {
 
           try {
             this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
-            await this.messageIo.startTls(this.secureContextOptions, this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
+            await this.messageIo.startTls(this.secureContextOptions, this.config.options.serverName ? this.config.options.serverName : this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
           } catch (err: any) {
             return this.socketError(err);
           }


### PR DESCRIPTION
We have serverName in connection configuration, but the logic for actually using it config the cn name is missing. This PR added the logic. #1388 

