### PR TITLE
feat(types): Export `ConnectionAuthentication` and `ConnectionOptions`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -328,9 +328,11 @@ interface ErrorWithCode extends Error {
   code?: string;
 }
 
+export type ConnectionAuthentication = DefaultAuthentication | NtlmAuthentication | AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryAccessTokenAuthentication | AzureActiveDirectoryServicePrincipalSecret | AzureActiveDirectoryDefaultAuthentication;
+
 interface InternalConnectionConfig {
   server: string;
-  authentication: DefaultAuthentication | NtlmAuthentication | AzureActiveDirectoryPasswordAuthentication | AzureActiveDirectoryMsiAppServiceAuthentication | AzureActiveDirectoryMsiVmAuthentication | AzureActiveDirectoryAccessTokenAuthentication | AzureActiveDirectoryServicePrincipalSecret | AzureActiveDirectoryDefaultAuthentication;
+  authentication: ConnectionAuthentication;
   options: InternalConnectionOptions;
 }
 
@@ -1065,7 +1067,7 @@ class Connection extends EventEmitter {
 
     this.fedAuthRequired = false;
 
-    let authentication: InternalConnectionConfig['authentication'];
+    let authentication: ConnectionAuthentication;
     if (config.authentication !== undefined) {
       if (typeof config.authentication !== 'object' || config.authentication === null) {
         throw new TypeError('The "config.authentication" property must be of type Object.');

--- a/src/tedious.ts
+++ b/src/tedious.ts
@@ -1,5 +1,5 @@
 import BulkLoad from './bulk-load';
-import Connection, { type ConnectionConfiguration } from './connection';
+import Connection, { type ConnectionAuthentication, type ConnectionConfiguration, type ConnectionOptions } from './connection';
 import Request from './request';
 import { name } from './library';
 
@@ -30,5 +30,7 @@ export {
 };
 
 export type {
-  ConnectionConfiguration
+  ConnectionAuthentication,
+  ConnectionConfiguration,
+  ConnectionOptions
 };


### PR DESCRIPTION
These types are used by `@types/mssql`. If this isn't desirable then we could propose a change to the type definitions in DefinitelyTyped.

- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/24a1115cea9315062833ded8a59de6ac9f627f2f/types/mssql/index.d.ts#L209
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/24a1115cea9315062833ded8a59de6ac9f627f2f/types/mssql/index.d.ts#L179

```console
node_modules/@types/mssql/index.d.ts(179,44): error TS2694: Namespace '"node_modules/tedious/lib/tedious"' has no exported member 'ConnectionOptions'.
node_modules/@types/mssql/index.d.ts(209,26): error TS2694: Namespace '"node_modules/tedious/lib/tedious"' has no exported member 'ConnectionAuthentication'.
```