### PR TITLE
fix: fix `bigint` validation

### DIFF
--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -4,6 +4,8 @@ import WritableTrackingBuffer from '../tracking-buffer/writable-tracking-buffer'
 
 const DATA_LENGTH = Buffer.from([0x08]);
 const NULL_LENGTH = Buffer.from([0x00]);
+const MAX_SAFE_BIGINT = 9223372036854775807n;
+const MIN_SAFE_BIGINT = -9223372036854775808n;
 
 const BigInt: DataType = {
   id: 0x7F,
@@ -36,21 +38,17 @@ const BigInt: DataType = {
     yield buffer.data;
   },
 
-  validate: function(value): null | number {
+  validate: function(value): null | bigint {
     if (value == null) {
       return null;
     }
 
-    if (typeof value !== 'number') {
-      value = Number(value);
+    if (typeof value !== 'bigint') {
+      value = globalThis.BigInt(value);
     }
 
-    if (isNaN(value)) {
-      throw new TypeError('Invalid number.');
-    }
-
-    if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
-      throw new TypeError(`Value must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}, inclusive.  For smaller or bigger numbers, use VarChar type.`);
+    if (value < MIN_SAFE_BIGINT || value > MAX_SAFE_BIGINT) {
+      throw new TypeError(`Value must be between ${MIN_SAFE_BIGINT} and ${MAX_SAFE_BIGINT}, inclusive.`);
     }
 
     return value;

--- a/test/unit/validations-test.js
+++ b/test/unit/validations-test.js
@@ -67,21 +67,25 @@ describe('Validations', function() {
     assert.strictEqual(value, null);
 
     value = TYPE.BigInt.validate(2147483647);
-    assert.strictEqual(value, 2147483647);
+    assert.strictEqual(value, 2147483647n);
 
-    value = TYPE.BigInt.validate(-9007199254740991);
-    assert.strictEqual(value, -9007199254740991);
+    value = TYPE.BigInt.validate(-9223372036854775808n);
+    assert.strictEqual(value, -9223372036854775808n);
 
-    value = TYPE.BigInt.validate(9007199254740991);
-    assert.strictEqual(value, 9007199254740991);
-
-    assert.throws(() => {
-      TYPE.BigInt.validate(-9007199254740992);
-    }, TypeError, 'Value must be between -9007199254740991 and 9007199254740991, inclusive.  For smaller or bigger numbers, use VarChar type.');
+    value = TYPE.BigInt.validate(9223372036854775807n);
+    assert.strictEqual(value, 9223372036854775807n);
 
     assert.throws(() => {
-      TYPE.BigInt.validate(9007199254740992);
-    }, TypeError, 'Value must be between -9007199254740991 and 9007199254740991, inclusive.  For smaller or bigger numbers, use VarChar type.');
+      TYPE.BigInt.validate(-9223372036854775809n);
+    }, TypeError, 'Value must be between -9223372036854775808 and 9223372036854775807, inclusive.');
+
+    assert.throws(() => {
+      TYPE.BigInt.validate(9223372036854775808n);
+    }, TypeError, 'Value must be between -9223372036854775808 and 9223372036854775807, inclusive.');
+
+    assert.throws(() => {
+      TYPE.BigInt.validate(0.5);
+    }, RangeError, 'The number 0.5 cannot be converted to a BigInt because it is not an integer');
   });
 
   it('SmallDateTime', () => {


### PR DESCRIPTION
This PR is for fixing issue #1610 
Now the validate function will throw an error if a invalid value is passed into BigInt type :
"The number <value> cannot be converted to a BigInt because it is not an integer"