### PR TITLE
fix: fix `options.debug.token` option not causing any debug output

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import * as util from 'util';
 import { Packet } from './packet';
+import type { Token } from './token/token';
 
 class Debug extends EventEmitter {
   declare options: {
@@ -44,7 +45,7 @@ class Debug extends EventEmitter {
     }
   }
 
-  token(token: any) {
+  token(token: Token) {
     if (this.haveListeners() && this.options.token) {
       this.log(util.inspect(token, { showHidden: false, depth: 5, colors: true }));
     }

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -19,6 +19,7 @@ export class Parser extends EventEmitter {
 
     this.parser = Readable.from(StreamParser.parseTokens(message, this.debug, this.options));
     this.parser.on('data', (token: Token) => {
+      debug.token(token);
       handler[token.handlerName as keyof TokenHandler](token as any);
     });
 


### PR DESCRIPTION
I don't know exactly when this was broken, but it looks like we haven't been getting any debug output from the `options.debug.token` option.

This also fixes one use of `any` in the `token` method in `Debug` by changing the type of the `token` parameter to `Token`.