### PR TITLE
feat: set error cause if available

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1963,7 +1963,7 @@ class Connection extends EventEmitter {
         }
 
         process.nextTick(() => {
-          this.emit('connect', new ConnectionError(err.message, 'EINSTLOOKUP'));
+          this.emit('connect', new ConnectionError(err.message, 'EINSTLOOKUP', { cause: err }));
         });
       });
     }
@@ -2331,11 +2331,11 @@ class Connection extends EventEmitter {
       const routingMessage = this.routingData ? ` (redirected from ${this.config.server}${hostPostfix})` : '';
       const message = `Failed to connect to ${server}${port}${routingMessage} - ${error.message}`;
       this.debug.log(message);
-      this.emit('connect', new ConnectionError(message, 'ESOCKET'));
+      this.emit('connect', new ConnectionError(message, 'ESOCKET', { cause: error }));
     } else {
       const message = `Connection lost - ${error.message}`;
       this.debug.log(message);
-      this.emit('error', new ConnectionError(message, 'ESOCKET'));
+      this.emit('error', new ConnectionError(message, 'ESOCKET', { cause: error }));
     }
     this.dispatchEvent('socketError', error);
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,8 +3,8 @@ export class ConnectionError extends Error {
 
   declare isTransient: boolean | undefined;
 
-  constructor(message: string, code?: string) {
-    super(message);
+  constructor(message: string, code?: string, options?: ErrorOptions) {
+    super(message, options);
 
     this.code = code;
   }
@@ -20,8 +20,8 @@ export class RequestError extends Error {
   declare procName: string | undefined;
   declare lineNumber: number | undefined;
 
-  constructor(message: string, code?: string) {
-    super(message);
+  constructor(message: string, code?: string, options?: ErrorOptions) {
+    super(message, options);
 
     this.code = code;
   }

--- a/src/request.ts
+++ b/src/request.ts
@@ -463,7 +463,7 @@ class Request extends EventEmitter {
       try {
         parameter.value = parameter.type.validate(parameter.value, collation);
       } catch (error: any) {
-        throw new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + error.message, 'EPARAM');
+        throw new RequestError('Validation failed for parameter \'' + parameter.name + '\'. ' + error.message, 'EPARAM', { cause: error });
       }
     }
   }

--- a/test/integration/connection-test.js
+++ b/test/integration/connection-test.js
@@ -248,6 +248,10 @@ describe('Initiate Connect Test', function() {
       try {
         assert.instanceOf(err, ConnectionError);
         assert.strictEqual(/** @type {ConnectionError} */(err).code, 'ESOCKET');
+
+        assert.instanceOf(/** @type {ConnectionError} */(err).cause, Error);
+        assert.strictEqual(/** @type {Error} */(/** @type {ConnectionError} */(err).cause).message, 'getaddrinfo ENOTFOUND something.invalid');
+
         assert.strictEqual(connection.connectTimer, undefined);
         done();
       } catch (e) {
@@ -277,6 +281,10 @@ describe('Initiate Connect Test', function() {
     connection.on('connect', (err) => {
       assert.instanceOf(err, ConnectionError);
       assert.strictEqual(/** @type {ConnectionError} */(err).code, 'EINSTLOOKUP');
+
+      assert.instanceOf(/** @type {ConnectionError} */(err).cause, Error);
+      assert.strictEqual(/** @type {Error} */(/** @type {ConnectionError} */(err).cause).message, 'getaddrinfo ENOTFOUND something.invalid');
+
       assert.strictEqual(connection.connectTimer, undefined);
 
       done();
@@ -310,6 +318,10 @@ describe('Initiate Connect Test', function() {
     connection.connect(function(err) {
       assert.instanceOf(err, ConnectionError);
       assert.strictEqual(/** @type {ConnectionError} */(err).code, 'ESOCKET');
+
+      assert.instanceOf(/** @type {ConnectionError} */(err).cause, Error);
+      console.log(/** @type {ConnectionError} */(err).cause);
+      assert.include(/** @type {Error} */(/** @type {ConnectionError} */(err).cause).message, 'no ciphers available');
     });
 
     connection.on('end', function() {


### PR DESCRIPTION
This pull request updates `ConnectionError` and `RequestError` with support for a new `options` argumenton their constructor. This parameter mirrors the `options` of `Error` base class and allows setting a `cause`.

I updated all the locations where `ConnectionError` or `RequestError` are constructed to set the `cause` if available.