### PR TITLE
feat: add connector factory method

### DIFF
--- a/examples/custom-connector.js
+++ b/examples/custom-connector.js
@@ -1,0 +1,30 @@
+var net = require('net');
+var Connection = require('../lib/tedious').Connection;
+
+var config = {
+  server: '192.168.1.212',
+  authentication: {
+    type: 'default',
+    options: {
+      userName: 'test',
+      password: 'test'
+    }
+  },
+  options: {
+    connector: async () => net.connect({
+      host: '192.168.1.212',
+      port: 1433,
+    })
+  }
+};
+
+const connection = new Connection(config);
+
+connection.connect((err) => {
+  if (err) {
+    console.log('Connection Failed');
+    throw err;
+  }
+
+  console.log('Custom connection Succeeded');
+});

--- a/test/unit/custom-connector.js
+++ b/test/unit/custom-connector.js
@@ -1,0 +1,62 @@
+const net = require('net');
+const assert = require('chai').assert;
+
+const { Connection } = require('../../src/tedious');
+
+describe('custom connector', function() {
+  let server;
+
+  beforeEach(function(done) {
+    server = net.createServer();
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('connection using a custom connector', function(done) {
+    let attemptedConnection = false;
+    let customConnectorCalled = false;
+
+    server.on('connection', async (connection) => {
+      attemptedConnection = true;
+      // no need to test auth/login, just end the connection sooner
+      connection.end();
+    });
+
+    const host = server.address().address;
+    const port = server.address().port;
+    const connection = new Connection({
+      server: host,
+      options: {
+        connector: async () => {
+          customConnectorCalled = true;
+          return net.connect({
+            host,
+            port,
+          });
+        },
+        port
+      },
+    });
+
+    connection.on('end', (err) => {
+      // validates the connection was stablished using the custom connector
+      assert.isOk(attemptedConnection);
+      assert.isOk(customConnectorCalled);
+
+      connection.close();
+      done();
+    });
+
+    connection.on('error', (err) => {
+      // Connection lost errors are expected due to ending connection sooner
+      if (!/Connection lost/.test(err)) {
+        throw err;
+      }
+    });
+
+    connection.connect();
+  });
+});


### PR DESCRIPTION
This changeset adds a new `connector` config option that may be used to define a custom socket factory method. Providing a much more flexible control of the socket connection creation.

Defining a custom `connector` config value allows **Tedious** to support a larger variety of environments/setups such as proxy servers using secure socket connections that are used by cloud providers such as GCP.

Linked below, the `pg` driver for PostgreSQL and the `mysql2` driver for MySQL are prior art example of this pattern. Also linked below is the Cloud SQL Node.js Connector, which demonstrates how third-party libraries can leverage the custom socket factory method.

**Refs:** https://github.com/sidorares/node-mysql2/blob/ba15fe25703665e516ab0a23af8d828d1473b8c3/lib/connection.js#L63-L65
**Refs:** https://github.com/brianc/node-postgres/blob/b357e1884ad25b23a4ab034b443ddfc8c8261951/packages/pg/lib/connection.js#L20
**Refs:** https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector
**Signed-off-by:** Ruy Adorno <ruyadorno@google.com>