### PR TITLE
chore: drop node 14 support, add node 19 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,10 +18,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Use Node.js 14
+    - name: Use Node.js 16
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -65,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 19.x]
       fail-fast: false
 
     steps:
@@ -183,7 +183,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 19.x]
       fail-fast: false
 
     steps:
@@ -341,7 +341,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   azure-sql-auth:
-    name: Azure SQL Server / Node.js 14.x
+    name: Azure SQL Server / Node.js 16.x
     runs-on: ubuntu-latest
 
     # Only run these tests if we have access to the secrets
@@ -349,10 +349,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14
+    - name: Use Node.js 16
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -394,7 +394,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   azure-ad-auth:
-    name: Azure SQL Server / Node.js 14.x
+    name: Azure SQL Server / Node.js 16.x
     runs-on: ubuntu-latest
 
     # Only run these tests if we have access to the secrets
@@ -402,10 +402,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14
+    - name: Use Node.js 16
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -452,7 +452,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   azure-ad-service-principal-auth:
-    name: Azure SQL Server / Node.js 14.x
+    name: Azure SQL Server / Node.js 16.x
     runs-on: ubuntu-latest
 
     # Only run these tests if we have access to the secrets
@@ -460,10 +460,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14
+    - name: Use Node.js 16
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -516,10 +516,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14
+    - name: Use Node.js 16
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Determine npm cache directory
       id: npm-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14
+    - name: Use Node.js 16
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: Tag latest release
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: "14"
     - nodejs_version: "16"
     - nodejs_version: "18"
+    - nodejs_version: "19"
 
 branches:
   only:

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "typescript": "^4.6.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/tediousjs/tedious.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "publishConfig": {
     "tag": "next"
@@ -109,7 +109,7 @@
         "@babel/preset-env",
         {
           "targets": {
-            "node": 14
+            "node": 16
           }
         }
       ],


### PR DESCRIPTION
BREAKING CHANGE: Node.js 14.x is no longer supported by `tedious`.