### PR TITLE
chore!: drop node 16 and 19 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,10 +19,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 19.x]
       fail-fast: false
 
     steps:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       matrix:
         mssql-version: [2016, 2017, 2019, 2022]
-        node-version: [16.x, 18.x, 19.x, 20.x]
+        node-version: [18.x, 19.x, 20.x]
       fail-fast: false
 
     steps:
@@ -359,7 +359,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   azure-sql-auth:
-    name: Azure SQL Server / Node.js 16.x
+    name: Azure SQL Server / Node.js 18.x
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -368,10 +368,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -413,7 +413,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   azure-ad-auth:
-    name: Azure SQL Server / Node.js 16.x
+    name: Azure SQL Server / Node.js 18.x
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -422,10 +422,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -472,7 +472,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   azure-ad-service-principal-auth:
-    name: Azure SQL Server / Node.js 16.x
+    name: Azure SQL Server / Node.js 18.x
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -481,10 +481,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Determine npm cache directory
       id: npm-cache
@@ -537,10 +537,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Determine npm cache directory
       id: npm-cache

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 21.x]
       fail-fast: false
 
     steps:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       matrix:
         mssql-version: [2016, 2017, 2019, 2022]
-        node-version: [18.x, 19.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 21.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x]
+        node-version: [18.x, 19.x, 20.x, 21.x]
       fail-fast: false
 
     steps:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       matrix:
         mssql-version: [2016, 2017, 2019, 2022]
-        node-version: [18.x, 19.x, 20.x]
+        node-version: [18.x, 19.x, 20.x, 21.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Tag latest release
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,8 @@ version: "{build}"
 environment:
   matrix:
     - nodejs_version: "18"
-    - nodejs_version: "19"
+    - nodejs_version: "20"
+    - nodejs_version: "21"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ version: "{build}"
 
 environment:
   matrix:
-    - nodejs_version: "16"
     - nodejs_version: "18"
     - nodejs_version: "19"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/tediousjs/tedious.git"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "publishConfig": {
     "tag": "next"
@@ -106,7 +106,7 @@
         "@babel/preset-env",
         {
           "targets": {
-            "node": 16
+            "node": 18
           }
         }
       ],


### PR DESCRIPTION
BREAKING CHANGE: Node.js 16.x and 19.x are no longer supported by `tedious`.