### PR TITLE
doc: update the encrypt via a suggestion

### DIFF
--- a/api-connection.html
+++ b/api-connection.html
@@ -522,9 +522,9 @@ connection.connect();
         <code>options.encrypt</code>
       </dt>
       <dd>
-        A boolean determining whether or not the connection will be encrypted. Set to <code>true</code> if you're on
-        Windows Azure.
-        (default: <code>true</code>).
+        A string value that can be only set to 'strict', indicates the usage of TDS 8.0 protocol. 
+        Otherwise, encrypt can be set to a boolean value which determines whether or not the connection will be encrypted.
+        (default: <code> true </code>).
       </dd>
 
       <dt>

--- a/api-connection.html
+++ b/api-connection.html
@@ -522,9 +522,9 @@ connection.connect();
         <code>options.encrypt</code>
       </dt>
       <dd>
-        A string value that can be only set to 'strict', indicates the usage of TDS 8.0 protocol. 
-        Otherwise, encrypt can be set to a boolean value which determines whether or not the connection will be encrypted.
-        (default: <code> true </code>).
+        A string value set to <code> strict </code> enables the TDS 8.0 protocol. 
+        Otherwise, encrypt can be set to a boolean value which determines 
+        whether or not the connection will be encrypted under the TDS 7.x protocol. (default: <code> true </code>)
       </dd>
 
       <dt>


### PR DESCRIPTION
David suggested we update the doc to: 
A string value set to 'strict' enables the TDS 8.0 protocol. Otherwise, encrypt can be set to a boolean value which determines whether or not the connection will be encrypted under the TDS 7.x protocol. (default: true ).