### PR TITLE
ci: update links to windows SQL server cumulative updates

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -180,17 +180,17 @@ jobs:
           '2022' {
             $exe_link = 'https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SQLServer2022-DEV-x64-ENU.exe'
             $box_link = 'https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SQLServer2022-DEV-x64-ENU.box'
-            $update_link = 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=105013'
+            $update_link = 'https://www.microsoft.com/en-us/download/details.aspx?id=105013'
           }
           '2019' {
             $exe_link = 'https://download.microsoft.com/download/8/4/c/84c6c430-e0f5-476d-bf43-eaaa222a72e0/SQLServer2019-DEV-x64-ENU.exe'
             $box_link = 'https://download.microsoft.com/download/8/4/c/84c6c430-e0f5-476d-bf43-eaaa222a72e0/SQLServer2019-DEV-x64-ENU.box'
-            $update_link = 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=100809'
+            $update_link = 'https://www.microsoft.com/en-us/download/details.aspx?id=100809'
           }
           '2017' {
             $exe_link = 'https://download.microsoft.com/download/E/F/2/EF23C21D-7860-4F05-88CE-39AA114B014B/SQLServer2017-DEV-x64-ENU.exe'
             $box_link = 'https://download.microsoft.com/download/E/F/2/EF23C21D-7860-4F05-88CE-39AA114B014B/SQLServer2017-DEV-x64-ENU.box'
-            $update_link = 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=56128'
+            $update_link = 'https://www.microsoft.com/en-us/download/details.aspx?id=56128'
           }
           '2016' {
             $exe_link = 'https://download.microsoft.com/download/4/1/A/41AD6EDE-9794-44E3-B3D5-A1AF62CD7A6F/sql16_sp2_dlc/en-us/SQLServer2016SP2-FullSlipstream-DEV-x64-ENU.exe'


### PR DESCRIPTION
See here for updated link: 
https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/sql/releases/sqlserver-2019/cumulativeupdate27.md

under "How to obtain or download the latest cumulative update package for Windows (recommended)"