### PR TITLE
fix: don't throw in _transform of BulkLoad

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -205,9 +205,13 @@ class RowTransform extends Transform {
         this.push(textPointerAndTimestampBuffer);
       }
 
-      this.push(c.type.generateParameterLength(parameter, this.mainOptions));
-      for (const chunk of c.type.generateParameterData(parameter, this.mainOptions)) {
-        this.push(chunk);
+      try {
+        this.push(c.type.generateParameterLength(parameter, this.mainOptions));
+        for (const chunk of c.type.generateParameterData(parameter, this.mainOptions)) {
+          this.push(chunk);
+        }
+      } catch (error: any) {
+        return callback(error);
       }
     }
 

--- a/test/integration/bulk-load-test.js
+++ b/test/integration/bulk-load-test.js
@@ -1562,4 +1562,28 @@ describe('BulkLoad', function() {
       }
     });
   });
+
+  it('should not throw in _transform function', (done) => {
+    const bulkLoad = connection.newBulkLoad(
+      '#tmpTestTable',
+      (err, rowCount) => {
+        assert.instanceOf(err, RangeError);
+        assert.strictEqual(/** @type {RangeError} */(err).message, 'The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received 3_.40_282_346_638_528_86e_+42');
+        assert.strictEqual(rowCount, 0);
+        done();
+      });
+
+    bulkLoad.addColumn('value', TYPES.Decimal, { precision: 7, scale: 4, nullable: true });
+
+    const request = new Request(bulkLoad.getTableCreationSql(), (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, [[-3.4028234663852886e+38]]);
+    });
+
+    connection.execSqlBatch(request);
+
+  });
 });


### PR DESCRIPTION
I got an `uncaughtException`, caused by trying to write a very large (negative) number using BulkLoad to a decimal column. Seems similar to https://github.com/tediousjs/tedious/issues/421. The stack trace I got:
```
RangeError: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received 3_.40_282_346_638_528_86e_+42
  File "node:internal/errors", line 496, in __node_internal_captureLargerStackTrace
  File "node:internal/errors", line 405, in new NodeError
  File "node:internal/buffer", line 74, in checkInt
  File "node:internal/buffer", line 694, in writeU_Int32LE
  File "node:internal/buffer", line 707, in Buffer.writeUInt32LE
  File "/app/node_modules/tedious/src/data-types/decimal.ts", line 77, in Object.generateParameterData
  File "<anonymous>", line unknown, in generateParameterData.next
  File "/app/node_modules/tedious/src/bulk-load.ts", line 209, in _transform
  File "node:internal/streams/transform", line 175, in Transform._write
  File "node:internal/streams/writable", line 392, in writeOrBuffer
  File "node:internal/streams/writable", line 333, in _write
  File "node:internal/streams/writable", line 337, in Writable.write
  File "node:internal/streams/readable", line 777, in Readable.ondata
  File "node:events", line 517, in Readable.emit
  File "node:internal/streams/readable", line 550, in Readable.read
  File "node:internal/streams/readable", line 1032, in flow
  File "node:internal/streams/readable", line 1013, in resume_
  File "node:internal/process/task_queues", line 82, in process.processTicksAndRejections
```

bulk-load:209 is inside the _tranform function, for which I think the following in the [nodejs documentation](https://nodejs.org/api/stream.html) holds:

> Throwing an Error from within these methods or manually emitting an 'error' event results in undefined behavior.

Therefore, I propose to catch such errors and call the callback with it. I verified that solved my case.

