### PR TITLE
test: fix TDS 8.0 test cases not being executed correctly

### DIFF
--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -532,6 +532,10 @@ describe('Encrypt Test', function() {
    * @param {(err: Error | null, supportsTds8?: boolean) => void} callback
    */
   function supportsTds8(config, callback) {
+    if (config.options.tdsVersion < '7_2') {
+      return callback(null, false);
+    }
+
     const connection = new Connection(config);
 
     connection.connect((err) => {
@@ -549,12 +553,12 @@ describe('Encrypt Test', function() {
           return callback(err);
         }
 
-        if (!productMajorVersion || productMajorVersion < '2022') {
+        if (!productMajorVersion || productMajorVersion < '16') {
           connection.close();
           return callback(null, false);
         }
 
-        if (productMajorVersion > '2022') {
+        if (productMajorVersion > '16') {
           connection.close();
           return callback(null, true);
         }


### PR DESCRIPTION
Our encrypt tests are not running due to SQL version detection that we added. This PR fix that. 
When the test actually running, we found out that TDS7_1 does not compatible with SQL server 2022, so we will skip corresponding tests. 