### PR TITLE
refactor: add additional parsers and tests

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -526,6 +526,49 @@ export class UInt32BE extends Parser<number> {
   }
 }
 
+export class UInt40LE extends Parser<number> {
+  index: number;
+  result: 0;
+
+  constructor() {
+    super();
+
+    this.index = 0;
+    this.result = 0;
+  }
+  parse(buffer: Buffer, offset: number): Result<number> {
+    const dataLength = 5;
+    if (this.index === 0) {
+      //reach the end of the incoming buffer
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      // Fast path, incoming buffer has all data available
+      if (offset + dataLength <= buffer.length) {
+        console.log('here')
+        //read low bytes and high bytes consectivly
+        const low = buffer.readUInt32LE(offset);
+        const high = buffer.readUInt8(offset + 4);
+        return { done: true, value: (2**32 * high) + low, offset: offset + dataLength};
+      }
+
+      this.result += buffer[offset++];
+      this.index += 1;
+    }
+
+    while (this.index < dataLength) {
+      if (offset === buffer.length) {
+        return { done: false, value: undefined, offset: offset };
+      }
+
+      this.result += buffer[offset++] * 2 ** (8 * this.index);
+      this.index += 1;
+    }
+
+    return { done: true, value: this.result, offset: offset };
+  }
+}
 
 export class BigInt64LE extends Parser<bigint> {
   index: number;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -657,10 +657,7 @@ export class UInt40LE extends Parser<number> {
 
       // Fast path, incoming buffer has all data available
       if (offset + dataLength <= buffer.length) {
-        // read low bytes and high bytes consectivly
-        const low = buffer.readUInt32LE(offset);
-        const high = buffer.readUInt8(offset + 4);
-        return { done: true, value: Math.pow(2, 32) * high + low, offset: offset + dataLength };
+        return { done: true, value: buffer.readUIntLE(offset, 5), offset: offset + dataLength };
       }
 
       this.result += buffer[offset++];

--- a/src/parser/tokens/env-change-token.ts
+++ b/src/parser/tokens/env-change-token.ts
@@ -48,14 +48,105 @@ function buildPacketSizeChangeToken([newValue, oldValue]: [string, string]) {
   return new PacketSizeEnvChangeToken(parseInt(newValue), parseInt(oldValue));
 }
 
+function buildBeginTransactionEnvChangeToken([newValue, oldValue]: [Buffer, Buffer]) {
+  return new BeginTransactionEnvChangeToken(newValue, oldValue);
+}
+
+function buildCommitTransactionEnvChangeToken([newValue, oldValue]: [Buffer, Buffer]) {
+  return new CommitTransactionEnvChangeToken(newValue, oldValue);
+}
+
+function buildRollbackTransactionEnvChangeToken([newValue, oldValue]: [Buffer, Buffer]) {
+  return new RollbackTransactionEnvChangeToken(newValue, oldValue);
+}
+
+function buildResetConnectionEnvChangeToken([newValue, oldValue]: [Buffer, Buffer]) {
+  return new ResetConnectionEnvChangeToken(newValue, oldValue);
+}
+
+function buildDatabaseEnvChangeToken([newValue, oldValue]: [string, string]) {
+  return new DatabaseEnvChangeToken(newValue, oldValue);
+}
+
+function buildLanguageEnvChangeToken([newValue, oldValue]: [string, string]) {
+  return new LanguageEnvChangeToken(newValue, oldValue);
+}
+
+function buildCharsetEnvChangeToken([newValue, oldValue]: [string, string]) {
+  return new CharsetEnvChangeToken(newValue, oldValue);
+}
+
+function buildDatabaseMirroringPartnerEnvChangeToken([newValue, oldValue]: [string, string]) {
+  return new DatabaseMirroringPartnerEnvChangeToken(newValue, oldValue);
+}
+
+function buildRoutingEnvChangeToken([newValue, oldValue]: [Buffer, Buffer]) {
+  const protocol = newValue.readUInt8(0);
+
+  if (protocol !== 0) {
+    throw new Error('Unknown protocol byte in routing change event');
+  }
+
+  const port = newValue.readUInt16LE(1);
+  const serverLen = newValue.readUInt16LE(3);
+  // 2 bytes per char, starting at offset 5
+  const server = newValue.toString('ucs2', 5, 5 + (serverLen * 2));
+
+  const newTokenValue = {
+    protocol: protocol,
+    port: port,
+    server: server
+  };
+
+  return new RoutingEnvChangeToken(newTokenValue, oldValue);
+}
+
+
 function chooseEnvChangeType(type: number): Parser<EnvChangeToken> {
   switch (type) {
-    case 7: {
-      return new Map(new Sequence<[Buffer, Buffer]>([new BVarbyte(), new BVarbyte()]), buildCollationChangeToken);
+    case 1: {
+      return new Map(new Sequence<[string, string]>([new BVarchar(), new BVarchar()]), buildDatabaseEnvChangeToken);
+    }
+
+    case 2: {
+      return new Map(new Sequence<[string, string]>([new BVarchar(), new BVarchar()]), buildLanguageEnvChangeToken);
+    }
+
+    case 3: {
+      return new Map(new Sequence<[string, string]>([new BVarchar(), new BVarchar()]), buildCharsetEnvChangeToken);
     }
 
     case 4: {
       return new Map(new Sequence<[string, string]>([new BVarchar(), new BVarchar()]), buildPacketSizeChangeToken);
+    }
+
+    case 7: {
+      return new Map(new Sequence<[Buffer, Buffer]>([new BVarbyte(), new BVarbyte()]), buildCollationChangeToken);
+    }
+
+    case 8: {
+      return new Map(new Sequence<[Buffer, Buffer]>([new BVarbyte(), new BVarbyte()]), buildBeginTransactionEnvChangeToken);
+    }
+
+    case 9: {
+      return new Map(new Sequence<[Buffer, Buffer]>([new BVarbyte(), new BVarbyte()]), buildCommitTransactionEnvChangeToken);
+    }
+
+    case 10: {
+      return new Map(new Sequence<[Buffer, Buffer]>([new BVarbyte(), new BVarbyte()]), buildRollbackTransactionEnvChangeToken);
+    }
+
+
+    case 13: {
+      return new Map(new Sequence<[string, string]>([new BVarchar(), new BVarchar()]), buildDatabaseMirroringPartnerEnvChangeToken);
+    }
+
+    case 18: {
+      return new Map(new Sequence<[Buffer, Buffer]>([new BVarbyte(), new BVarbyte()]), buildResetConnectionEnvChangeToken);
+    }
+
+    case 20: {
+      return new Map(new Sequence<[Buffer, Buffer]>([new UsVarbyte(), new UsVarbyte()]), buildRoutingEnvChangeToken);
     }
 
     default: {

--- a/test/unit/parser/env-change-token-test.ts
+++ b/test/unit/parser/env-change-token-test.ts
@@ -1,27 +1,85 @@
 import { assert } from 'chai';
 import { EnvChangeTokenParser } from '../../../src/parser/tokens/env-change-token';
 import WritableTrackingBuffer from '../../../src/tracking-buffer/writable-tracking-buffer';
+import { Collation } from '../../../src/collation';
+
+
+function buildToken(newValue: string|Buffer, oldValue: string|Buffer, type: number) {
+
+  const envValueDataBuffer = new WritableTrackingBuffer(0);
+  envValueDataBuffer.writeUInt8(type); // Type
+  if (Buffer.isBuffer(newValue) && Buffer.isBuffer(oldValue)) {
+    envValueDataBuffer.writeUInt8(newValue.length);
+    envValueDataBuffer.writeBuffer(newValue);
+    envValueDataBuffer.writeUInt8(oldValue.length);
+    envValueDataBuffer.writeBuffer(oldValue);
+  } else if (typeof newValue === 'string' && typeof oldValue === 'string') {
+    envValueDataBuffer.writeBVarchar(newValue);
+    envValueDataBuffer.writeBVarchar(oldValue);
+  }
+
+  const envChangeBuffer = new WritableTrackingBuffer(0);
+  envChangeBuffer.writeUInt8(0xE3); // TokenType
+  envChangeBuffer.writeUsVarbyte(envValueDataBuffer.data); // Length + EnvValueData
+
+  return envChangeBuffer.data;
+}
 
 describe('EnvChangeTokenParser', function() {
-  it('can parse packet size change tokens', function() {
-    const oldSize = '1024';
-    const newSize = '2048';
-
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
-
-    buffer.writeUInt8(0xe3);
-    buffer.writeUInt16LE(0); // Length written later
-    buffer.writeUInt8(0x04); // Packet size
-    buffer.writeBVarchar(newSize);
-    buffer.writeBVarchar(oldSize);
-
-    const data = buffer.data;
-    data.writeUInt16LE(data.length - 3, 1);
-
+  it('can parse Database Change tokens', function() {
+    const oldDb = 'DataBase';
+    const newDb = 'OtherDataBase';
+    const data = buildToken(newDb, oldDb, 1);
     const parser = new EnvChangeTokenParser();
     const result = parser.parse(data, 1);
 
-    console.log(result);
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'DATABASE');
+    assert.strictEqual(token.oldValue, 'DataBase');
+    assert.strictEqual(token.newValue, 'OtherDataBase');
+  });
+  it('can parse Language Change tokens', function() {
+    const oldLang = 'us_english';
+    const newLang = 'Italian';
+    const data = buildToken(newLang, oldLang, 2);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'LANGUAGE');
+    assert.strictEqual(token.oldValue, 'us_english');
+    assert.strictEqual(token.newValue, 'Italian');
+  });
+  it('can parse Charset Change tokens', function() {
+    const oldCharset = 'iso_1';
+    const newCharset = 'utf8';
+    const data = buildToken(newCharset, oldCharset, 3);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'CHARSET');
+    assert.strictEqual(token.oldValue, 'iso_1');
+    assert.strictEqual(token.newValue, 'utf8');
+  });
+  it('can parse packet size change tokens', function() {
+    const oldSize = '1024';
+    const newSize = '2048';
+    const data = buildToken(newSize, oldSize, 4);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
 
     assert.isTrue(result.done);
     assert.isDefined(result.value);
@@ -31,5 +89,128 @@ describe('EnvChangeTokenParser', function() {
     assert.strictEqual(token.type, 'PACKET_SIZE');
     assert.strictEqual(token.oldValue, 1024);
     assert.strictEqual(token.newValue, 2048);
+  });
+  it('can parse collation change tokens', function() {
+    const oldCollation = Buffer.from([ 0x11, 0x04, 0x34, 0x30, 0x00 ]);
+    const newCollation = Buffer.from([ 0x11, 0x04, 0x04, 0x20, 0x00 ]);
+    const data = buildToken(newCollation, oldCollation, 7);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'SQL_COLLATION');
+    assert.instanceOf(token.oldValue, Collation);
+    assert.deepEqual(token.oldValue instanceof Collation ? token.oldValue.toBuffer() : undefined, oldCollation);
+    assert.instanceOf(token.newValue, Collation);
+    assert.deepEqual(token.newValue instanceof Collation ? token.newValue.toBuffer() : undefined, newCollation);
+  });
+  it('can parse begin transaction change tokens', function() {
+    const newValue = Buffer.from([ 0x04, 0x05, 0x06]);
+    const data = buildToken(newValue, Buffer.alloc(0), 8);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'BEGIN_TXN');
+    assert.deepEqual(token.oldValue, Buffer.alloc(0));
+    assert.deepEqual(token.newValue, newValue);
+  });
+  it('can parse commit transaction change tokens', function() {
+    const oldValue = Buffer.from([ 0x01, 0x02, 0x03]);
+    const data = buildToken(Buffer.alloc(0), oldValue, 9);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'COMMIT_TXN');
+    assert.deepEqual(token.oldValue, oldValue);
+    assert.deepEqual(token.newValue, Buffer.alloc(0));
+  });
+  it('can parse rollback transaction change tokens', function() {
+    const oldValue = Buffer.from([ 0x01, 0x02, 0x03]);
+    const data = buildToken(Buffer.alloc(0), oldValue, 10);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'ROLLBACK_TXN');
+    assert.deepEqual(token.oldValue, oldValue);
+    assert.deepEqual(token.newValue, Buffer.alloc(0));
+  });
+  it('can parse database mirroring partner change tokens', function() {
+    const newMDb = 'NewDataBase';
+    const data = buildToken(newMDb, Buffer.alloc(0).toString(), 13);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'DATABASE_MIRRORING_PARTNER');
+    assert.deepEqual(token.oldValue, Buffer.alloc(0).toString());
+    assert.deepEqual(token.newValue, newMDb);
+  });
+  it('can parse reset connection change tokens', function() {
+    const data = buildToken(Buffer.alloc(0), Buffer.alloc(0), 18);
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+
+    assert.strictEqual(token.type, 'RESET_CONNECTION');
+    assert.deepEqual(token.oldValue, Buffer.alloc(0));
+    assert.deepEqual(token.newValue, Buffer.alloc(0));
+  });
+  it('can parse routing change tokens', function() {
+    const valueBuffer = new WritableTrackingBuffer(0);
+    valueBuffer.writeUInt8(0); // Protocol
+    valueBuffer.writeUInt16LE(60130); // Port
+    valueBuffer.writeUsVarchar('127.0.0.1', 'ucs2');
+
+    const envValueDataBuffer = new WritableTrackingBuffer(0);
+    envValueDataBuffer.writeUInt8(20); // Type
+    envValueDataBuffer.writeUsVarbyte(valueBuffer.data);
+    envValueDataBuffer.writeUsVarbyte(Buffer.alloc(0));
+
+    const envChangeBuffer = new WritableTrackingBuffer(0);
+    envChangeBuffer.writeUInt8(0xE3); // TokenType
+    envChangeBuffer.writeUsVarbyte(envValueDataBuffer.data); // Length + EnvValueData
+
+    const data = envChangeBuffer.data;
+    const parser = new EnvChangeTokenParser();
+    const result = parser.parse(data, 1);
+
+    assert.isTrue(result.done);
+    assert.isDefined(result.value);
+
+    const token = result.value!;
+    assert.strictEqual(token.type, 'ROUTING_CHANGE');
+    assert.deepEqual(token.oldValue, Buffer.alloc(0));
+    assert.deepEqual(token.newValue, {
+      protocol: 0,
+      port: 60130,
+      server: '127.0.0.1'
+    });
   });
 });

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -14,6 +14,9 @@ import {
   UInt32BE,
   UInt40LE,
   UInt64LE,
+  UNumeric64LE,
+  UNumeric96LE,
+  UNumeric128LE,
   BigInt64LE,
   BigUInt64LE,
   BVarchar,
@@ -539,8 +542,8 @@ describe('UInt40LE', function() {
   });
 });
 
-describe.only('UInt64LE', function() {
-  it('parses an unsigned int', function() {
+describe('UInt64LE', function() {
+  it('parses an unsigned integer', function() {
     const parser = new UInt64LE();
     const result = parser.parse(Buffer.from('FF00FFFF00FFFFFF', 'hex'), 0);
     assert.isTrue(result.done);
@@ -548,7 +551,7 @@ describe.only('UInt64LE', function() {
     assert.strictEqual(result.offset, 8);
   });
 
-  it('parses an unsigned bigint over multiple buffers', function() {
+  it('parses an unsigned integer over multiple buffers', function() {
     const parser = new UInt64LE();
 
     {
@@ -604,6 +607,300 @@ describe.only('UInt64LE', function() {
       const result = parser.parse(Buffer.from('FF', 'hex'), 0);
       assert.isTrue(result.done);
       assert.strictEqual(result.value, 18446742978492825855);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('UNumeric64LE', function() {
+  it('parses an unsigned numeric value', function() {
+    const parser = new UNumeric64LE();
+    const result = parser.parse(Buffer.from('FF00FFFF00FFFFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 18446742978492825855);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses an unsigned numeric value over multiple buffers', function() {
+    const parser = new UNumeric64LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 18446742978492825855);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('UNumeric96LE', function() {
+  it('parses an unsigned numeric value', function() {
+    const parser = new UNumeric96LE();
+    const result = parser.parse(Buffer.from('FF00FFFF00FFFFFFFFFFFFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 7.922816251426434e+28);
+    assert.strictEqual(result.offset, 12);
+  });
+
+  it('parses an unsigned numeric value over multiple buffers', function() {
+    const parser = new UNumeric96LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 7.922816251426434e+28);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('UNumeric128LE', function() {
+  it('parses an unsigned numeric value', function() {
+    const parser = new UNumeric128LE();
+    const result = parser.parse(Buffer.from('FF00FFFF00FFFFFFFFFFFFFFFFFFFFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 3.402823669209385e+38);
+    assert.strictEqual(result.offset, 16);
+  });
+
+  it('parses an unsigned numeric value over multiple buffers', function() {
+    const parser = new UNumeric128LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 3.402823669209385e+38);
       assert.strictEqual(result.offset, 1);
     }
   });

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -13,6 +13,7 @@ import {
   UInt32LE,
   UInt32BE,
   UInt40LE,
+  UInt64LE,
   BigInt64LE,
   BigUInt64LE,
   BVarchar,
@@ -533,6 +534,76 @@ describe('UInt40LE', function() {
       const result = parser.parse(Buffer.from('FF', 'hex'), 0);
       assert.isTrue(result.done);
       assert.strictEqual(result.value, 1099511562495);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe.only('UInt64LE', function() {
+  it('parses an unsigned int', function() {
+    const parser = new UInt64LE();
+    const result = parser.parse(Buffer.from('FF00FFFF00FFFFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 18446742978492825855);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses an unsigned bigint over multiple buffers', function() {
+    const parser = new UInt64LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 18446742978492825855);
       assert.strictEqual(result.offset, 1);
     }
   });

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -10,6 +10,7 @@ import {
   Int32BE,
   UInt32LE,
   UInt32BE,
+  UInt40LE,
   BigInt64LE,
   BigUInt64LE,
   BVarchar,
@@ -323,6 +324,56 @@ describe('UInt32LE', function() {
       const result = parser.parse(Buffer.from('FF', 'hex'), 0);
       assert.isTrue(result.done);
       assert.strictEqual(result.value, 4294902015);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe.only('UInt40LE', function() {
+  it('parses an unsigned integer', function() {
+    const parser = new UInt40LE();
+    const result = parser.parse(Buffer.from('FF00FFFFFF', 'hex'), 0);
+
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 1099511562495);
+    assert.strictEqual(result.offset, 5);
+  });
+
+  it('parses an unsigned integer over multiple buffers', function() {
+    const parser = new UInt40LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, 1099511562495);
       assert.strictEqual(result.offset, 1);
     }
   });

--- a/test/unit/parser/parser-test.ts
+++ b/test/unit/parser/parser-test.ts
@@ -8,6 +8,8 @@ import {
   UInt16LE,
   Int32LE,
   Int32BE,
+  Int64BE,
+  Int64LE,
   UInt32LE,
   UInt32BE,
   UInt40LE,
@@ -286,6 +288,163 @@ describe('Int32BE', function() {
   });
 });
 
+describe('Int64LE', function() {
+  it('parses an signed negative integer', function() {
+    const parser = new Int64LE();
+    const result = parser.parse(Buffer.from('FFFF00FF000000FF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, -72057589759672320);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses an signed positive integer', function() {
+    const parser = new Int64LE();
+    const result = parser.parse(Buffer.from('FFFF00FF00000001', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 72057589759672320);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses a signed integer over multiple buffers', function() {
+    const parser = new Int64LE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, -72057589759672320);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
+describe('Int64BE', function() {
+  it('parses an signed negative integer', function() {
+    const parser = new Int64BE();
+    const result = parser.parse(Buffer.from('FF000000FF00FFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, -72057589759672320);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses an signed positive integer', function() {
+    const parser = new Int64BE();
+    const result = parser.parse(Buffer.from('01000000FF00FFFF', 'hex'), 0);
+    assert.isTrue(result.done);
+    assert.strictEqual(result.value, 72057589759672320);
+    assert.strictEqual(result.offset, 8);
+  });
+
+  it('parses a signed integer over multiple buffers', function() {
+    const parser = new Int64BE();
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('00', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isFalse(result.done);
+      assert.isUndefined(result.value);
+      assert.strictEqual(result.offset, 1);
+    }
+
+    {
+      const result = parser.parse(Buffer.from('FF', 'hex'), 0);
+      assert.isTrue(result.done);
+      assert.strictEqual(result.value, -72057589759672320);
+      assert.strictEqual(result.offset, 1);
+    }
+  });
+});
+
 describe('UInt32LE', function() {
   it('parses an unsigned integer', function() {
     const parser = new UInt32LE();
@@ -329,7 +488,7 @@ describe('UInt32LE', function() {
   });
 });
 
-describe.only('UInt40LE', function() {
+describe('UInt40LE', function() {
   it('parses an unsigned integer', function() {
     const parser = new UInt40LE();
     const result = parser.parse(Buffer.from('FF00FFFFFF', 'hex'), 0);


### PR DESCRIPTION
Adds the following parsers:

UInt40LE
Int64BE
Int64LE
Unumeric64LE
Unumeric96LE
Unumeric128LE

Envchangetoken

Adds tests for these parsers:

UInt40
Int64BE
Int64LE
Unumeric64LE
Unumeric96LE
Unumeric128LE

Envchangetoken