### PR TITLE
fix: use userland module for `punycode`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/lru-cache": "^5.1.1",
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.18.38",
+        "@types/punycode": "^2.1.3",
         "@types/sprintf-js": "^1.1.2",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -3287,6 +3288,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/punycode": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.3.tgz",
+      "integrity": "sha512-dFkH9Mz0yY5UfQVSrpj1grQyqRwe4TohTLlHFx4Gli8/fsaNyoOVUAsiEBZk5JBwbEJVZ49W6st8D5g6dRJb/w==",
       "dev": true
     },
     "node_modules/@types/retry": {
@@ -16230,6 +16237,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/punycode": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.3.tgz",
+      "integrity": "sha512-dFkH9Mz0yY5UfQVSrpj1grQyqRwe4TohTLlHFx4Gli8/fsaNyoOVUAsiEBZk5JBwbEJVZ49W6st8D5g6dRJb/w==",
       "dev": true
     },
     "@types/retry": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/lru-cache": "^5.1.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.18.38",
+    "@types/punycode": "^2.1.3",
     "@types/sprintf-js": "^1.1.2",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,7 +1,7 @@
 import net from 'net';
 import dns, { type LookupAddress } from 'dns';
 
-import * as punycode from 'punycode';
+import * as punycode from 'punycode/';
 import { AbortSignal } from 'node-abort-controller';
 import AbortError from './errors/abort-error';
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -1,7 +1,7 @@
 import dgram from 'dgram';
 import dns from 'dns';
 import net from 'net';
-import * as punycode from 'punycode';
+import * as punycode from 'punycode/';
 import { AbortSignal } from 'node-abort-controller';
 
 import AbortError from './errors/abort-error';

--- a/test/unit/connector-test.js
+++ b/test/unit/connector-test.js
@@ -1,6 +1,6 @@
 const Mitm = require('mitm');
 const sinon = require('sinon');
-const punycode = require('punycode');
+const punycode = require('punycode/');
 const assert = require('chai').assert;
 const { AbortController } = require('node-abort-controller');
 const AggregateError = require('es-aggregate-error');

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const punycode = require('punycode');
+const punycode = require('punycode/');
 const assert = require('chai').assert;
 const dgram = require('dgram');
 const { AbortController } = require('node-abort-controller');


### PR DESCRIPTION
The slash at the end is necessary to use the userland module. The module built-in to node is deprecated.
