### PR TITLE
refactor: replace `punycode` with `node:url`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11612,6 +11612,14 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -22252,6 +22260,11 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "q": {
       "version": "1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
         "node-abort-controller": "^3.1.1",
-        "punycode": "^2.3.0",
         "sprintf-js": "^1.1.2"
       },
       "devDependencies": {
@@ -37,7 +36,6 @@
         "@types/lru-cache": "^5.1.1",
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.18.38",
-        "@types/punycode": "^2.1.3",
         "@types/sprintf-js": "^1.1.2",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -3288,12 +3286,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
-    "node_modules/@types/punycode": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.3.tgz",
-      "integrity": "sha512-dFkH9Mz0yY5UfQVSrpj1grQyqRwe4TohTLlHFx4Gli8/fsaNyoOVUAsiEBZk5JBwbEJVZ49W6st8D5g6dRJb/w==",
       "dev": true
     },
     "node_modules/@types/retry": {
@@ -11620,14 +11612,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -16237,12 +16221,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
-    "@types/punycode": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.3.tgz",
-      "integrity": "sha512-dFkH9Mz0yY5UfQVSrpj1grQyqRwe4TohTLlHFx4Gli8/fsaNyoOVUAsiEBZk5JBwbEJVZ49W6st8D5g6dRJb/w==",
       "dev": true
     },
     "@types/retry": {
@@ -22274,11 +22252,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
-    "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "jsbi": "^4.3.0",
     "native-duplexpair": "^1.0.0",
     "node-abort-controller": "^3.1.1",
-    "punycode": "^2.3.0",
     "sprintf-js": "^1.1.2"
   },
   "devDependencies": {
@@ -68,7 +67,6 @@
     "@types/lru-cache": "^5.1.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.18.38",
-    "@types/punycode": "^2.1.3",
     "@types/sprintf-js": "^1.1.2",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,7 +1,7 @@
 import net from 'net';
 import dns, { type LookupAddress } from 'dns';
 
-import * as punycode from 'punycode';
+import url from 'node:url';
 import { AbortSignal } from 'node-abort-controller';
 import AbortError from './errors/abort-error';
 
@@ -167,7 +167,7 @@ export async function lookupAllAddresses(host: string, lookup: LookupFunction, s
 
       signal.addEventListener('abort', onAbort);
 
-      lookup(punycode.toASCII(host), { all: true }, (err, addresses) => {
+      lookup(url.domainToASCII(host), { all: true }, (err, addresses) => {
         signal.removeEventListener('abort', onAbort);
 
         err ? reject(err) : resolve(addresses);

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -1,7 +1,7 @@
 import dgram from 'dgram';
 import dns from 'dns';
 import net from 'net';
-import * as punycode from 'punycode';
+import url from 'node:url';
 import { AbortSignal } from 'node-abort-controller';
 
 import AbortError from './errors/abort-error';
@@ -83,7 +83,7 @@ export async function sendMessage(host: string, port: number, lookup: LookupFunc
 
       signal.addEventListener('abort', onAbort);
 
-      lookup(punycode.toASCII(host), { all: true }, (err, addresses) => {
+      lookup(url.domainToASCII(host), { all: true }, (err, addresses) => {
         signal.removeEventListener('abort', onAbort);
 
         err ? reject(err) : resolve(addresses);

--- a/test/unit/connector-test.js
+++ b/test/unit/connector-test.js
@@ -1,6 +1,6 @@
 const Mitm = require('mitm');
 const sinon = require('sinon');
-const punycode = require('punycode');
+const url = require('node:url');
 const assert = require('chai').assert;
 const { AbortController } = require('node-abort-controller');
 const AggregateError = require('es-aggregate-error');
@@ -27,7 +27,7 @@ describe('lookupAllAddresses', function() {
     }
 
     assert.isOk(lookup.called, 'Failed to call `lookup` function for hostname');
-    assert.isOk(lookup.calledWithMatch(punycode.toASCII(server)), 'Unexpected hostname passed to `lookup`');
+    assert.isOk(lookup.calledWithMatch(url.domainToASCII(server)), 'Unexpected hostname passed to `lookup`');
   });
 
   it('test ASCII Server name', async function() {

--- a/test/unit/instance-lookup-test.js
+++ b/test/unit/instance-lookup-test.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const punycode = require('punycode');
+const url = require('node:url');
 const assert = require('chai').assert;
 const dgram = require('dgram');
 const { AbortController } = require('node-abort-controller');
@@ -361,7 +361,7 @@ describe('parseBrowserResponse', function() {
     }
 
     sinon.assert.calledOnce(lookup);
-    sinon.assert.calledWithMatch(lookup, punycode.toASCII(options.server));
+    sinon.assert.calledWithMatch(lookup, url.domainToASCII(options.server));
   });
 
   it('test ASCII Server name', async function() {


### PR DESCRIPTION
Seems that native node:url supports the same functionality that tedious required. Replace punnyCode side function with url.domainToASCII. 