### PR TITLE
ci: GitHub Actions cleanup

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,8 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
+
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -80,7 +80,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -263,7 +263,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -344,7 +344,7 @@ jobs:
       id: npm-cache
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -389,7 +389,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -436,7 +436,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -484,7 +484,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -528,7 +528,7 @@ jobs:
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 
@@ -55,7 +55,7 @@ jobs:
 
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -212,7 +212,7 @@ jobs:
 
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -336,7 +336,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 
@@ -380,7 +380,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 
@@ -427,7 +427,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 
@@ -475,7 +475,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 
@@ -519,7 +519,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:
@@ -78,7 +78,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:
@@ -261,7 +261,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:
@@ -343,7 +343,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
     - uses: actions/cache@v3
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
@@ -387,7 +387,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:
@@ -434,7 +434,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:
@@ -482,7 +482,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:
@@ -526,7 +526,7 @@ jobs:
     - name: Determine npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -260,6 +260,7 @@ jobs:
 
     - name: Determine npm cache directory
       id: npm-cache
+      shell: bash
       run: |
         echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
       with:
         fetch-depth: 0
     - name: Use Node.js 18
@@ -50,7 +51,8 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -206,7 +208,8 @@ jobs:
 
         Pop-Location
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -330,7 +333,8 @@ jobs:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
     - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
@@ -373,7 +377,8 @@ jobs:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
     - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
@@ -419,7 +424,8 @@ jobs:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
     - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
@@ -466,7 +472,8 @@ jobs:
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
     - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
@@ -509,7 +516,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
     - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
+
     - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.0.3
       with:
         node-version: 18
 


### PR DESCRIPTION
This upgrades various GitHub Actions to their latest versions, and removes usage of the deprecated `set-output` command.