### PR TITLE
test: allow easier test debugging via `TEDIOUS_DEBUG` env variable

### DIFF
--- a/test/helpers/debug-options-from-env.ts
+++ b/test/helpers/debug-options-from-env.ts
@@ -1,0 +1,24 @@
+export function debugOptionsFromEnv() {
+  const options = {
+    packet: false,
+    data: false,
+    payload: false,
+    token: false,
+  };
+
+  if (!process.env.TEDIOUS_DEBUG) {
+    return options;
+  }
+
+  for (const type of process.env.TEDIOUS_DEBUG.split(',')) {
+    switch (type) {
+      case 'packet':
+      case 'data':
+      case 'payload':
+      case 'token':
+        options[type] = true;
+    }
+  }
+
+  return options;
+}

--- a/test/integration/binary-insert-test.js
+++ b/test/integration/binary-insert-test.js
@@ -7,19 +7,13 @@ const TYPES = require('../../src/data-type').typeByName;
 
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 const config = JSON.parse(
   fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
 ).config;
 
-config.options.debug = {
-  packet: true,
-  data: true,
-  payload: true,
-  token: true,
-  log: true
-};
-
+config.options.debug = debugOptionsFromEnv();
 config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
 describe('inserting binary data', function() {
@@ -28,6 +22,10 @@ describe('inserting binary data', function() {
   beforeEach(function(done) {
     this.connection = new Connection(config);
     this.connection.connect(done);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      this.connection.on('debug', console.log);
+    }
   });
 
   afterEach(function(done) {

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -9,8 +9,7 @@ const TYPES = require('../../src/data-type').typeByName;
 import Connection from '../../src/connection';
 import { RequestError } from '../../src/errors';
 import Request from '../../src/request';
-
-const debugMode = false;
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const { config } = JSON.parse(
@@ -21,14 +20,7 @@ function getConfig() {
 
   config.options.cancelTimeout = 1000;
 
-  if (debugMode) {
-    config.options.debug = {
-      packet: true,
-      data: true,
-      payload: true,
-      token: true
-    };
-  }
+  config.options.debug = debugOptionsFromEnv();
 
   return config;
 }
@@ -43,14 +35,14 @@ describe('BulkLoad', function() {
     connection = new Connection(getConfig());
     connection.connect(done);
 
-    if (debugMode) {
+    if (process.env.TEDIOUS_DEBUG) {
       connection.on('debug', (message) => console.log(message));
-      connection.on('infoMessage', (info) =>
-        console.log('Info: ' + info.number + ' - ' + info.message)
-      );
-      connection.on('errorMessage', (error) =>
-        console.log('Error: ' + error.number + ' - ' + error.message)
-      );
+      connection.on('infoMessage', (info) => {
+        console.log('Info: ' + info.number + ' - ' + info.message);
+      });
+      connection.on('errorMessage', (error) => {
+        console.log('Error: ' + error.number + ' - ' + error.message);
+      });
     }
   });
 

--- a/test/integration/collation-test.ts
+++ b/test/integration/collation-test.ts
@@ -6,6 +6,7 @@ import Connection from '../../src/connection';
 import Request from '../../src/request';
 import { Flags } from '../../src/collation';
 import { TYPES } from '../../src/data-type';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const { config } = JSON.parse(
@@ -13,6 +14,7 @@ function getConfig() {
   );
 
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
+  config.options.debug = debugOptionsFromEnv();
 
   return config;
 }
@@ -33,6 +35,11 @@ describe('Database Collation Support', function() {
     connection.once('databaseChange', (databaseName) => {
       originalDatabaseName = databaseName;
     });
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect(done);
   });
 

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -10,19 +10,14 @@ import Connection from '../../src/connection';
 import { ConnectionError, RequestError } from '../../src/errors';
 import Request from '../../src/request';
 import { versions } from '../../src/tds-versions';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const config = JSON.parse(
     fs.readFileSync(homedir + '/.tedious/test-connection.json', 'utf8')
   ).config;
 
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: true,
-    log: true,
-  };
+  config.options.debug = debugOptionsFromEnv();
 
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
@@ -54,9 +49,9 @@ describe('Initiate Connect Test', function() {
       done();
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.connect(function(err) {
       assert.ok(err);
@@ -100,9 +95,9 @@ describe('Initiate Connect Test', function() {
       return assert.ok(~error.message.indexOf('failed') || ~error.message.indexOf('登录失败'));
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.connect(function(err) {
       assert.ok(err);
@@ -139,9 +134,9 @@ describe('Initiate Connect Test', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    return connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should connect by instance name', function(done) {
@@ -174,9 +169,9 @@ describe('Initiate Connect Test', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    return connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should connect by invalid instance name', function(done) {
@@ -205,9 +200,9 @@ describe('Initiate Connect Test', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    return connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should potentially throw an error on invalid crypto credential details', function(done) {
@@ -230,6 +225,9 @@ describe('Initiate Connect Test', function() {
     const config = getConfig();
 
     const connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect((err) => {
       if (err) {
         return done(err);
@@ -244,6 +242,9 @@ describe('Initiate Connect Test', function() {
     const config = getConfig();
 
     const connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect((err) => {
       if (err) {
         return done(err);
@@ -264,6 +265,9 @@ describe('Initiate Connect Test', function() {
     const config = getConfig();
 
     const connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.on('connect', (err) => {
       if (err) {
         return done(err);
@@ -280,6 +284,10 @@ describe('Initiate Connect Test', function() {
       server: 'something.invalid',
       options: { connectTimeout: 30000 },
     });
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.on('connect', (err) => {
       try {
@@ -307,6 +315,10 @@ describe('Initiate Connect Test', function() {
       },
     });
 
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.on('connect', (err) => {
       assert.instanceOf(err, ConnectionError);
       assert.strictEqual(/** @type {ConnectionError} */(err).code, 'EINSTLOOKUP');
@@ -331,6 +343,11 @@ describe('Initiate Connect Test', function() {
     };
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect(function(err) {
       assert.instanceOf(err, ConnectionError);
       assert.strictEqual(/** @type {ConnectionError} */(err).code, 'ESOCKET');
@@ -357,6 +374,10 @@ describe('Initiate Connect Test', function() {
     });
 
     let connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.connect((err) => {
       assert.ifError(err);
@@ -386,6 +407,10 @@ describe('Initiate Connect Test', function() {
 
     let connection = new Connection({ ...config, options: { ...config.options, workstationId: 'foo.bar.baz' } });
 
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect((err) => {
       assert.ifError(err);
 
@@ -402,6 +427,9 @@ describe('Initiate Connect Test', function() {
     config.options.connectTimeout = 1;
 
     const connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.on('error', (error) => { assert.ifError(error); });
     connection.connect((err) => { });
 
@@ -423,6 +451,10 @@ describe('Initiate Connect Test', function() {
         connectTimeout: 3000
       }
     });
+
+    if (process.env.TEDIOUS_DEBUG) {
+      conn.on('debug', console.log);
+    }
 
     conn.connect((err) => {
       conn.close();
@@ -508,9 +540,9 @@ describe('Ntlm Test', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   }
 
   it('should ntlm', function(done) {
@@ -537,6 +569,10 @@ describe('Encrypt Test', function() {
     }
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.connect((err) => {
       if (err) {
@@ -610,6 +646,9 @@ describe('Encrypt Test', function() {
         config.options.encrypt = 'strict';
 
         connection = new Connection(config);
+        if (process.env.TEDIOUS_DEBUG) {
+          connection.on('debug', console.log);
+        }
         connection.connect(done);
       });
     });
@@ -654,6 +693,9 @@ describe('Encrypt Test', function() {
       const config = getConfig();
       config.options.encrypt = true;
       connection = new Connection(config);
+      if (process.env.TEDIOUS_DEBUG) {
+        connection.on('debug', console.log);
+      }
       connection.connect(done);
     });
 
@@ -694,6 +736,9 @@ describe('BeginTransaction Tests', function() {
   beforeEach(function(done) {
     const config = getConfig();
     connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect(done);
   });
 
@@ -769,9 +814,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    return connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   describe('when `useColumnNames` is `true`', function() {
@@ -780,6 +825,11 @@ describe('Insertion Tests', function() {
       config.options.useColumnNames = true;
 
       const connection = new Connection(config);
+
+      if (process.env.TEDIOUS_DEBUG) {
+        connection.on('debug', console.log);
+      }
+
       connection.connect((err) => {
         if (err) {
           return done(err);
@@ -814,6 +864,10 @@ describe('Insertion Tests', function() {
       config.options.useColumnNames = true;
 
       const connection = new Connection(config);
+
+      if (process.env.TEDIOUS_DEBUG) {
+        connection.on('debug', console.log);
+      }
 
       connection.connect((err) => {
         if (err) {
@@ -860,6 +914,11 @@ describe('Insertion Tests', function() {
         config.options.useColumnNames = true;
 
         const connection = new Connection(config);
+
+        if (process.env.TEDIOUS_DEBUG) {
+          connection.on('debug', console.log);
+        }
+
         connection.connect((err) => {
           if (err) {
             return done(err);
@@ -942,9 +1001,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should exec sql with order', function(done) {
@@ -996,9 +1055,9 @@ describe('Insertion Tests', function() {
       // console.log("#{error.number} : #{error.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should exec Bad Sql', function(done) {
@@ -1025,9 +1084,9 @@ describe('Insertion Tests', function() {
       assert.ok(error);
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should close connection request pending', function(done) {
@@ -1060,9 +1119,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should sql with multiple result sets', function(done) {
@@ -1102,9 +1161,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should row count for update', function(done) {
@@ -1138,9 +1197,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should row collection on request completion', function(done) {
@@ -1176,9 +1235,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should row collection on Done', function(done) {
@@ -1228,9 +1287,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should exec proc as sql', function(done) {
@@ -1270,9 +1329,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should reset Connection', function(done) {
@@ -1357,9 +1416,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should support cancelling a request while it is processed on the server', function(done) {
@@ -1430,9 +1489,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', (text) => {
-      // console.log(text);
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should request timeout', (done) => {
@@ -1482,9 +1541,9 @@ describe('Insertion Tests', function() {
       // console.log("#{info.number} : #{info.message}")
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 });
 
@@ -1497,6 +1556,10 @@ describe('Advanced Input Test', function() {
    */
   function runSqlBatch(done, config, sql, requestCallback) {
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     const request = new Request(sql, function(err, rowCount) {
       requestCallback(err, rowCount);
@@ -1556,6 +1619,10 @@ describe('Date Insert Test', function() {
 
     const connection = new Connection(config);
 
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     const request = new Request('select @@datefirst', function(err) {
       assert.ifError(err);
       connection.close();
@@ -1611,6 +1678,10 @@ describe('Language Insert Test', function() {
 
     const connection = new Connection(config);
 
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     const request = new Request('select @@language', function(err) {
       assert.ifError(err);
       connection.close();
@@ -1647,6 +1718,11 @@ describe('custom textsize value', function() {
     config.options.textsize = 123456;
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect((err) => {
       /**
        * @type {number | undefined}
@@ -1705,6 +1781,11 @@ describe('custom textsize value', function() {
     config.options.textsize = undefined;
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect((err) => {
       /**
        * @type {number | undefined}
@@ -1736,6 +1817,11 @@ describe('custom textsize value', function() {
     config.options.textsize = -1;
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect((err) => {
       /**
        * @type {number | undefined}
@@ -1771,6 +1857,11 @@ describe('custom textsize value', function() {
     config.options.textsize = 0;
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect((err) => {
       /**
        * @type {number | undefined}
@@ -1802,6 +1893,11 @@ describe('custom textsize value', function() {
     config.options.textsize = 1000.0123;
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
     connection.connect((err) => {
       /**
        * @type {number | undefined}
@@ -1840,6 +1936,10 @@ describe('should test date format', function() {
     config.options.dateFormat = dateFormat;
 
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     const request = new Request(
       'SELECT DATE_FORMAT FROM sys.dm_exec_sessions WHERE SESSION_ID = @@SPID ',
@@ -1886,6 +1986,10 @@ describe('Boolean Config Options Test', function() {
     const config = getConfig();
     config.options[optionName] = optionValue;
     const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     const request = new Request(
       `SELECT (${optionFlag} & @@OPTIONS) AS OPTION_FLAG_OR_ZERO;`,

--- a/test/integration/datatypes-in-results-test.ts
+++ b/test/integration/datatypes-in-results-test.ts
@@ -6,26 +6,14 @@ import Request from '../../src/request';
 import { typeByName as TYPES } from '../../src/data-type';
 
 import { homedir } from 'os';
-
-const debug = false;
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 const config = JSON.parse(
   fs.readFileSync(homedir() + '/.tedious/test-connection.json', 'utf8')
 ).config;
+
 config.options.textsize = 8 * 1024;
-
-if (debug) {
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: true,
-    log: true,
-  };
-} else {
-  config.options.debug = {};
-}
-
+config.options.debug = debugOptionsFromEnv();
 config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
 describe('Datatypes in results test', function() {
@@ -38,11 +26,9 @@ describe('Datatypes in results test', function() {
       console.log(`${error.number} : ${error.message}`);
     });
 
-    connection.on('debug', function(message) {
-      if (debug) {
-        console.log(message);
-      }
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.connect(done);
   });

--- a/test/integration/invalid-packet-stream-test.js
+++ b/test/integration/invalid-packet-stream-test.js
@@ -2,6 +2,7 @@
 
 const { assert } = require('chai');
 const net = require('net');
+const { debugOptionsFromEnv } = require('../helpers/debug-options-from-env');
 const Connection = require('../../src/tedious').Connection;
 const ConnectionError = require('../../src/errors').ConnectionError;
 
@@ -55,8 +56,13 @@ describe('Connecting to a server that sends invalid packet data', function() {
       server: addressInfo.address,
       options: {
         port: addressInfo.port,
+        debug: debugOptionsFromEnv()
       }
     });
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
 
     connection.connect((err) => {
       assert.instanceOf(err, ConnectionError);

--- a/test/integration/parameterised-statements-test.js
+++ b/test/integration/parameterised-statements-test.js
@@ -7,20 +7,14 @@ const TYPES = require('../../src/data-type').typeByName;
 import async from 'async';
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const config = JSON.parse(
     fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
   ).config;
 
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: true,
-    log: true,
-  };
-
+  config.options.debug = debugOptionsFromEnv();
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
   return config;
@@ -101,9 +95,9 @@ function execSql(done, type, value, tdsVersion, options, expectedValue, cast, co
     console.log(`${error.number} : ${error.message}`);
   });
 
-  connection.on('debug', function(text) {
-    // console.log(text)
-  });
+  if (process.env.TEDIOUS_DEBUG) {
+    connection.on('debug', console.log);
+  }
 }
 
 /**
@@ -163,9 +157,9 @@ function execSqlOutput(done, type, value, expectedValue, connectionOptions) {
     done();
   });
 
-  connection.on('debug', function(text) {
-    // console.log(text)
-  });
+  if (process.env.TEDIOUS_DEBUG) {
+    connection.on('debug', console.log);
+  }
 }
 
 describe('Parameterised Statements Test', function() {
@@ -989,10 +983,15 @@ describe('Parameterised Statements Test', function() {
 
   it('supports TVP values', function(done) {
     const config = getConfig();
-    const connection = new Connection(config);
 
     if (config.options.tdsVersion < '7_3_A') {
       this.skip();
+    }
+
+    const connection = new Connection(config);
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
     }
 
     connection.connect(function(err) {
@@ -1168,9 +1167,9 @@ describe('Parameterised Statements Test', function() {
       done();
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should call procedure with parameters', function(done) {
@@ -1251,9 +1250,9 @@ end')\
       done();
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
 });

--- a/test/integration/pause-resume-test.js
+++ b/test/integration/pause-resume-test.js
@@ -6,10 +6,12 @@ const assert = require('chai').assert;
 import Connection from '../../src/connection';
 import Request from '../../src/request';
 import { RequestError } from '../../src/errors';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const config = JSON.parse(fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')).config;
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
+  config.options.debug = debugOptionsFromEnv();
   // 250 ms timeout until the first response package is received
   config.options.requestTimeout = 250;
   return config;
@@ -22,6 +24,9 @@ describe('Pause-Resume Test', function() {
 
   beforeEach(function(done) {
     connection = new Connection(getConfig());
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect(done);
   });
 

--- a/test/integration/prepare-execute-statements-test.js
+++ b/test/integration/prepare-execute-statements-test.js
@@ -6,20 +6,14 @@ const assert = require('chai').assert;
 
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const config = JSON.parse(
     fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
   ).config;
 
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: false,
-    log: true,
-  };
-
+  config.options.debug = debugOptionsFromEnv();
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
   return config;
@@ -58,15 +52,18 @@ describe('Prepare Execute Statement', function() {
       done();
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('does not cause unexpected `returnValue` events to be emitted', function(done) {
     const config = getConfig();
 
     const connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect(function(err) {
       if (err) {
         return done(err);
@@ -138,7 +135,9 @@ describe('Prepare Execute Statement', function() {
     });
 
     const connection = new Connection(config);
-
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     request.on('prepared', function() {
       connection.execute(request);
     });
@@ -185,8 +184,8 @@ describe('Prepare Execute Statement', function() {
       done();
     });
 
-    connection.on('debug', function(text) {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 });

--- a/test/integration/rpc-test.js
+++ b/test/integration/rpc-test.js
@@ -6,19 +6,14 @@ const assert = require('chai').assert;
 
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const config = JSON.parse(
     fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
   ).config;
 
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: true,
-    log: true,
-  };
+  config.options.debug = debugOptionsFromEnv();
 
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
@@ -46,9 +41,9 @@ describe('RPC test', function() {
       console.log(`${error.number} : ${error.message}`);
     });
 
-    connection.on('debug', (text) => {
-      // console.log(text)
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   afterEach(function(done) {
@@ -360,11 +355,9 @@ set @paramOut = @paramIn\
       assert.ok(error);
     });
 
-    connection.on(
-      'debug',
-      function(text) { }
-      // console.log(text)
-    );
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
   it('should proc return value', function(done) {
@@ -414,11 +407,9 @@ set @paramOut = @paramIn\
       assert.ok(error);
     });
 
-    connection.on(
-      'debug',
-      function(text) { }
-      // console.log(text)
-    );
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
   });
 
 });

--- a/test/integration/socket-error-test.js
+++ b/test/integration/socket-error-test.js
@@ -5,19 +5,14 @@ const { assert } = require('chai');
 
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   const config = JSON.parse(
     fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
   ).config;
 
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: false,
-    log: true
-  };
+  config.options.debug = debugOptionsFromEnv();
 
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
@@ -37,6 +32,9 @@ describe('A `error` on the network socket', function() {
 
     connection = new Connection(getConfig());
     connection.on('error', done);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect((err) => {
       connection.removeListener('error', done);
       done(err);

--- a/test/integration/transactions-test.js
+++ b/test/integration/transactions-test.js
@@ -3,26 +3,14 @@ const Request = require('../../src/request');
 const Transaction = require('../../src/transaction');
 const fs = require('fs');
 const async = require('async');
+const { debugOptionsFromEnv } = require('../helpers/debug-options-from-env');
 const assert = require('chai').assert;
-
-const debug = false;
 
 const config = JSON.parse(
   fs.readFileSync(require('os').homedir() + '/.tedious/test-connection.json', 'utf8')
 ).config;
 
-if (debug) {
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: true,
-    log: true
-  };
-} else {
-  config.options.debug = {};
-}
-
+config.options.debug = debugOptionsFromEnv();
 config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
 class Tester {
@@ -52,11 +40,9 @@ class Tester {
       console.log(`${error.number} : ${error.message}`);
     });
 
-    this.connection.on('debug', (message) => {
-      if (debug) {
-        console.log(message);
-      }
-    });
+    if (process.env.TEDIOUS_DEBUG) {
+      this.connection.on('debug', console.log);
+    }
   }
 
   createTable(callback) {

--- a/test/integration/tvp-test.js
+++ b/test/integration/tvp-test.js
@@ -7,6 +7,7 @@ const { assert } = require('chai');
 
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
 
 function getConfig() {
   var config = JSON.parse(
@@ -15,13 +16,7 @@ function getConfig() {
 
   config.options.tdsVersion = process.env.TEDIOUS_TDS_VERSION;
 
-  config.options.debug = {
-    packet: true,
-    data: true,
-    payload: true,
-    token: true,
-    log: true
-  };
+  config.options.debug = debugOptionsFromEnv();
 
   return config;
 }
@@ -37,6 +32,9 @@ describe('calling a procedure that takes and returns a TVP', function() {
     config = getConfig();
 
     connection = new Connection(config);
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
     connection.connect(done);
   });
 


### PR DESCRIPTION
This allows enabling debug output during test runs by setting the `TEDIOUS_DEBUG` variable. The value for the variable is a string containing a value like `packet`, `data`, `payload`, `token`, or any combination of these values separated by `,`.