### PR TITLE
feat(types): export `ConnectionConfiguration` type

### DIFF
--- a/src/tedious.ts
+++ b/src/tedious.ts
@@ -20,7 +20,6 @@ export function connect(config: ConnectionConfiguration, connectListener?: (err?
 export {
   BulkLoad,
   Connection,
-  ConnectionConfiguration,
   Request,
   library,
   ConnectionError,
@@ -28,4 +27,8 @@ export {
   TYPES,
   ISOLATION_LEVEL,
   TDS_VERSION
+};
+
+export type {
+  ConnectionConfiguration
 };

--- a/src/tedious.ts
+++ b/src/tedious.ts
@@ -20,6 +20,7 @@ export function connect(config: ConnectionConfiguration, connectListener?: (err?
 export {
   BulkLoad,
   Connection,
+  ConnectionConfiguration,
   Request,
   library,
   ConnectionError,


### PR DESCRIPTION
Thanks for adding first-party typings! I've noticed that ConnectionConfiguration wasn't exported, while we are using that for sequelize here; https://github.com/sequelize/sequelize/blob/main/packages/core/src/dialects/mssql/connection-manager.ts (@types/tedious calls it ConnectionConfig but the object is basically the same as ConnectionConfiguration)

I went ahead and just exported the type here, but I'm open to hear if you have other suggestions on what type to use.
