### PR TITLE
chore: update `typescript`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "semantic-release": "^22.0.12",
         "sinon": "^21.0.0",
         "typedoc": "^0.28.14",
-        "typescript": "^5.5.4"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.17"
@@ -12969,10 +12969,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "semantic-release": "^22.0.12",
     "sinon": "^21.0.0",
     "typedoc": "^0.28.14",
-    "typescript": "^5.5.4"
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "docs": "typedoc",

--- a/src/login7-payload.ts
+++ b/src/login7-payload.ts
@@ -134,7 +134,7 @@ class Login7Payload {
 
   toBuffer() {
     const fixedData = Buffer.alloc(94);
-    const buffers = [fixedData];
+    const buffers: Buffer[] = [fixedData];
 
     let offset = 0;
     let dataOffset = fixedData.length;

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -53,7 +53,7 @@ export class Packet {
     if (typeOrBuffer instanceof Buffer) {
       this.buffer = typeOrBuffer;
     } else {
-      const type = typeOrBuffer;
+      const type = typeOrBuffer as number;
       this.buffer = Buffer.alloc(HEADER_LENGTH, 0);
       this.buffer.writeUInt8(type, OFFSET.Type);
       this.buffer.writeUInt8(STATUS.NORMAL, OFFSET.Status);

--- a/src/prelogin-payload.ts
+++ b/src/prelogin-payload.ts
@@ -84,7 +84,7 @@ class PreloginPayload {
       this.data = bufferOrOptions;
       this.options = { encrypt: false, version: { major: 0, minor: 0, build: 0, subbuild: 0 } };
     } else {
-      this.options = bufferOrOptions;
+      this.options = bufferOrOptions as Options;
       this.createOptions();
     }
     this.extractOptions();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "lib": [ "esnext" ],
+    "lib": [ "ES2022" ],
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "exactOptionalPropertyTypes": true,

--- a/types/js-md4.d.ts
+++ b/types/js-md4.d.ts
@@ -1,6 +1,6 @@
 declare module 'js-md4' {
   declare const md4: {
-    arrayBuffer(message: string | ArrayBuffer): ArrayBuffer;
+    arrayBuffer(message: string | number[] | Uint8Array | ArrayBuffer): ArrayBuffer;
   };
 
   export = md4;


### PR DESCRIPTION
This bumps `typescript` to `5.9.3` and updates `eslint` and related dependencies to their latest versions.

As part of the `eslint` upgrade, this also updates the `eslint` configuration to the new format.