### PR TITLE
docs: Add Comment About A Request Lasting Longer Than Its Timeout

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -750,7 +750,9 @@ export interface ConnectionOptions {
   readOnlyIntent?: boolean;
 
   /**
-   * The number of milliseconds before a request is considered failed, or `0` for no timeout
+   * The number of milliseconds before a request is considered failed, or `0` for no timeout.
+   *
+   * As soon as a response is received, the timeout is cleared. This means that queries that immediately return a response have ability to run longer than this timeout.
    *
    * (default: `15000`).
    */


### PR DESCRIPTION
Issue: https://github.com/tediousjs/tedious/issues/1485

Queries that return a response before finishing have ability to run longer than the `requestTimeout`.
When a response is received the timeout for the request is cancelled. This is because it can't be known what the client will do with the response.

