### PR TITLE
feat: add new error type for param validation

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import Connection, { InternalConnectionOptions } from './connection';
+import { ParameterValidationError } from './errors';
 
 import { Transform } from 'stream';
 import { TYPE as TOKEN_TYPE } from './token/token';
@@ -185,7 +186,8 @@ class RowTransform extends Transform {
         try {
           value = c.type.validate(value, c.collation);
         } catch (error: any) {
-          return callback(error);
+          const validateError = new ParameterValidationError(error.message, c.name, value);
+          return callback(validateError);
         }
       }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -31,7 +31,7 @@ import SqlBatchPayload from './sqlbatch-payload';
 import MessageIO from './message-io';
 import { Parser as TokenStreamParser } from './token/token-stream-parser';
 import { Transaction, ISOLATION_LEVEL, assertValidIsolationLevel } from './transaction';
-import { ConnectionError, RequestError } from './errors';
+import { ConnectionError, RequestError, ParameterValidationError } from './errors';
 import { connectInParallel, connectInSequence } from './connector';
 import { name as libraryName } from './library';
 import { versions } from './tds-versions';
@@ -2829,26 +2829,27 @@ class Connection extends EventEmitter {
       scale: undefined
     });
 
-    try {
-      for (let i = 0, len = request.parameters.length; i < len; i++) {
-        const parameter = request.parameters[i];
 
+    for (let i = 0, len = request.parameters.length; i < len; i++) {
+      const parameter = request.parameters[i];
+      const value = parameters ? parameters[parameter.name] : null;
+      try {
         executeParameters.push({
           ...parameter,
-          value: parameter.type.validate(parameters ? parameters[parameter.name] : null, this.databaseCollation)
+          value: parameter.type.validate(value, this.databaseCollation)
         });
+      } catch (error: any) {
+        const validateError = new ParameterValidationError(error.message, parameter.name, value);
+        request.error = validateError;
+
+        process.nextTick(() => {
+          this.debug.log(validateError.message);
+          request.callback(validateError);
+        });
+
+        return;
       }
-    } catch (error: any) {
-      request.error = error;
-
-      process.nextTick(() => {
-        this.debug.log(error.message);
-        request.callback(error);
-      });
-
-      return;
     }
-
     this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Execute, executeParameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,17 +27,13 @@ export class RequestError extends Error {
   }
 }
 
-export class ParameterValidationError extends Error {
-  code: string | undefined;
-
+export class ParameterValidationError extends TypeError {
   paramName: string | undefined;
   paramValue: any | undefined;
 
-  constructor(message: string, paramName: string, paramValue: any, code?: string) {
+  constructor(message: string, paramName: string, paramValue: any) {
     super(message);
     this.paramName = paramName;
     this.paramValue = paramValue;
-    this.message = `Validation failed for parameter:"${paramName}" with value:"${paramValue}" and message:"${message}"`;
-    this.code = code;
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,3 +26,18 @@ export class RequestError extends Error {
     this.code = code;
   }
 }
+
+export class ParameterValidationError extends Error {
+  code: string | undefined;
+
+  paramName: string | undefined;
+  paramValue: any | undefined;
+
+  constructor(message: string, paramName: string, paramValue: any, code?: string) {
+    super(message);
+    this.paramName = paramName;
+    this.paramValue = paramValue;
+    this.message = `Validation failed for parameter:"${paramName}" with value:"${paramValue}" and message:"${message}"`;
+    this.code = code;
+  }
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { ParameterValidationError } from './errors';
+import { RequestError, ParameterValidationError } from './errors';
 import { type Parameter, type DataType } from './data-type';
 
 import Connection from './connection';
@@ -463,7 +463,11 @@ class Request extends EventEmitter {
       try {
         parameter.value = parameter.type.validate(parameter.value, collation);
       } catch (error: any) {
-        throw new ParameterValidationError(error.message, parameter.name, parameter.value);
+        const paramvalidationErr = new ParameterValidationError(error.message, parameter.name, parameter.value);
+        const requestErr = new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + error.message, 'EPARAM');
+        requestErr.cause = paramvalidationErr;
+
+        throw requestErr;
       }
     }
   }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Parameter, DataType } from './data-type';
-import { RequestError } from './errors';
+import { ParameterValidationError } from './errors';
 
 import Connection from './connection';
 import { Metadata } from './metadata-parser';
@@ -463,7 +463,7 @@ class Request extends EventEmitter {
       try {
         parameter.value = parameter.type.validate(parameter.value, collation);
       } catch (error: any) {
-        throw new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + error.message, 'EPARAM');
+        throw new ParameterValidationError(error.message, parameter.name, parameter.value);
       }
     }
   }

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -7,7 +7,7 @@ const assert = require('chai').assert;
 const TYPES = require('../../src/data-type').typeByName;
 
 import Connection from '../../src/connection';
-import { RequestError } from '../../src/errors';
+import { RequestError, ParameterValidationError } from '../../src/errors';
 import Request from '../../src/request';
 
 const debugMode = false;
@@ -1525,8 +1525,10 @@ describe('BulkLoad', function() {
        * @param {undefined | number} rowCount
        */
       function completeBulkLoad(err, rowCount) {
-        assert.instanceOf(err, TypeError);
-        assert.strictEqual(/** @type {TypeError} */(err).message, 'Invalid date.');
+        assert.instanceOf(err, ParameterValidationError);
+        assert.strictEqual(/** @type {ParameterValidationError} */(err).paramName, 'value');
+        assert.strictEqual(/** @type {ParameterValidationError} */(err).paramValue, 'invalid date');
+        assert.strictEqual(/** @type {ParameterValidationError} */(err).message, 'Validation failed for parameter:"value" with value:"invalid date" and message:"Invalid date."');
 
         done();
       }
@@ -1545,8 +1547,10 @@ describe('BulkLoad', function() {
        * @param {undefined | number} rowCount
        */
       function completeBulkLoad(err, rowCount) {
-        assert.instanceOf(err, TypeError);
-        assert.strictEqual(/** @type {TypeError} */(err).message, 'Invalid date.');
+        assert.instanceOf(err, ParameterValidationError);
+        assert.strictEqual(/** @type {ParameterValidationError} */(err).paramName, 'value');
+        assert.strictEqual(/** @type {ParameterValidationError} */(err).paramValue, 'invalid date');
+        assert.strictEqual(/** @type {ParameterValidationError} */(err).message, 'Validation failed for parameter:"value" with value:"invalid date" and message:"Invalid date."');
 
         assert.strictEqual(rowCount, 0);
 


### PR DESCRIPTION
This should resolve #1557
create a new Error subclass (maybe called ParameterValidationError), have it inherit from whatever error class we currently use (that might be TypeError, but I'm not sure), and define the additional properties on that.

User will have access to the param name and param value information via both message and error properties. 