### PR TITLE
ci: don't require azure tests to pass for release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -510,7 +510,7 @@ jobs:
 
   pre-release:
     name: Pre-Release
-    needs: [test, azure-sql-auth, azure-ad-auth, azure-ad-service-principal-auth]
+    needs: [test, test-windows]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Tests against Azure have been incredibly flaky recently. Make them non-required for creating a new release (I already made them non-required for merging a pull request).