### PR TITLE
fix: clear the cancel timer when cleaning up a connection

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2140,6 +2140,7 @@ class Connection extends EventEmitter {
   cleanupConnection() {
     if (!this.closed) {
       this.clearRequestTimer();
+      this.clearCancelTimer();
       this.closeConnection();
 
       process.nextTick(() => {

--- a/test/unit/connection-cancel-timer-test.ts
+++ b/test/unit/connection-cancel-timer-test.ts
@@ -28,11 +28,27 @@ function buildLoginAckToken(): Buffer {
 
 // Consume and discard a message's data so the iterator can advance to the
 // next incoming message.
+//
+// This drives the async iterator explicitly rather than using `for await...of`
+// because the project's eslint config (`no-unused-vars` + `no-void`) rejects an
+// unused loop binding.
 async function drainMessage(message: AsyncIterable<Buffer>): Promise<void> {
   const iterator = message[Symbol.asyncIterator]();
   while (!(await iterator.next()).done) {
     // Discard each chunk.
   }
+}
+
+// Read the next message the client sends, assert its TDS packet type, and drain
+// its payload. Guards against the message stream ending unexpectedly, so a
+// premature end surfaces as a clear assertion failure rather than a `TypeError`
+// on `message.type`.
+async function expectMessage(iterator: AsyncIterableIterator<Message>, expectedType: number): Promise<void> {
+  const { value: message, done } = await iterator.next();
+  assert.isNotOk(done, 'expected another message from the client, but the stream ended');
+  assert.isDefined(message, 'expected a message from the client, but received none');
+  assert.strictEqual(message.type, expectedType);
+  await drainMessage(message);
 }
 
 describe('Connection cancel timer handling', function() {
@@ -102,11 +118,8 @@ describe('Connection cancel timer handling', function() {
 
       try {
         // PRELOGIN
+        await expectMessage(messageIterator, 0x12);
         {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x12);
-          await drainMessage(message);
-
           const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
           const responseMessage = new Message({ type: 0x12 });
           responseMessage.end(responsePayload.data);
@@ -114,36 +127,26 @@ describe('Connection cancel timer handling', function() {
         }
 
         // LOGIN7
+        await expectMessage(messageIterator, 0x10);
         {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x10);
-          await drainMessage(message);
-
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end(buildLoginAckToken());
           outgoingMessageStream.write(responseMessage);
         }
 
         // SQL Batch (Initial SQL)
+        await expectMessage(messageIterator, 0x01);
         {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x01);
-          await drainMessage(message);
-
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end();
           outgoingMessageStream.write(responseMessage);
         }
 
-        // The client is now logged in and will issue a request. Read the request
-        // message in full - completing the read means the client finished sending
-        // it, so the "cancel after request sent" path (which sends an attention
-        // message and arms the cancel timer) is now wired up.
-        {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x03); // RPC_REQUEST
-          await drainMessage(message);
-        }
+        // The client is now logged in and will issue a request. Reading the
+        // request message in full means the client finished sending it, so the
+        // "cancel after request sent" path (which sends an attention message and
+        // arms the cancel timer) is now wired up.
+        await expectMessage(messageIterator, 0x03); // RPC_REQUEST
 
         // Cancel the in-flight request from the client side. This sends an
         // attention message to the server and arms the cancel timer.
@@ -151,11 +154,7 @@ describe('Connection cancel timer handling', function() {
 
         // Read the attention message the client sends. Once we have it, we know
         // the cancel timer has been armed on the client.
-        {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x06); // ATTENTION
-          await drainMessage(message);
-        }
+        await expectMessage(messageIterator, 0x06); // ATTENTION
 
         // Send the (cut short) response to the canceled request so the client
         // moves into its `SentAttention` state, waiting for the attention

--- a/test/unit/connection-cancel-timer-test.ts
+++ b/test/unit/connection-cancel-timer-test.ts
@@ -1,0 +1,232 @@
+import { assert } from 'chai';
+import * as net from 'net';
+import { Connection, Request } from '../../src/tedious';
+import IncomingMessageStream from '../../src/incoming-message-stream';
+import OutgoingMessageStream from '../../src/outgoing-message-stream';
+import Debug from '../../src/debug';
+import PreloginPayload from '../../src/prelogin-payload';
+import Message from '../../src/message';
+
+function buildLoginAckToken(): Buffer {
+  const progname = 'Tedious SQL Server';
+
+  const buffer = Buffer.from([
+    0xAD, // Type
+    0x00, 0x00, // Length
+    0x00, // interface number - SQL
+    0x74, 0x00, 0x00, 0x04, // TDS version number
+    Buffer.byteLength(progname, 'ucs2') / 2, ...Buffer.from(progname, 'ucs2'), // Progname
+    0x00, // major
+    0x00, // minor
+    0x00, 0x00, // buildNum
+  ]);
+
+  buffer.writeUInt16LE(buffer.length - 3, 1);
+
+  return buffer;
+}
+
+describe('Connection cancel timer handling', function() {
+  let server: net.Server;
+  let _connections: net.Socket[];
+
+  beforeEach(function(done) {
+    _connections = [];
+    server = net.createServer();
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function(done) {
+    _connections.forEach((connection) => {
+      connection.destroy();
+    });
+
+    server.close(done);
+  });
+
+  // Regression test for a leaked cancel timer.
+  //
+  // When a request is canceled after its request message was fully sent, an
+  // attention message is sent to the server and a cancel timer is armed as a
+  // watchdog. If the connection is then torn down (e.g. via `close`) before the
+  // server's attention acknowledgement arrives, `cleanupConnection` used to
+  // clear the request timer but not the cancel timer. The orphaned cancel timer
+  // would later fire in the `Final` state, where `dispatchEvent('socketError')`
+  // has no handler and therefore emits a spurious `error` event - long after the
+  // connection has already emitted `end`.
+  it('does not emit a spurious cancel-timeout error when closed while a cancel is in flight', function(done) {
+    const cancelTimeout = 150;
+
+    // The time `connection.close()` was called, and the delays (relative to it)
+    // at which `error` events were observed on the client connection.
+    let closeTime: number | undefined;
+    const errorDelays: number[] = [];
+
+    let finished = false;
+    const finish = (err?: Error) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      done(err);
+    };
+
+    server.on('connection', async (socket) => {
+      _connections.push(socket);
+
+      // The client closes its socket abruptly as part of this test, which
+      // surfaces as an `ECONNRESET` on the server socket. Swallow it so it
+      // does not bubble up as an unhandled error.
+      socket.on('error', () => { /* ignore */ });
+
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      socket.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(socket);
+
+      const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+      try {
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildLoginAckToken());
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // The client is now logged in and will issue a request. Read the request
+        // message in full - completing the read means the client finished sending
+        // it, so the "cancel after request sent" path (which sends an attention
+        // message and arms the cancel timer) is now wired up.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x03); // RPC_REQUEST
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+        }
+
+        // Cancel the in-flight request from the client side. This sends an
+        // attention message to the server and arms the cancel timer.
+        connection.cancel();
+
+        // Read the attention message the client sends. Once we have it, we know
+        // the cancel timer has been armed on the client.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06); // ATTENTION
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+        }
+
+        // Send the (cut short) response to the canceled request so the client
+        // moves into its `SentAttention` state, waiting for the attention
+        // acknowledgement...
+        {
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // ...but never send the acknowledgement. Instead, close the connection
+        // while the cancel is still in flight and the cancel timer is armed.
+        setImmediate(() => {
+          closeTime = Date.now();
+          connection.close();
+        });
+
+        // Give the (leaked) cancel timer well over `cancelTimeout` to fire.
+        //
+        // Tearing down a connection that is waiting on a response surfaces an
+        // immediate "connection lost" socket error, so we cannot simply assert
+        // that no `error` is emitted. Instead we rely on timing: any error
+        // caused by the teardown itself arrives within a few milliseconds of
+        // `close()`, whereas the orphaned cancel timer only fires roughly
+        // `cancelTimeout` later. An error observed well after `close()` can
+        // therefore only have come from the leaked timer.
+        setTimeout(() => {
+          const lateError = errorDelays.some((delay) => delay >= cancelTimeout / 2);
+
+          if (lateError) {
+            finish(new Error('A spurious error was emitted ~' + cancelTimeout + 'ms after the connection was closed (leaked cancel timer).'));
+          } else {
+            finish();
+          }
+        }, cancelTimeout + 150);
+      } catch (err) {
+        finish(err as Error);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: cancelTimeout
+      }
+    });
+
+    // Record when (relative to `close()`) each `error` event arrives. Errors
+    // emitted before `close()` are not relevant to this test.
+    connection.on('error', () => {
+      if (closeTime !== undefined) {
+        errorDelays.push(Date.now() - closeTime);
+      }
+    });
+
+    connection.connect((err) => {
+      if (err) {
+        return finish(err);
+      }
+
+      const request = new Request('SELECT 1', () => {
+        // The request is expected to complete with an `ECLOSE` error once the
+        // connection is closed. Nothing to assert here.
+      });
+
+      connection.execSql(request);
+    });
+  });
+});

--- a/test/unit/connection-cancel-timer-test.ts
+++ b/test/unit/connection-cancel-timer-test.ts
@@ -26,18 +26,27 @@ function buildLoginAckToken(): Buffer {
   return buffer;
 }
 
+// Consume and discard a message's data so the iterator can advance to the
+// next incoming message.
+async function drainMessage(message: AsyncIterable<Buffer>): Promise<void> {
+  const iterator = message[Symbol.asyncIterator]();
+  while (!(await iterator.next()).done) {
+    // Discard each chunk.
+  }
+}
+
 describe('Connection cancel timer handling', function() {
   let server: net.Server;
-  let _connections: net.Socket[];
+  let serverConnections: net.Socket[];
 
   beforeEach(function(done) {
-    _connections = [];
+    serverConnections = [];
     server = net.createServer();
     server.listen(0, '127.0.0.1', done);
   });
 
   afterEach(function(done) {
-    _connections.forEach((connection) => {
+    serverConnections.forEach((connection) => {
       connection.destroy();
     });
 
@@ -55,12 +64,15 @@ describe('Connection cancel timer handling', function() {
   // has no handler and therefore emits a spurious `error` event - long after the
   // connection has already emitted `end`.
   it('does not emit a spurious cancel-timeout error when closed while a cancel is in flight', function(done) {
-    const cancelTimeout = 150;
+    const cancelTimeout = 300;
 
     // The time `connection.close()` was called, and the delays (relative to it)
     // at which `error` events were observed on the client connection.
     let closeTime: number | undefined;
     const errorDelays: number[] = [];
+
+    // The error the in-flight request completed with.
+    let requestError: (Error & { code?: string }) | null | undefined;
 
     let finished = false;
     const finish = (err?: Error) => {
@@ -72,7 +84,7 @@ describe('Connection cancel timer handling', function() {
     };
 
     server.on('connection', async (socket) => {
-      _connections.push(socket);
+      serverConnections.push(socket);
 
       // The client closes its socket abruptly as part of this test, which
       // surfaces as an `ECONNRESET` on the server socket. Swallow it so it
@@ -93,10 +105,7 @@ describe('Connection cancel timer handling', function() {
         {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x12);
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
           const responseMessage = new Message({ type: 0x12 });
@@ -108,10 +117,7 @@ describe('Connection cancel timer handling', function() {
         {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x10);
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end(buildLoginAckToken());
@@ -122,10 +128,7 @@ describe('Connection cancel timer handling', function() {
         {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x01);
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
 
           const responseMessage = new Message({ type: 0x04 });
           responseMessage.end();
@@ -139,10 +142,7 @@ describe('Connection cancel timer handling', function() {
         {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x03); // RPC_REQUEST
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
         }
 
         // Cancel the in-flight request from the client side. This sends an
@@ -154,10 +154,7 @@ describe('Connection cancel timer handling', function() {
         {
           const { value: message } = await messageIterator.next();
           assert.strictEqual(message.type, 0x06); // ATTENTION
-          const chunks: Buffer[] = [];
-          for await (const data of message) {
-            chunks.push(data);
-          }
+          await drainMessage(message);
         }
 
         // Send the (cut short) response to the canceled request so the client
@@ -178,20 +175,22 @@ describe('Connection cancel timer handling', function() {
 
         // Give the (leaked) cancel timer well over `cancelTimeout` to fire.
         //
-        // Tearing down a connection that is waiting on a response surfaces an
+        // Tearing down a connection that is waiting on a response may surface an
         // immediate "connection lost" socket error, so we cannot simply assert
         // that no `error` is emitted. Instead we rely on timing: any error
         // caused by the teardown itself arrives within a few milliseconds of
         // `close()`, whereas the orphaned cancel timer only fires roughly
-        // `cancelTimeout` later. An error observed well after `close()` can
-        // therefore only have come from the leaked timer.
+        // `cancelTimeout` later. With a `cancelTimeout` of 300ms, an error
+        // observed 150ms or more after `close()` is comfortably separated from
+        // teardown noise and can only have come from the leaked timer.
         setTimeout(() => {
-          const lateError = errorDelays.some((delay) => delay >= cancelTimeout / 2);
-
-          if (lateError) {
-            finish(new Error('A spurious error was emitted ~' + cancelTimeout + 'ms after the connection was closed (leaked cancel timer).'));
-          } else {
+          try {
+            const lateError = errorDelays.some((delay) => delay >= cancelTimeout / 2);
+            assert.isFalse(lateError, 'a spurious error was emitted ~' + cancelTimeout + 'ms after the connection was closed (leaked cancel timer)');
+            assert.strictEqual(requestError?.code, 'ECLOSE', 'the in-flight request should complete with an ECLOSE error');
             finish();
+          } catch (assertionError) {
+            finish(assertionError as Error);
           }
         }, cancelTimeout + 150);
       } catch (err) {
@@ -221,9 +220,8 @@ describe('Connection cancel timer handling', function() {
         return finish(err);
       }
 
-      const request = new Request('SELECT 1', () => {
-        // The request is expected to complete with an `ECLOSE` error once the
-        // connection is closed. Nothing to assert here.
+      const request = new Request('SELECT 1', (reqErr) => {
+        requestError = reqErr as (Error & { code?: string }) | null | undefined;
       });
 
       connection.execSql(request);

--- a/test/unit/connection-cancel-timer-test.ts
+++ b/test/unit/connection-cancel-timer-test.ts
@@ -28,13 +28,9 @@ function buildLoginAckToken(): Buffer {
 
 // Consume and discard a message's data so the iterator can advance to the
 // next incoming message.
-//
-// This drives the async iterator explicitly rather than using `for await...of`
-// because the project's eslint config (`no-unused-vars` + `no-void`) rejects an
-// unused loop binding.
 async function drainMessage(message: AsyncIterable<Buffer>): Promise<void> {
-  const iterator = message[Symbol.asyncIterator]();
-  while (!(await iterator.next()).done) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of message) {
     // Discard each chunk.
   }
 }


### PR DESCRIPTION
## Problem

When a request is canceled after its request message was fully sent, an attention message is sent to the server and a cancel timer is armed as a watchdog (`_cancelAfterRequestSent` → `createCancelTimer`). That timer is only ever cleared on the happy path — when the attention acknowledgement is received (`SentAttention`), or when it is replaced by a newer timer.

`cleanupConnection` cleared the request timer but **not** the cancel timer. So if the connection was torn down while a cancel was still in flight — via `close()`, a socket error, or the socket closing — the armed cancel timer was leaked.

It would later fire in the `Final` state, where `dispatchEvent('socketError')` has no handler and instead emits an `error` event (and calls `close()` again) — long after the connection had already emitted `end`. With no remaining `error` listener, this crashes the process with an unhandled `error` event.

## Fix

Clear the cancel timer in `cleanupConnection`, alongside the request timer, so it can never outlive the connection:

```js
cleanupConnection() {
  if (!this.closed) {
    this.clearRequestTimer();
    this.clearCancelTimer();   // ← added
    this.closeConnection();
    ...
```

The legitimate cancel watchdog path is unaffected: there the timer fires (and tears the connection down) *before* cleanup runs, so clearing it during cleanup is a no-op in that case.

## Testing

Adds `test/unit/connection-cancel-timer-test.ts`, a mock-server regression test that logs in, issues a request, cancels it (arming the cancel timer via the attention message), then `close()`s the connection while the cancel is in flight.

Detection is timing-based: tearing down a connection that is waiting on a response surfaces an immediate "connection lost" error, whereas the orphaned cancel timer only fires ~`cancelTimeout` later — so an error observed well after `close()` can only be the leaked timer.

- **Without the fix:** fails (`a spurious error was emitted ~150ms after the connection was closed`)
- **With the fix:** passes
- Full unit suite remains green.