### PR TITLE
fix: don't convert BigInt type to Number before writing to buffer to prevent RangeError

### DIFF
--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -34,7 +34,7 @@ const BigInt: DataType = {
     }
 
     const buffer = new WritableTrackingBuffer(8);
-    buffer.writeInt64LE(Number(parameter.value));
+    buffer.writeBigInt64LE(typeof parameter.value === 'bigint' ? parameter.value : globalThis.BigInt(parameter.value));
     yield buffer.data;
   },
 

--- a/test/unit/int-data-type.js
+++ b/test/unit/int-data-type.js
@@ -1,5 +1,5 @@
 const { assert } = require('chai');
-const { typeByName: { Int, SmallInt, TinyInt } } = require('../../src/data-type');
+const { typeByName: { Int, SmallInt, TinyInt, BigInt } } = require('../../src/data-type');
 
 describe('integer-data-types', function() {
   describe('int data type test', function() {
@@ -43,6 +43,20 @@ describe('integer-data-types', function() {
       it('test valid parameter values', function() {
         const buffer = Buffer.concat([...TinyInt.generateParameterData(item.param, {})]);
         assert.equal(buffer.readInt8(0), item.expected);
+      });
+    });
+  });
+
+  describe('big int data type test', function() {
+    const params = [
+      { param: { value: 9223372036854775807n }, expected: 9223372036854775807n },
+      { param: { value: -9223372036854775808n }, expected: -9223372036854775808n }
+    ];
+
+    params.forEach(function(item) {
+      it('test valid parameter values', function() {
+        const buffer = Buffer.concat([...BigInt.generateParameterData(item.param, {})]);
+        assert.equal(buffer.readBigInt64LE(0), item.expected);
       });
     });
   });


### PR DESCRIPTION
Passing big integer values as bigint parameters caused a RangeError with the following message:
`RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= -(2n ** 63n) and < 2n ** 63n. Received 9_223_372_036_854_775_808n`.

The patch removes this unneeded conversion and instead convert other types to BigInt.