### PR TITLE
fix: keep message stream aligned when canceling with a disabled cancel timeout

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3766,6 +3766,14 @@ Connection.prototype.STATE = {
         }
 
         const onCancel = () => {
+          // If the request was canceled before the request message was
+          // fully sent, the message was terminated with the `IGNORE` bit
+          // set and no attention message was sent. The server's response
+          // to the ignored message is handled like a regular response.
+          if (!this.attentionSent) {
+            return;
+          }
+
           tokenStreamParser.removeListener('end', onEndOfMessage);
 
           if (this.request instanceof Request && this.request.paused) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1036,6 +1036,14 @@ class Connection extends EventEmitter {
   declare requestTimer: undefined | NodeJS.Timeout;
 
   /**
+   * Whether an attention message was sent to the server to cancel the
+   * currently active request.
+   *
+   * @private
+   */
+  declare attentionSent: boolean;
+
+  /**
    * @private
    */
   declare _cancelAfterRequestSent: () => void;
@@ -1780,8 +1788,11 @@ class Connection extends EventEmitter {
 
     this.state = this.STATE.INITIALIZED;
 
+    this.attentionSent = false;
+
     this._cancelAfterRequestSent = () => {
       this.messageIo.sendMessage(TYPE.ATTENTION);
+      this.attentionSent = true;
       this.createCancelTimer();
     };
 
@@ -3176,6 +3187,7 @@ class Connection extends EventEmitter {
       }
 
       this.request = request;
+      this.attentionSent = false;
       request.connection! = this;
       request.rowCount! = 0;
       request.rows! = [];
@@ -3722,15 +3734,15 @@ Connection.prototype.STATE = {
 
         const tokenStreamParser = this.createTokenStreamParser(message, new RequestTokenHandler(this, this.request!));
 
-        // If the request was canceled and we have a `cancelTimer`
-        // defined, we send a attention message after the
-        // request message was fully sent off.
+        // If the request was canceled after the request message was
+        // fully sent off, an attention message was sent to the server.
         //
-        // We already started consuming the current message
-        // (but all the token handlers should be no-ops), and
-        // need to ensure the next message is handled by the
-        // `SENT_ATTENTION` state.
-        if (this.request?.canceled && this.cancelTimer) {
+        // We already started consuming the current message (the response
+        // to the canceled request, with all the token handlers being
+        // no-ops), and need to ensure the next message (containing the
+        // attention acknowledgement) is handled by the `SENT_ATTENTION`
+        // state.
+        if (this.request?.canceled && this.attentionSent) {
           return this.transitionTo(this.STATE.SENT_ATTENTION);
         }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3223,7 +3223,11 @@ class Connection extends EventEmitter {
 
       message.once('finish', () => {
         request.removeListener('cancel', onCancel);
-        request.once('cancel', this._cancelAfterRequestSent);
+        // Prepend the listener so it always runs before the
+        // `SentClientRequest` state's `cancel` handler, regardless of the
+        // order in which the two were registered. The latter relies on
+        // `attentionSent` already being set, which only this listener does.
+        request.prependOnceListener('cancel', this._cancelAfterRequestSent);
 
         this.resetConnectionOnNextRequest = false;
         this.debug.payload(function() {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2164,6 +2164,7 @@ class Connection extends EventEmitter {
         this.request = undefined;
       }
 
+      this.attentionSent = false;
       this.closed = true;
     }
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3195,7 +3195,11 @@ class Connection extends EventEmitter {
 
       const onCancel = () => {
         payloadStream.unpipe(message);
-        payloadStream.destroy(new RequestError('Canceled.', 'ECANCEL'));
+        payloadStream.destroy();
+
+        // The request error might already be set, e.g. if the payload
+        // stream errored before the cancellation.
+        request.error ??= new RequestError('Canceled.', 'ECANCEL');
 
         // set the ignore bit and end the message.
         message.ignore = true;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3847,6 +3847,7 @@ Connection.prototype.STATE = {
         // 3.2.5.7 Sent Attention State
         // Discard any data contained in the response, until we receive the attention response
         if (handler.attentionReceived) {
+          this.attentionSent = false;
           this.clearCancelTimer();
 
           const sqlRequest = this.request!;

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -1,11 +1,12 @@
 import { assert } from 'chai';
 import * as net from 'net';
-import { Connection, Request, RequestError } from '../../src/tedious';
+import { Connection, Request, RequestError, TYPES } from '../../src/tedious';
 import IncomingMessageStream from '../../src/incoming-message-stream';
 import OutgoingMessageStream from '../../src/outgoing-message-stream';
 import Debug from '../../src/debug';
 import PreloginPayload from '../../src/prelogin-payload';
 import Message from '../../src/message';
+import { Packet } from '../../src/packet';
 
 function buildLoginAckToken(): Buffer {
   const progname = 'Tedious SQL Server';
@@ -54,6 +55,20 @@ function buildAttentionAckToken(): Buffer {
   buffer.writeBigUInt64LE(0n, offset); // rowCount
 
   return buffer;
+}
+
+/**
+ * Builds a `COLMETADATA` token for a single `int` column named `a`.
+ */
+function buildColMetadataToken(): Buffer {
+  return Buffer.from([
+    0x81, // COLMETADATA
+    0x01, 0x00, // column count
+    0x00, 0x00, 0x00, 0x00, // userType
+    0x00, 0x00, // flags
+    0x38, // INT4
+    0x01, 0x61, 0x00 // column name - 'a'
+  ]);
 }
 
 /**
@@ -345,4 +360,175 @@ describe('Canceling a request', function() {
     });
   });
 
+  it('should complete the request with `ECANCEL` when canceled while the request message is being sent and the response already started arriving', function(done) {
+    // Used by the client side to signal to the server side that the request
+    // was canceled.
+    let signalCanceled!: () => void;
+    const requestCanceled = new Promise<void>((resolve) => {
+      signalCanceled = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          await drainMessage(message);
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildLoginAckToken());
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`insert bulk ...`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // Bulk Load
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x07);
+
+          // Send the first packet of the response message right away,
+          // while the client is still sending the bulk load message,
+          // like a server would do when it encounters an error in the
+          // middle of a bulk load.
+          const packet = new Packet(0x04);
+          packet.packetId(1);
+          packet.addData(buildColMetadataToken());
+          connection.write(packet.buffer);
+
+          // Wait until the client canceled the bulk load before reading
+          // the bulk load message, so that the cancellation is guaranteed
+          // to happen while the bulk load message is still being sent.
+          await requestCanceled;
+
+          // Drain the bulk load message. As the bulk load was canceled
+          // while it was being sent, the message ends with the `IGNORE`
+          // bit set.
+          await drainMessage(message);
+
+          // Finish the response message.
+          const finalPacket = new Packet(0x04);
+          finalPacket.packetId(2);
+          finalPacket.last(true);
+          finalPacket.addData(buildDoneToken());
+          connection.write(finalPacket.buffer);
+        }
+
+        // SQL Batch (`select 2`) - no attention message is expected
+        // in between, as the canceled bulk load message was never
+        // fully sent.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual(err.code, 'ECANCEL');
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      bulkLoad.addColumn('a', TYPES.VarBinary, { length: 8000, nullable: false });
+
+      // A row stream that never completes, so the bulk load message
+      // stays in flight until the bulk load is canceled. The first row
+      // is large enough to fill a packet, so the server starts receiving
+      // the bulk load message right away.
+      connection.execBulkLoad(bulkLoad, (async function*() {
+        yield [Buffer.alloc(8000)];
+
+        await new Promise<unknown>(() => {
+          // This promise never resolves.
+        });
+      })());
+
+      // Cancel the bulk load once its message is being sent and the
+      // first part of the response message has arrived.
+      setTimeout(() => {
+        connection.cancel();
+        signalCanceled();
+      }, 100);
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
 });

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -1,0 +1,232 @@
+import { assert } from 'chai';
+import * as net from 'net';
+import { Connection, Request, RequestError } from '../../src/tedious';
+import IncomingMessageStream from '../../src/incoming-message-stream';
+import OutgoingMessageStream from '../../src/outgoing-message-stream';
+import Debug from '../../src/debug';
+import PreloginPayload from '../../src/prelogin-payload';
+import Message from '../../src/message';
+
+function buildLoginAckToken(): Buffer {
+  const progname = 'Tedious SQL Server';
+
+  const buffer = Buffer.from([
+    0xAD, // Type
+    0x00, 0x00, // Length
+    0x00, // interface number - SQL
+    0x74, 0x00, 0x00, 0x04, // TDS version number
+    Buffer.byteLength(progname, 'ucs2') / 2, ...Buffer.from(progname, 'ucs2'), // Progname
+    0x00, // major
+    0x00, // minor
+    0x00, 0x00, // buildNum
+  ]);
+
+  buffer.writeUInt16LE(buffer.length - 3, 1);
+
+  return buffer;
+}
+
+/**
+ * Builds a final `DONE` token, optionally with a row count.
+ */
+function buildDoneToken(rowCount?: number): Buffer {
+  const buffer = Buffer.alloc(13);
+
+  let offset = 0;
+  offset = buffer.writeUInt8(0xFD, offset); // DONE
+  offset = buffer.writeUInt16LE(rowCount !== undefined ? 0x0010 : 0x0000, offset); // status = DONE_COUNT or DONE_FINAL
+  offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
+  buffer.writeBigUInt64LE(BigInt(rowCount ?? 0), offset); // rowCount
+
+  return buffer;
+}
+
+/**
+ * Builds a `DONE` token that acknowledges a previously sent attention message.
+ */
+function buildAttentionAckToken(): Buffer {
+  const buffer = Buffer.alloc(13);
+
+  let offset = 0;
+  offset = buffer.writeUInt8(0xFD, offset); // DONE
+  offset = buffer.writeUInt16LE(0x0020, offset); // status = DONE_ATTN
+  offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
+  buffer.writeBigUInt64LE(0n, offset); // rowCount
+
+  return buffer;
+}
+
+describe('Canceling a request', function() {
+  let server: net.Server;
+  let _connections: net.Socket[];
+
+  beforeEach(function(done) {
+    _connections = [];
+    server = net.createServer((connection) => {
+      _connections.push(connection);
+    });
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function(done) {
+    _connections.forEach((connection) => {
+      connection.destroy();
+    });
+
+    server.close(done);
+  });
+
+  it('should complete the canceled request and leave the message stream aligned when `cancelTimeout` is disabled', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildLoginAckToken());
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`select 1`) - no response is sent before
+        // the attention message arrives.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+        }
+
+        // ATTENTION
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          // Every client request receives exactly one response message:
+          // first the response to the canceled request, then a separate
+          // message containing only the `DONE` token that acknowledges
+          // the attention message.
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+
+        // SQL Batch (`select 2`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual(err.code, 'ECANCEL');
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response, not the leftover attention
+        // acknowledgement message.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      connection.execSqlBatch(request);
+
+      // Cancel the request once the request message has been sent off.
+      setTimeout(() => {
+        connection.cancel();
+      }, 50);
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+});

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -72,6 +72,34 @@ function buildColMetadataToken(): Buffer {
 }
 
 /**
+ * Builds an `ERROR` token, as a server would send when it encounters an
+ * error in the middle of processing a request (e.g. a failing bulk load).
+ */
+function buildErrorToken(): Buffer {
+  const message = 'Bulk load data conversion error.';
+  const messageData = Buffer.from(message, 'ucs2');
+
+  const data = Buffer.alloc(4 + 1 + 1 + 2 + messageData.length + 1 + 1 + 4);
+
+  let offset = 0;
+  offset = data.writeUInt32LE(4815, offset); // number
+  offset = data.writeUInt8(1, offset); // state
+  offset = data.writeUInt8(16, offset); // class
+  offset = data.writeUInt16LE(message.length, offset); // message length (in characters)
+  offset += messageData.copy(data, offset); // message
+  offset = data.writeUInt8(0, offset); // server name length
+  offset = data.writeUInt8(0, offset); // proc name length
+  data.writeUInt32LE(0, offset); // line number (TDS 7.2+)
+
+  const buffer = Buffer.alloc(3 + data.length);
+  buffer.writeUInt8(0xAA, 0); // ERROR
+  buffer.writeUInt16LE(data.length, 1); // token length
+  data.copy(buffer, 3);
+
+  return buffer;
+}
+
+/**
  * Reads and discards all data of the given message.
  */
 async function drainMessage(message: Message): Promise<void> {
@@ -532,6 +560,214 @@ describe('Canceling a request', function() {
       bulkLoad.on('columnMetadata', () => {
         connection.cancel();
         signalCanceled();
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('should complete the request with `ECANCEL` when a bulk load is canceled after it was fully sent but the server already responded with an error', function(done) {
+    // This models a real bulk load that the server rejects mid-stream: the
+    // server starts responding (here with an error) while the client is
+    // still sending the bulk load message, the client keeps streaming the
+    // remaining rows until the message is fully sent, and only then is the
+    // bulk load canceled.
+    //
+    // In that ordering the client registers its `SentClientRequest` cancel
+    // handler (when the response starts arriving) *before* the request
+    // message finishes sending (which registers the post-send cancel
+    // handler). The post-send handler must still run first so that an
+    // attention message is sent and acknowledged; otherwise the attention
+    // acknowledgement is left unread and corrupts the next request.
+
+    // Signals (client -> generator) that the error response was received,
+    // so the bulk load row stream may complete.
+    let signalErrorReceived!: () => void;
+    const errorReceived = new Promise<void>((resolve) => {
+      signalErrorReceived = resolve;
+    });
+
+    // Signals (server -> client) that the full bulk load message was
+    // received, which means the client already finished sending it (so its
+    // `finish` event fired and the post-send cancel handler is registered).
+    // Canceling only after this point exercises the post-send cancel path
+    // with a response that started arriving early.
+    let signalDrained!: () => void;
+    const requestDrained = new Promise<void>((resolve) => {
+      signalDrained = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          await drainMessage(message);
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`insert bulk ...`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // Bulk Load
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x07);
+
+          // Start responding with an error right away, while the client is
+          // still sending the bulk load message, like a server would do
+          // when it rejects a bulk load (e.g. a data conversion error).
+          // The response message is left open (no final packet yet) until
+          // the bulk load message has been fully received.
+          const packet = new Packet(0x04);
+          packet.packetId(1);
+          packet.addData(buildErrorToken());
+          connection.write(packet.buffer);
+
+          // Drain the rest of the bulk load message. Once this resolves,
+          // the client has finished sending the bulk load message, so its
+          // `finish` event already fired.
+          await drainMessage(message);
+
+          // Now let the client cancel - after the request message was
+          // fully sent off.
+          signalDrained();
+
+          // The cancellation is performed by sending an attention message.
+          const { value: attentionMessage } = await messageIterator.next();
+          assert.strictEqual(attentionMessage.type, 0x06);
+
+          await drainMessage(attentionMessage);
+
+          // Finish the (cut short) response to the canceled request.
+          const finalPacket = new Packet(0x04);
+          finalPacket.packetId(2);
+          finalPacket.last(true);
+          finalPacket.addData(buildDoneToken());
+          connection.write(finalPacket.buffer);
+
+          // Acknowledge the attention message in a separate message.
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+
+        // SQL Batch (`select 2`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual(err.code, 'ECANCEL');
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response, not the leftover attention
+        // acknowledgement message.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      bulkLoad.addColumn('a', TYPES.VarBinary, { length: 8000, nullable: false });
+
+      // A row stream that completes only once the error response has been
+      // received, so the bulk load message is guaranteed to finish sending
+      // *after* the response started arriving. The first row is large
+      // enough to fill a packet, so the server starts receiving the bulk
+      // load message right away.
+      connection.execBulkLoad(bulkLoad, (async function*() {
+        yield [Buffer.alloc(8000)];
+
+        await errorReceived;
+      })());
+
+      connection.on('errorMessage', () => {
+        signalErrorReceived();
+      });
+
+      // Cancel the bulk load once the server received the full bulk load
+      // message, i.e. after the request message was fully sent off.
+      requestDrained.then(() => {
+        connection.cancel();
       });
     });
 

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -102,6 +102,15 @@ describe('Canceling a request', function() {
   });
 
   it('should complete the canceled request and leave the message stream aligned when `cancelTimeout` is disabled', function(done) {
+    // Used by the server side to signal to the client side that the request
+    // message was fully received. Canceling after this point guarantees the
+    // cancellation is performed by sending an attention message, not by
+    // terminating the request message with the `IGNORE` bit set.
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
     server.on('connection', async (connection) => {
       const debug = new Debug();
       const incomingMessageStream = new IncomingMessageStream(debug);
@@ -134,7 +143,7 @@ describe('Canceling a request', function() {
           await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
-          responseMessage.end(buildLoginAckToken());
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
           outgoingMessageStream.write(responseMessage);
         }
 
@@ -157,6 +166,8 @@ describe('Canceling a request', function() {
           assert.strictEqual(message.type, 0x01);
 
           await drainMessage(message);
+
+          signalRequestReceived();
         }
 
         // ATTENTION
@@ -226,13 +237,10 @@ describe('Canceling a request', function() {
 
       connection.execSqlBatch(request);
 
-      // Cancel the request after a short delay, to ensure the request
-      // message was fully sent off and the cancellation is performed by
-      // sending an attention message, not by terminating the request
-      // message with the `IGNORE` bit set.
-      setTimeout(() => {
+      // Cancel the request once the server received the request message.
+      requestReceived.then(() => {
         connection.cancel();
-      }, 50);
+      });
     });
 
     connection.on('end', () => {
@@ -273,7 +281,7 @@ describe('Canceling a request', function() {
           await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
-          responseMessage.end(buildLoginAckToken());
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
           outgoingMessageStream.write(responseMessage);
         }
 
@@ -400,7 +408,7 @@ describe('Canceling a request', function() {
           await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
-          responseMessage.end(buildLoginAckToken());
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
           outgoingMessageStream.write(responseMessage);
         }
 
@@ -519,12 +527,12 @@ describe('Canceling a request', function() {
         });
       })());
 
-      // Cancel the bulk load once its message is being sent and the
-      // first part of the response message has arrived.
-      setTimeout(() => {
+      // Cancel the bulk load once the first part of the response message
+      // has arrived, while the bulk load message is still being sent.
+      bulkLoad.on('columnMetadata', () => {
         connection.cancel();
         signalCanceled();
-      }, 100);
+      });
     });
 
     connection.on('end', () => {

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -229,4 +229,139 @@ describe('Canceling a request', function() {
       done();
     });
   });
+
+  it('should complete the request with `ECANCEL` when canceled before the request message was fully sent', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildLoginAckToken());
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`select 1`) - the request message was canceled
+        // while it was being sent, so its final packet carries the
+        // `IGNORE` bit. The server discards the request, but still
+        // responds with a (empty) response message.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`select 2`) - no attention message is expected
+        // in between, as the canceled request was never fully sent.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual(err.code, 'ECANCEL');
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      connection.execSqlBatch(request);
+
+      // Cancel the request immediately, before the request message
+      // was fully sent off.
+      connection.cancel();
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
 });

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -56,6 +56,16 @@ function buildAttentionAckToken(): Buffer {
   return buffer;
 }
 
+/**
+ * Reads and discards all data of the given message.
+ */
+async function drainMessage(message: Message): Promise<void> {
+  const iterator = message[Symbol.asyncIterator]();
+  while (!(await iterator.next()).done) {
+    // Discard the data.
+  }
+}
+
 describe('Canceling a request', function() {
   let server: net.Server;
   let _connections: net.Socket[];
@@ -93,10 +103,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x12);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
           const responseMessage = new Message({ type: 0x12 });
@@ -109,10 +116,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x10);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end(buildLoginAckToken());
@@ -124,10 +128,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end();
@@ -140,10 +141,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
         }
 
         // ATTENTION
@@ -151,10 +149,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x06);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           // Every client request receives exactly one response message:
           // first the response to the canceled request, then a separate
@@ -174,17 +169,14 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end(buildDoneToken(7));
           outgoingMessageStream.write(responseMessage);
         }
-      } catch (err) {
-        console.log(err);
+      } catch (err: any) {
+        done(err);
       }
     });
 
@@ -219,7 +211,10 @@ describe('Canceling a request', function() {
 
       connection.execSqlBatch(request);
 
-      // Cancel the request once the request message has been sent off.
+      // Cancel the request after a short delay, to ensure the request
+      // message was fully sent off and the cancellation is performed by
+      // sending an attention message, not by terminating the request
+      // message with the `IGNORE` bit set.
       setTimeout(() => {
         connection.cancel();
       }, 50);
@@ -247,10 +242,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x12);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
           const responseMessage = new Message({ type: 0x12 });
@@ -263,10 +255,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x10);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end(buildLoginAckToken());
@@ -278,10 +267,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end();
@@ -296,10 +282,7 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end();
@@ -312,17 +295,14 @@ describe('Canceling a request', function() {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
 
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end(buildDoneToken(7));
           outgoingMessageStream.write(responseMessage);
         }
-      } catch (err) {
-        console.log(err);
+      } catch (err: any) {
+        done(err);
       }
     });
 
@@ -364,4 +344,5 @@ describe('Canceling a request', function() {
       done();
     });
   });
+
 });


### PR DESCRIPTION
This PR fixes two related defects in how a connection determines the outcome of a canceled request. Both stem from the cancellation result being inferred indirectly from unrelated state, rather than tracked explicitly.

## Canceling with `cancelTimeout: 0` corrupts the message stream

When a request is canceled after its request message was fully sent, an attention message is sent to the server, and the server responds with two messages: the (possibly cut short) response to the canceled request, followed by a separate message containing the `DONE` token that acknowledges the attention message.

Whether the connection expected that acknowledgement message was decided by checking if a cancel timer exists — using the timer as a proxy for "an attention message was sent". With `cancelTimeout: 0`, no cancel timer is ever created, so after a cancellation:

- the response to the canceled request was processed as a regular response, invoking the request's completion callback **without an error**, and
- the attention acknowledgement message was left unread in the message stream, so the **next** request consumed the leftover acknowledgement as its own response, leaving the message stream permanently misaligned from that point on.

The connection now tracks explicitly whether an attention message was sent for the active request, and the cancel timer goes back to being purely a watchdog.

## `ECANCEL` was threaded through the payload stream teardown

When a request is canceled *before* its request message was fully sent (the message is then terminated with the `IGNORE` bit set), the `ECANCEL` error was only set indirectly: the payload stream was destroyed with the error, and the payload stream's `error` event handler then stored it on the request. That indirection is unreliable:

- Destroying a payload stream that has already ended (and was auto-destroyed) is a no-op that emits no `error` event — the canceled request would then complete reporting **success**.
- The `error` event is deferred until the payload's async iterator settles, so for a payload waiting on further data (e.g. a bulk load with an idle row stream), it fires arbitrarily late.
- The error never actually reached the underlying payload stream: a stream wrapped as a payload is torn down by the async iterator machinery with its own `AbortError`, whether the outer stream is destroyed with an error or not.

The cancel handler now sets the `ECANCEL` error directly and destroys the payload stream without an error; the payload stream's `error` handler is solely responsible for genuine payload errors. Request timeouts are unaffected (`ETIMEOUT` is assigned unconditionally right after the cancellation is initiated and overrides `ECANCEL` as before).

## Testing

- New unit tests against a mock server that follows the protocol's request/response model (one response message per client request, attention acknowledgement as a standalone message):
  - canceling with `cancelTimeout: 0` completes the request with `ECANCEL` *and* the follow-up request receives its own response, proving the stream stays aligned (fails on `master`);
  - canceling before the request message was fully sent completes with `ECANCEL` and sends no attention message (pins behavior that previously depended on stream teardown internals).
- Verified against a real SQL Server 2022 instance: the full integration suite passes, including the request cancellation and bulk load tests.
