### PR TITLE
refactor: move the `loginError` property from `Connection` into `Login7Handler`

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -957,10 +957,6 @@ class Connection extends EventEmitter {
   /**
    * @private
    */
-  declare loginError: undefined | AggregateError | ConnectionError;
-  /**
-   * @private
-   */
   declare debug: Debug;
   /**
    * @private
@@ -3491,13 +3487,12 @@ class Connection extends EventEmitter {
 
       if (handler.loginAckReceived) {
         return handler.routingData;
-      } else if (this.loginError) {
-        throw this.loginError;
+      } else if (handler.loginError) {
+        throw handler.loginError;
       } else {
         throw new ConnectionError('Login failed.', 'ELOGIN');
       }
     } finally {
-      this.loginError = undefined;
       signal.removeEventListener('abort', onAbort);
     }
   }
@@ -3547,14 +3542,13 @@ class Connection extends EventEmitter {
           });
 
           this.ntlmpacket = undefined;
-        } else if (this.loginError) {
-          throw this.loginError;
+        } else if (handler.loginError) {
+          throw handler.loginError;
         } else {
           throw new ConnectionError('Login failed.', 'ELOGIN');
         }
       }
     } finally {
-      this.loginError = undefined;
       signal.removeEventListener('abort', onAbort);
     }
   }
@@ -3655,13 +3649,12 @@ class Connection extends EventEmitter {
         // sent the fedAuth token message, the rest is similar to standard login 7
         this.transitionTo(this.STATE.SENT_LOGIN7_WITH_STANDARD_LOGIN);
         return await this.performSentLogin7WithStandardLogin(signal);
-      } else if (this.loginError) {
-        throw this.loginError;
+      } else if (handler.loginError) {
+        throw handler.loginError;
       } else {
         throw new ConnectionError('Login failed.', 'ELOGIN');
       }
     } finally {
-      this.loginError = undefined;
       signal.removeEventListener('abort', onAbort);
     }
   }

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -250,10 +250,13 @@ export class Login7TokenHandler extends TokenHandler {
 
   declare loginAckReceived: boolean;
 
+  declare loginError: ConnectionError | undefined;
+
   constructor(connection: Connection) {
     super();
     this.loginAckReceived = false;
     this.connection = connection;
+    this.loginError = undefined;
   }
 
   onInfoMessage(token: InfoMessageToken) {
@@ -270,7 +273,7 @@ export class Login7TokenHandler extends TokenHandler {
       error.isTransient = true;
     }
 
-    this.connection.loginError = error;
+    this.loginError = error;
   }
 
   onSSPI(token: SSPIToken) {
@@ -309,27 +312,27 @@ export class Login7TokenHandler extends TokenHandler {
 
     if (authentication.type === 'azure-active-directory-password' || authentication.type === 'azure-active-directory-access-token' || authentication.type === 'azure-active-directory-msi-vm' || authentication.type === 'azure-active-directory-msi-app-service' || authentication.type === 'azure-active-directory-service-principal-secret' || authentication.type === 'azure-active-directory-default') {
       if (token.fedAuth === undefined) {
-        this.connection.loginError = new ConnectionError('Did not receive Active Directory authentication acknowledgement');
+        this.loginError = new ConnectionError('Did not receive Active Directory authentication acknowledgement');
       } else if (token.fedAuth.length !== 0) {
-        this.connection.loginError = new ConnectionError(`Active Directory authentication acknowledgment for ${authentication.type} authentication method includes extra data`);
+        this.loginError = new ConnectionError(`Active Directory authentication acknowledgment for ${authentication.type} authentication method includes extra data`);
       }
     } else if (token.fedAuth === undefined && token.utf8Support === undefined) {
-      this.connection.loginError = new ConnectionError('Received acknowledgement for unknown feature');
+      this.loginError = new ConnectionError('Received acknowledgement for unknown feature');
     } else if (token.fedAuth) {
-      this.connection.loginError = new ConnectionError('Did not request Active Directory authentication, but received the acknowledgment');
+      this.loginError = new ConnectionError('Did not request Active Directory authentication, but received the acknowledgment');
     }
   }
 
   onLoginAck(token: LoginAckToken) {
     if (!token.tdsVersion) {
       // unsupported TDS version
-      this.connection.loginError = new ConnectionError('Server responded with unknown TDS version.', 'ETDS');
+      this.loginError = new ConnectionError('Server responded with unknown TDS version.', 'ETDS');
       return;
     }
 
     if (!token.interface) {
       // unsupported interface
-      this.connection.loginError = new ConnectionError('Server responded with unsupported interface.', 'EINTERFACENOTSUPP');
+      this.loginError = new ConnectionError('Server responded with unsupported interface.', 'EINTERFACENOTSUPP');
       return;
     }
 


### PR DESCRIPTION
This moves the `loginError` property from the `Connection` class into `Login7TokenHandler` — one less piece of cross-cutting mutable state to keep track of on `Connection` itself.

Since a fresh `Login7TokenHandler` is created for each login response message (including each iteration of the NTLM challenge loop), scoping the error to the handler is naturally correct and removes the need to reset `loginError` between login attempts: the three `performSentLogin7With*` methods now read `handler.loginError` directly, and their `finally`-block cleanup of the property goes away.

This has been rebuilt on top of the current async connection establishment flow (#1661/#1663/#1665), replacing the original pre-refactor version of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
