### PR TITLE
chore: add benchmarks to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ scripts/
 todo
 .*
 /scratch
+benchmarks/


### PR DESCRIPTION
https://github.com/tediousjs/tedious/issues/1686

Benchmarks (like tests & examples) do not need to be published with the package. Add benchmarks to `.npmignore`