### PR TITLE
fix: include schema in TVP type declaration

### DIFF
--- a/src/data-types/tvp.ts
+++ b/src/data-types/tvp.ts
@@ -14,7 +14,8 @@ const TVP: DataType = {
 
   declaration: function(parameter) {
     const value = parameter.value as any; // Temporary solution. Remove 'any' later.
-    return value.name + ' readonly';
+    const schema = value.schema ? value.schema + '.' : '';
+    return schema + value.name + ' readonly';
   },
 
   generateTypeInfo(parameter) {

--- a/test/unit/data-type.ts
+++ b/test/unit/data-type.ts
@@ -1384,6 +1384,36 @@ describe('TinyInt', function() {
 });
 
 describe('TVP', function() {
+  describe('.declaration', function() {
+    it('returns type name with readonly', function() {
+      const result = TYPES.TVP.declaration({
+        value: { name: 'MyTableType', schema: '', columns: [], rows: [] }
+      } as any);
+      assert.strictEqual(result, 'MyTableType readonly');
+    });
+
+    it('includes schema when present', function() {
+      const result = TYPES.TVP.declaration({
+        value: { name: 'UDT_StringArray', schema: 'AI', columns: [], rows: [] }
+      } as any);
+      assert.strictEqual(result, 'AI.UDT_StringArray readonly');
+    });
+
+    it('works with null schema', function() {
+      const result = TYPES.TVP.declaration({
+        value: { name: 'MyTableType', schema: null, columns: [], rows: [] }
+      } as any);
+      assert.strictEqual(result, 'MyTableType readonly');
+    });
+
+    it('works with undefined schema', function() {
+      const result = TYPES.TVP.declaration({
+        value: { name: 'MyTableType', columns: [], rows: [] }
+      } as any);
+      assert.strictEqual(result, 'MyTableType readonly');
+    });
+  });
+
   describe('.generateParameterLength', function() {
     it('returns the correct data length', function() {
       assert.deepEqual(TYPES.TVP.generateParameterLength({ value: null }, options), Buffer.from([0xFF, 0xFF]));


### PR DESCRIPTION
⚠️  LLM disclaimer: I've used an LLM to help create this PR, but have reviewed the changes before submitting.

We've had a [bug reported in the node-mssql repo](https://github.com/tediousjs/node-mssql/issues/1759), which looks to originate from the TVP declaration in the tedious driver. Hopefully this fixes the root cause of the issue.

---

The TVP declaration function only used value.name when generating the type declaration for sp_executesql @params, ignoring value.schema. This caused 'Cannot find data type' errors when using TVPs with schema-qualified UDT names (e.g. AI.UDT_StringArray).

The declaration now prepends the schema when present, producing 'AI.UDT_StringArray readonly' instead of 'UDT_StringArray readonly'.

This does not affect the RPC path (callProcedure) which uses generateTypeInfo and already handles schema correctly.

Fixes: tediousjs/node-mssql#1759

**Before submitting a PR :**
1. Ensure your fork is created from `master` branch of [the repository](https://github.com/tediousjs/tedious).
2. Run `npm install` in the root folder.
3. After bug fix/code change, ensure all the existing tests and new tests (if any) pass (`npm run-script test-all`). During development, to run individual test use `node_modules/nodeunit test/<test_file.js> -t <test_name>`.
4. Build the driver (`npm run build`).
5. Run eslint and flow typechecker (`npm run lint`).
6. Run commitlint (`node_modules/.bin/commitlint --from origin/master --to HEAD`). Refer [commit conventions](https://commitlint.js.org/#/concepts-commit-conventions) and [commit rules](https://commitlint.js.org/#/reference-rules).

**Thank you for Contributing!**
