### PR TITLE
fix: export AggregateError

### DIFF
--- a/src/tedious.ts
+++ b/src/tedious.ts
@@ -8,6 +8,7 @@ import { ConnectionError, RequestError } from './errors';
 import { TYPES } from './data-type';
 import { ISOLATION_LEVEL } from './transaction';
 import { versions as TDS_VERSION } from './tds-versions';
+import AggregateError from 'es-aggregate-error';
 
 const library = { name: name };
 
@@ -18,6 +19,7 @@ export function connect(config: ConnectionConfiguration, connectListener?: (err?
 }
 
 export {
+  AggregateError,
   BulkLoad,
   Connection,
   Request,


### PR DESCRIPTION
`AggregateError`s are being used to wrap multiple errors in v15, but the `AggregateError` class is not being exported, meaning it's not possible to perform `instanceof` checks on errors. This class should be exported so that these types of checks can be performed reliably.