### PR TITLE
refactor: easier commitlint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "scripts": {
     "docs": "typedoc",
     "lint": "eslint src test --ext .js,.ts && tsc",
+    "lint:commit": "commitlint --from origin/master --to HEAD",
     "test": "mocha --forbid-only test/unit test/unit/token test/unit/tracking-buffer",
     "test-integration": "mocha --forbid-only test/integration/",
     "test-all": "mocha --forbid-only test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,6 +4,6 @@
 3. After bug fix/code change, ensure all the existing tests and new tests (if any) pass (`npm run-script test-all`). During development, to run individual test use `node_modules/nodeunit test/<test_file.js> -t <test_name>`.
 4. Build the driver (`npm run build`).
 5. Run eslint and flow typechecker (`npm run lint`).
-6. Run commitlint (`node_modules/.bin/commitlint --from origin/master --to HEAD`). Refer [commit conventions](https://commitlint.js.org/#/concepts-commit-conventions) and [commit rules](https://commitlint.js.org/#/reference-rules).
+6. Run commitlint (`npm run lint:commit`). Refer [commit conventions](https://commitlint.js.org/#/concepts-commit-conventions) and [commit rules](https://commitlint.js.org/#/reference-rules).
 
 **Thank you for Contributing!**


### PR DESCRIPTION
This creates a slightly easier to use commitlint command for contributors to use.

Instead of `node_modules/.bin/commitlint --from origin/master --to HEAD` contributors can now use `npm run lint:commit`. PR template updated as well