### PR TITLE
refactor: add additional parsers and tests

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -362,6 +362,47 @@ export class UInt16LE extends Parser<number> {
   }
 }
 
+export class UInt24LE extends Parser<number> {
+  index: number;
+  result: 0;
+
+  constructor() {
+    super();
+
+    this.index = 0;
+    this.result = 0;
+  }
+
+  parse(buffer: Buffer, offset: number): Result<number> {
+    const dataLength = 3;
+    if (this.index === 0) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      // Fast path, buffer has all data available
+      if (offset + dataLength <= buffer.length) {
+        return { done: true, value: buffer.readUIntLE(offset, dataLength), offset: offset + dataLength };
+      }
+
+      this.result += buffer[offset++];
+      this.index += 1;
+    }
+
+    while (this.index < dataLength) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      this.result += buffer[offset++] * 2 ** (8 * this.index);
+      this.index += 1;
+    }
+
+    return { done: true, value: this.result, offset: offset };
+  }
+}
+
+
 export class Int32LE extends Parser<number> {
   index: number;
   result: 0;
@@ -569,7 +610,6 @@ export class BigInt64LE extends Parser<bigint> {
       if (offset === buffer.length) {
         return { done: false, value: undefined, offset: offset };
       }
-      console.log(this.index);
       if (this.index < dataLength - 1) {
         this.hi += buffer[offset++] * 2 ** (8 * (this.index - 4));
       } else {

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -17,6 +17,7 @@ import {
   DoubleLE,
   DoubleBE,
   BVarchar,
+  UsVarchar,
   UsVarbyte
 } from '../../../src/parser';
 
@@ -888,6 +889,147 @@ describe('BVarchar', function() {
   });
 });
 
+
+describe('UsVarchar', function() {
+  it('parses a unicode string with a length specified using an unsigned char', function() {
+    const parser = new UsVarchar();
+
+    const result = parser.parse(Buffer.from('080041004200430044004500460047004800', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.deepEqual(result.value, 'ABCDEFGH');
+    assert.strictEqual(result.offset, 18);
+  });
+
+  it('parses in chunks', function() {
+    const parser = new UsVarchar();
+
+    {
+      const result = parser.parse(Buffer.from('08', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('41', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('42', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('43', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('44', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('45', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('46', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('47', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('48', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.deepEqual(result.value, 'ABCDEFGH');
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
 
 describe('UsVarbyte', function() {
   it('parses an binary with a length specified using an unsigned short', function() {

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -18,6 +18,7 @@ import {
   DoubleBE,
   BVarchar,
   UsVarchar,
+  BVarbyte,
   UsVarbyte
 } from '../../../src/parser';
 
@@ -1026,6 +1027,62 @@ describe('UsVarchar', function() {
       const result = parser.parse(Buffer.from('00', 'hex'), 0);
       assert.isTrue(result.done);
       assert.deepEqual(result.value, 'ABCDEFGH');
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('BVarbyte', function() {
+  it('parses an binary with a length specified using an unsigned short', function() {
+    const parser = new BVarbyte();
+
+    const result = parser.parse(Buffer.from('050102030405', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.offset, 6);
+  });
+
+  it('parses in chunks', function() {
+    const parser = new BVarbyte();
+
+    {
+      const result = parser.parse(Buffer.from('05', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('01', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('02', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('03', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('04', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('05', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.deepEqual(result.value, Buffer.from('0102030405', 'hex'));
       assert.strictEqual(result.offset, 1);
     }
   });

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -12,6 +12,10 @@ import {
   UInt32BE,
   BigInt64LE,
   BigUInt64LE,
+  FloatLE,
+  FloatBE,
+  DoubleLE,
+  DoubleBE,
   BVarchar,
   UsVarbyte
 } from '../../../src/parser';
@@ -516,6 +520,235 @@ describe('BigUInt64LE', function() {
       const result = parser.parse(Buffer.from('FF', 'hex'), 0);
       assert.isTrue(result.done);
       assert.strictEqual(result.value, 18446742978492825855n);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('FloatLE', function() {
+  it('parses a float', function() {
+    const parser = new FloatLE();
+
+    const result = parser.parse(Buffer.from('00010000', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 3.587324068671532e-43);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses a float over multiple buffers', function() {
+    const parser = new FloatLE();
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('01', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 3.587324068671532e-43);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('FloatBE', function() {
+  it('parses a float', function() {
+    const parser = new FloatBE();
+
+    const result = parser.parse(Buffer.from('00000100', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 3.587324068671532e-43);
+    assert.strictEqual(result.offset, 4);
+  });
+
+  it('parses a float over multiple buffers', function() {
+    const parser = new FloatBE();
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('01', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 3.587324068671532e-43);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('DoubleLE', function() {
+  it('parses a double', function() {
+    const parser = new DoubleLE();
+
+    const result = parser.parse(Buffer.from('0000000000000010', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 1.2882297539194267e-231);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses a double over multiple buffers', function() {
+    const parser = new DoubleLE();
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('10', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 1.2882297539194267e-231);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+
+describe('DoubleBE', function() {
+  it('parses a double', function() {
+    const parser = new DoubleBE();
+
+    const result = parser.parse(Buffer.from('1000000000000000', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 1.2882297539194267e-231);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses a double over multiple buffers', function() {
+    const parser = new DoubleBE();
+
+    {
+      const result = parser.parse(Buffer.from('10', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 1.2882297539194267e-231);
       assert.strictEqual(result.offset, 1);
     }
   });

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -16,6 +16,7 @@ import {
   FloatBE,
   DoubleLE,
   DoubleBE,
+  UInt24LE,
   BVarchar,
   UsVarchar,
   BVarbyte,
@@ -751,6 +752,42 @@ describe('DoubleBE', function() {
       const result = parser.parse(Buffer.from('00', 'hex'), 0);
       assert.isTrue(result.done);
       assert.strictEqual(result.value, 1.2882297539194267e-231);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('UInt24LE', function() {
+  it('parses an unsigned short', function() {
+    const parser = new UInt24LE();
+    const result = parser.parse(Buffer.from('000010', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 1048576);
+    assert.strictEqual(result.offset, 3);
+  });
+
+  it('parses an unsigned short over multiple buffers', function() {
+    const parser = new UInt24LE();
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('10', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 1048576);
       assert.strictEqual(result.offset, 1);
     }
   });


### PR DESCRIPTION
Adds the following parsers:
```
FloatLE
FloatBE
DoubleLE
DoubleBE
UInt24LE
```

Adds tests for these parsers:
```
UsVarchar
BVarbyte
```