### PR TITLE
fix: fix type information on some `ConnectionOptions` properties

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -498,7 +498,7 @@ export interface ConnectionOptions {
    * during the given transaction's execution. This sets the value for `SET XACT_ABORT` during the
    * initial SQL phase of a connection [documentation](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-xact-abort-transact-sql).
    */
-  abortTransactionOnError?: boolean;
+  abortTransactionOnError?: boolean | undefined;
 
   /**
    * Application name used for identifying a specific application in profiling, logging or tracing tools of SQLServer.
@@ -757,7 +757,7 @@ export interface ConnectionOptions {
    *
    * Mutually exclusive with [[instanceName]]
    */
-  port?: number;
+  port?: number | undefined;
 
   /**
    * A boolean, determining whether the connection will request read only access from a SQL Server Availability
@@ -811,14 +811,14 @@ export interface ConnectionOptions {
    *
    * (default: `7_4`)
    */
-  tdsVersion?: string;
+  tdsVersion?: string | undefined;
 
   /**
    * Specifies the size of varchar(max), nvarchar(max), varbinary(max), text, ntext, and image data returned by a SELECT statement.
    *
    * (default: `2147483647`)
    */
-  textsize?: string;
+  textsize?: number;
 
   /**
    * If "true", the SQL Server SSL certificate is automatically trusted when the communication layer is encrypted using SSL.


### PR DESCRIPTION
This was extracted from https://github.com/tediousjs/tedious/pull/1634 and makes some of the `ConnectionOptions` properties accept `undefined` values.

It also fixes the type for the `textSize` option to be a `number` instead of a `string`.