### PR TITLE
ci: increase mocha timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "mocha": {
     "require": "test/setup.js",
-    "timeout": 5000,
+    "timeout": 10000,
     "extension": [
       "js",
       "ts"


### PR DESCRIPTION
increase the project mocha timeout to 10 seconds to prevent `dns.lookup` timeout