### PR TITLE
refactor: additional parsers

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -287,7 +287,7 @@ export class Int32LE extends Parser<number> {
       this.index += 1;
     }
 
-    while (this.index < 4) {
+    while (this.index < dataLength) {
       if (offset === buffer.length) {
         return { done: false, value: undefined, offset: offset };
       }
@@ -306,6 +306,44 @@ export class Int32LE extends Parser<number> {
   }
 }
 
+export class Int32BE extends Parser<number> {
+  index: number;
+  result: 0;
+
+  constructor() {
+    super();
+
+    this.index = 0;
+    this.result = 0;
+  }
+
+  parse(buffer: Buffer, offset: number): Result<number> {
+    const dataLength = 4;
+    if (this.index === 0) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      // Fast path, buffer has all data available
+      if (offset + dataLength <= buffer.length) {
+        return { done: true, value: buffer.readInt32BE(offset), offset: offset + dataLength };
+      }
+
+      this.result += (buffer[offset++] << 24);
+      this.index += 1;
+    }
+
+    while (this.index < dataLength) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+      this.result += buffer[offset++] * 2 ** (8 * (3 - this.index));
+      this.index += 1;
+    }
+
+    return { done: true, value: this.result, offset: offset };
+  }
+}
 
 export class UInt32LE extends Parser<number> {
   index: number;
@@ -368,7 +406,7 @@ export class BigUInt64LE extends Parser<bigint> {
       }
 
       // Fast path, buffer has all data available
-      if (offset + 8 <= buffer.length) {
+      if (offset + dataLength <= buffer.length) {
         return { done: true, value: buffer.readBigUInt64LE(offset), offset: offset + 8 };
       }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -385,6 +385,45 @@ export class UInt32LE extends Parser<number> {
   }
 }
 
+export class UInt32BE extends Parser<number> {
+  index: number;
+  result: 0;
+
+  constructor() {
+    super();
+
+    this.index = 0;
+    this.result = 0;
+  }
+
+  parse(buffer: Buffer, offset: number): Result<number> {
+    const dataLength = 4;
+    if (this.index === 0) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      // Fast path, buffer has all data available
+      if (offset + dataLength <= buffer.length) {
+        return { done: true, value: buffer.readUInt32BE(offset), offset: offset + dataLength };
+      }
+
+      this.result += buffer[offset++] * 2 ** 24;
+      this.index += 1;
+    }
+
+    while (this.index < dataLength) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+      this.result += buffer[offset++] * 2 ** (8 * (3 - this.index));
+      this.index += 1;
+    }
+
+    return { done: true, value: this.result, offset: offset };
+  }
+}
+
 export class BigUInt64LE extends Parser<bigint> {
   index: number;
   lo: number;

--- a/src/token/loginack-token-parser.ts
+++ b/src/token/loginack-token-parser.ts
@@ -43,7 +43,6 @@ function parseTokenData(buffer: Buffer) {
   }
 
   const data = result.value;
-
   return new LoginAckToken({
     interface: interfaceTypes[data.interfaceNumber],
     tdsVersion: versions[data.tdsVersionNumber],

--- a/src/token/returnstatus-token-parser.ts
+++ b/src/token/returnstatus-token-parser.ts
@@ -1,12 +1,19 @@
 // s2.2.7.16
-import Parser, { ParserOptions } from './stream-parser';
-
+import LegacyParser, { ParserOptions } from './stream-parser';
 import { ReturnStatusToken } from './token';
 
-function returnStatusParser(parser: Parser, _options: ParserOptions, callback: (token: ReturnStatusToken) => void) {
-  parser.readInt32LE((value) => {
-    callback(new ReturnStatusToken(value));
-  });
+import { Int32LE, Map } from '../parser';
+
+export class ReturnStatusTokenParser extends Map<number, ReturnStatusToken> {
+  constructor() {
+    super(new Int32LE(), (value) => {
+      return new ReturnStatusToken(value);
+    });
+  }
+}
+
+export function returnStatusParser(parser: LegacyParser, _options: ParserOptions, callback: (token: ReturnStatusToken) => void) {
+  parser.execParser(ReturnStatusTokenParser, callback);
 }
 
 export default returnStatusParser;

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -7,6 +7,7 @@ import {
   Int32LE,
   Int32BE,
   UInt32LE,
+  UInt32BE,
   BigUInt64LE,
   BVarchar,
   UsVarbyte
@@ -257,6 +258,49 @@ describe('UInt32LE', function() {
   });
 });
 
+describe('UInt32BE', function() {
+  it('parses an unsigned integer', function() {
+    const parser = new UInt32BE();
+    const result = parser.parse(Buffer.from('FFFF00FF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 4294902015);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses an unsigned integer over multiple buffers', function() {
+    const parser = new UInt32BE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 4294902015);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
 describe('BigUInt64LE', function() {
   it('parses an unsigned bigint', function() {
     const parser = new BigUInt64LE();
@@ -327,7 +371,7 @@ describe('BigUInt64LE', function() {
   });
 });
 
-describe.only('BVarchar', function() {
+describe('BVarchar', function() {
   it('parses a unicode string with a length specified using an unsigned char', function() {
     const parser = new BVarchar();
 

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -5,6 +5,7 @@ import {
   Int16LE,
   UInt16LE,
   Int32LE,
+  Int32BE,
   UInt32LE,
   BigUInt64LE,
   UsVarbyte
@@ -160,6 +161,57 @@ describe('Int32LE', function() {
   });
 });
 
+describe('Int32BE', function() {
+  it('parses an signed negative integer', function() {
+    const parser = new Int32BE();
+    const result = parser.parse(Buffer.from('FFFF00FF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, -65281);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses an signed positive integer', function() {
+    const parser = new Int32BE();
+    const result = parser.parse(Buffer.from('00FFFFFF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 16777215);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses a signed integer over multiple buffers', function() {
+    const parser = new Int32BE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, -65281);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
 
 describe('UInt32LE', function() {
   it('parses an unsigned integer', function() {

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -8,6 +8,7 @@ import {
   Int32BE,
   UInt32LE,
   BigUInt64LE,
+  BVarchar,
   UsVarbyte
 } from '../../../src/parser';
 
@@ -325,6 +326,141 @@ describe('BigUInt64LE', function() {
     }
   });
 });
+
+describe.only('BVarchar', function() {
+  it('parses a unicode string with a length specified using an unsigned char', function() {
+    const parser = new BVarchar();
+
+    const result = parser.parse(Buffer.from('0841004200430044004500460047004800', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.deepEqual(result.value, 'ABCDEFGH');
+    assert.strictEqual(result.offset, 17);
+  });
+
+  it('parses in chunks', function() {
+    const parser = new BVarchar();
+
+    {
+      const result = parser.parse(Buffer.from('08', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('41', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('42', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('43', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('44', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('45', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('46', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('47', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('48', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.deepEqual(result.value, 'ABCDEFGH');
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
 
 describe('UsVarbyte', function() {
   it('parses an binary with a length specified using an unsigned short', function() {

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -6,6 +6,7 @@ import {
   UInt16LE,
   Int32LE,
   UInt32LE,
+  BigUInt64LE,
   UsVarbyte
 } from '../../../src/parser';
 
@@ -198,6 +199,76 @@ describe('UInt32LE', function() {
       const result = parser.parse(Buffer.from('FF', 'hex'), 0);
       assert.isTrue(result.done);
       assert.strictEqual(result.value, 4294902015);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('BigUInt64LE', function() {
+  it('parses an unsigned bigint', function() {
+    const parser = new BigUInt64LE();
+    const result = parser.parse(Buffer.from('FF00FFFF00FFFFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 18446742978492825855n);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses an unsigned bigint over multiple buffers', function() {
+    const parser = new BigUInt64LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 18446742978492825855n);
       assert.strictEqual(result.offset, 1);
     }
   });


### PR DESCRIPTION
This PR includes the following base parsers and unit tests:

- `int32be`
- `bvarchar`
- `uint32be`
- `biguint64le`

Includes following token parsers:

- `returnstatusparser`
- `loginack`