### PR TITLE
refactor: parser combinator additions

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -238,63 +238,37 @@ export class Int32LE extends Parser<number> {
   }
 
   parse(buffer: Buffer, offset: number): Result<number> {
-    switch (this.index) {
-      case 0: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        // Fast path, buffer has all data available
-        if (offset + 4 <= buffer.length) {
-          return { done: true, value: buffer.readInt32LE(offset), offset: offset + 4 };
-        }
-
-        this.result += buffer[offset++];
-        this.index += 1;
-
-        // fall through
+    const dataLength = 4;
+    if (this.index === 0) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
       }
 
-      case 1: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        this.result += buffer[offset++] * 2 ** 8;
-        this.index += 1;
-
-        // fall through
+      // Fast path, buffer has all data available
+      if (offset + dataLength <= buffer.length) {
+        return { done: true, value: buffer.readInt32LE(offset), offset: offset + dataLength };
       }
 
-      case 2: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        this.result += buffer[offset++] * 2 ** 16;
-        this.index += 1;
-
-        // fall through
-      }
-
-      case 3: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        this.result += (buffer[offset++] << 24);
-        this.index += 1;
-
-        // fall through
-      }
-
-      case 4: {
-        return { done: true, value: this.result, offset: offset };
-      }
-
-      default:
-        throw new Error('unreachable');
+      this.result += buffer[offset++];
+      this.index += 1;
     }
+
+    while (this.index < 4) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      if (this.index < dataLength - 1) {
+        this.result += buffer[offset++] * 2 ** (8 * this.index);
+      } else {
+        // Last byte
+        this.result += buffer[offset++] << (8 * this.index);
+      }
+
+      this.index += 1;
+    }
+
+    return { done: true, value: this.result, offset: offset };
   }
 }
 
@@ -311,63 +285,31 @@ export class UInt32LE extends Parser<number> {
   }
 
   parse(buffer: Buffer, offset: number): Result<number> {
-    switch (this.index) {
-      case 0: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        // Fast path, buffer has all data available
-        if (offset + 4 <= buffer.length) {
-          return { done: true, value: buffer.readUInt32LE(offset), offset: offset + 4 };
-        }
-
-        this.result += buffer[offset++];
-        this.index += 1;
-
-        // fall through
+    const dataLength = 4;
+    if (this.index === 0) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
       }
 
-      case 1: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        this.result += buffer[offset++] * 2 ** 8;
-        this.index += 1;
-
-        // fall through
+      // Fast path, buffer has all data available
+      if (offset + dataLength <= buffer.length) {
+        return { done: true, value: buffer.readUInt32LE(offset), offset: offset + dataLength };
       }
 
-      case 2: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        this.result += buffer[offset++] * 2 ** 16;
-        this.index += 1;
-
-        // fall through
-      }
-
-      case 3: {
-        if (offset === buffer.length) {
-          return { done: false, value: undefined, offset: offset };
-        }
-
-        this.result += buffer[offset++] * 2 ** 24;
-        this.index += 1;
-
-        // fall through
-      }
-
-      case 4: {
-        return { done: true, value: this.result, offset: offset };
-      }
-
-      default:
-        throw new Error('unreachable');
+      this.result += buffer[offset++];
+      this.index += 1;
     }
+
+    while (this.index < dataLength) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      this.result += buffer[offset++] * 2 ** (8 * this.index);
+      this.index += 1;
+    }
+
+    return { done: true, value: this.result, offset: offset };
   }
 }
 

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -1,5 +1,82 @@
 import { assert } from 'chai';
-import { UInt16LE, UsVarbyte } from '../../../src/parser';
+import {
+  Int8,
+  UInt8,
+  Int16LE,
+  UInt16LE,
+  Int32LE,
+  UInt32LE,
+  UsVarbyte
+} from '../../../src/parser';
+
+describe('Int8', function() {
+  it('parses a signed negative char', function() {
+    const parser = new Int8();
+    const result = parser.parse(Buffer.from('F0', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, -16);
+    assert.strictEqual(result.offset, 1);
+  });
+
+  it('parses a signed positive char', function() {
+    const parser = new Int8();
+    const result = parser.parse(Buffer.from('0F', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 15);
+    assert.strictEqual(result.offset, 1);
+  });
+});
+
+describe('UInt8', function() {
+  it('parses an unsigned char', function() {
+    const parser = new UInt8();
+    const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 255);
+    assert.strictEqual(result.offset, 1);
+  });
+});
+
+describe('Int16LE', function() {
+  it('parses a signed negative short', function() {
+    const parser = new Int16LE();
+    const result = parser.parse(Buffer.from('00FF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, -256);
+    assert.strictEqual(result.offset, 2);
+  });
+
+  it('parses a signed positive short', function() {
+    const parser = new Int16LE();
+    const result = parser.parse(Buffer.from('FF0F', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 4095);
+    assert.strictEqual(result.offset, 2);
+  });
+
+  it('parses a signed short over multiple buffers', function() {
+    const parser = new Int16LE();
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, -256);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
 
 describe('UInt16LE', function() {
   it('parses an unsigned short', function() {
@@ -17,12 +94,110 @@ describe('UInt16LE', function() {
     {
       const result = parser.parse(Buffer.from('FF', 'hex'), 0);
       assert.isFalse(result.done);
+      assert.isUndefined(result.value);
       assert.strictEqual(result.offset, 1);
     }
 
     {
       const result = parser.parse(Buffer.from('00', 'hex'), 0);
       assert.isTrue(result.done);
+      assert.strictEqual(result.value, 255);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('Int32LE', function() {
+  it('parses an signed negative integer', function() {
+    const parser = new Int32LE();
+    const result = parser.parse(Buffer.from('FF00FFFF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, -65281);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses an signed positive integer', function() {
+    const parser = new Int32LE();
+    const result = parser.parse(Buffer.from('FFFFFF00', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 16777215);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses a signed integer over multiple buffers', function() {
+    const parser = new Int32LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, -65281);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+
+describe('UInt32LE', function() {
+  it('parses an unsigned integer', function() {
+    const parser = new UInt32LE();
+    const result = parser.parse(Buffer.from('FF00FFFF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 4294902015);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses an unsigned integer over multiple buffers', function() {
+    const parser = new UInt32LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 4294902015);
       assert.strictEqual(result.offset, 1);
     }
   });


### PR DESCRIPTION
Adds the following base parsers:

- `int8`
- `int16le`
- `int32le`

Adds unit tests for:

- `int8`
- `uint8`
- `int16le`
- `int32le`
- `uint32le`
