### PR TITLE
feat: skip config validation when using connector

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -331,7 +331,7 @@ interface ErrorWithCode extends Error {
 }
 
 interface InternalConnectionConfig {
-  server: string;
+  server: undefined | string;
   authentication: DefaultAuthentication | NtlmAuthentication | AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryAccessTokenAuthentication | AzureActiveDirectoryServicePrincipalSecret | AzureActiveDirectoryDefaultAuthentication;
   options: InternalConnectionOptions;
 }
@@ -1061,7 +1061,7 @@ class Connection extends EventEmitter {
       throw new TypeError('The "config" argument is required and must be of type Object.');
     }
 
-    if (typeof config.server !== 'string') {
+    if (typeof config.server !== 'string' && !config.options!.connector) {
       throw new TypeError('The "config.server" property is required and must be of type string.');
     }
 
@@ -1352,8 +1352,15 @@ class Connection extends EventEmitter {
         if (typeof config.options.connector !== 'function') {
           throw new TypeError('The "config.options.connector" property must be a function.');
         }
+        if (config.server) {
+          throw new Error('Server and connector are mutually exclusive, but ' + config.server + ' and a connector function were provided');
+        }
+        if (config.options.port) {
+          throw new Error('Port and connector are mutually exclusive, but ' + config.options.port + ' and a connector function were provided');
+        }
 
         this.config.options.connector = config.options.connector;
+        this.config.options.port = undefined;
       }
 
       if (config.options.cryptoCredentialsDetails !== undefined) {
@@ -1917,7 +1924,10 @@ class Connection extends EventEmitter {
   initialiseConnection() {
     const signal = this.createConnectTimer();
 
-    if (this.config.options.port) {
+    if (this.config.options.connector) {
+      // port and multiSubnetFailover are not used when using a custom connector
+      return this.connectOnPort(0, false, signal, this.config.options.connector);
+    } else if (this.config.options.port) {
       return this.connectOnPort(this.config.options.port, this.config.options.multiSubnetFailover, signal, this.config.options.connector);
     } else {
       return instanceLookup({
@@ -1990,7 +2000,7 @@ class Connection extends EventEmitter {
     return new TokenStreamParser(message, this.debug, handler, this.config.options);
   }
 
-  socketHandlingForSendPreLogin(socket: net.Socket) {
+  socketHandlingForSendPreLogin(socket: net.Socket, customConnector: boolean) {
     socket.on('error', (error) => { this.socketError(error); });
     socket.on('close', () => { this.socketClose(); });
     socket.on('end', () => { this.socketEnd(); });
@@ -2002,7 +2012,11 @@ class Connection extends EventEmitter {
     this.socket = socket;
 
     this.closed = false;
-    this.debug.log('connected to ' + this.config.server + ':' + this.config.options.port);
+    const message =
+      'connected to ' + this.config.server + ':' + this.config.options.port;
+    const customConnectorMessage =
+      'connected via custom connector';
+    this.debug.log(customConnector ? customConnectorMessage : message);
 
     this.sendPreLogin();
     this.transitionTo(this.STATE.SENT_PRELOGIN);
@@ -2010,11 +2024,12 @@ class Connection extends EventEmitter {
 
   wrapWithTls(socket: net.Socket): Promise<tls.TLSSocket> {
     return new Promise((resolve, reject) => {
+      const server = String(this.config.server);
       const secureContext = tls.createSecureContext(this.secureContextOptions);
       // If connect to an ip address directly,
       // need to set the servername to an empty string
       // if the user has not given a servername explicitly
-      const serverName = !net.isIP(this.config.server) ? this.config.server : '';
+      const serverName = !net.isIP(server) ? server : '';
       const encryptOptions = {
         host: this.config.server,
         socket: socket,
@@ -2034,7 +2049,7 @@ class Connection extends EventEmitter {
 
   connectOnPort(port: number, multiSubnetFailover: boolean, signal: AbortSignal, customConnector?: () => Promise<net.Socket>) {
     const connectOpts = {
-      host: this.routingData ? this.routingData.server : this.config.server,
+      host: this.routingData ? this.routingData.server : String(this.config.server),
       port: this.routingData ? this.routingData.port : port,
       localAddress: this.config.options.localAddress
     };
@@ -2055,7 +2070,7 @@ class Connection extends EventEmitter {
         }
       }
 
-      this.socketHandlingForSendPreLogin(socket);
+      this.socketHandlingForSendPreLogin(socket, Boolean(customConnector));
     })().catch((err) => {
       this.clearConnectTimer();
 
@@ -2137,8 +2152,10 @@ class Connection extends EventEmitter {
     // otherwise, leave the message empty.
     const routingMessage = this.routingData ? ` (redirected from ${this.config.server}${hostPostfix})` : '';
     const message = `Failed to connect to ${server}${port}${routingMessage} in ${this.config.options.connectTimeout}ms`;
-    this.debug.log(message);
-    this.emit('connect', new ConnectionError(message, 'ETIMEOUT'));
+    const customConnectorMessage = `Failed to connect using custom connector in ${this.config.options.connectTimeout}ms`;
+    const errMessage = this.config.options.connector ? customConnectorMessage : message;
+    this.debug.log(errMessage);
+    this.emit('connect', new ConnectionError(errMessage, 'ETIMEOUT'));
     this.connectTimer = undefined;
     this.dispatchEvent('connectTimeout');
   }
@@ -2273,8 +2290,10 @@ class Connection extends EventEmitter {
       // otherwise, leave the message empty.
       const routingMessage = this.routingData ? ` (redirected from ${this.config.server}${hostPostfix})` : '';
       const message = `Failed to connect to ${server}${port}${routingMessage} - ${error.message}`;
-      this.debug.log(message);
-      this.emit('connect', new ConnectionError(message, 'ESOCKET'));
+      const customConnectorMessage = `Failed to connect using custom connector - ${error.message}`;
+      const errMessage = this.config.options.connector ? customConnectorMessage : message;
+      this.debug.log(errMessage);
+      this.emit('connect', new ConnectionError(errMessage, 'ESOCKET'));
     } else {
       const message = `Connection lost - ${error.message}`;
       this.debug.log(message);
@@ -2299,15 +2318,21 @@ class Connection extends EventEmitter {
    * @private
    */
   socketClose() {
-    this.debug.log('connection to ' + this.config.server + ':' + this.config.options.port + ' closed');
+    const message = 'connection to ' + this.config.server + ':' + this.config.options.port + ' closed';
+    const customConnectorMessage = 'connection closed';
+    this.debug.log(this.config.options.connector ? customConnectorMessage : message);
     if (this.state === this.STATE.REROUTING) {
-      this.debug.log('Rerouting to ' + this.routingData!.server + ':' + this.routingData!.port);
+      const message = 'Rerouting to ' + this.routingData!.server + ':' + this.routingData!.port;
+      const customConnectorMessage = 'Rerouting';
+      this.debug.log(this.config.options.connector ? customConnectorMessage : message);
 
       this.dispatchEvent('reconnect');
     } else if (this.state === this.STATE.TRANSIENT_FAILURE_RETRY) {
       const server = this.routingData ? this.routingData.server : this.config.server;
       const port = this.routingData ? this.routingData.port : this.config.options.port;
-      this.debug.log('Retry after transient failure connecting to ' + server + ':' + port);
+      const message = 'Retry after transient failure connecting to ' + server + ':' + port;
+      const customConnectorMessage = 'Retry after transient failure connecting';
+      this.debug.log(this.config.options.connector ? customConnectorMessage : message);
 
       this.dispatchEvent('retry');
     } else {
@@ -3254,7 +3279,8 @@ Connection.prototype.STATE = {
 
           try {
             this.transitionTo(this.STATE.SENT_TLSSSLNEGOTIATION);
-            await this.messageIo.startTls(this.secureContextOptions, this.config.options.serverName ? this.config.options.serverName : this.routingData?.server ?? this.config.server, this.config.options.trustServerCertificate);
+            const serverName = this.config.options.serverName ? this.config.options.serverName : String(this.routingData?.server ?? this.config.server);
+            await this.messageIo.startTls(this.secureContextOptions, serverName, this.config.options.trustServerCertificate);
           } catch (err: any) {
             return this.socketError(err);
           }

--- a/src/instance-lookup.ts
+++ b/src/instance-lookup.ts
@@ -14,7 +14,7 @@ const MYSTERY_HEADER_LENGTH = 3;
 type LookupFunction = (hostname: string, options: dns.LookupAllOptions, callback: (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void) => void;
 
 // Most of the functionality has been determined from from jTDS's MSSqlServerInfo class.
-export async function instanceLookup(options: { server: string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction, signal: AbortSignal }) {
+export async function instanceLookup(options: { server: undefined | string, instanceName: string, timeout?: number, retries?: number, port?: number, lookup?: LookupFunction, signal: AbortSignal }) {
   const server = options.server;
   if (typeof server !== 'string') {
     throw new TypeError('Invalid arguments: "server" must be a string');
@@ -57,7 +57,7 @@ export async function instanceLookup(options: { server: string, instanceName: st
     try {
       response = await withTimeout(timeout, async (signal) => {
         const request = Buffer.from([0x02]);
-        return await sendMessage(options.server, port, lookup, signal, request);
+        return await sendMessage(String(options.server), port, lookup, signal, request);
       }, signal);
     } catch (err) {
       // If the current attempt timed out, continue with the next


### PR DESCRIPTION
This changeset fixes a problem in the original custom `connector` factory method implementation that required the `server` config property to be defined even though its value is ignored.

Removing the validation when `config.options.connector` is defined fixes the problem.

Ref: https://github.com/tediousjs/tedious/pull/1540
Fixes: https://github.com/tediousjs/tedious/issues/1541
