### PR TITLE
chore(deps): update Node 18-compatible dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@azure/core-auth": "^1.7.2",
         "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.6.5",
+        "@js-joda/core": "^6.0.1",
         "@types/node": ">=18",
         "bl": "^6.1.4",
         "iconv-lite": "^0.7.0",
@@ -39,7 +39,7 @@
         "@typescript-eslint/eslint-plugin": "^8.46.3",
         "@typescript-eslint/parser": "^8.46.3",
         "async": "^3.2.6",
-        "babel-plugin-istanbul": "^7.0.1",
+        "babel-plugin-istanbul": "^8.0.0",
         "chai": "^4.5.0",
         "codecov": "^3.8.3",
         "eslint": "^9.39.1",
@@ -48,9 +48,9 @@
         "nyc": "^17.1.0",
         "rimraf": "^5.0.10",
         "semantic-release": "^22.0.12",
-        "sinon": "^21.0.0",
+        "sinon": "^22.0.0",
         "typedoc": "^0.28.14",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18.17"
@@ -2510,9 +2510,9 @@
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.7.0.tgz",
-      "integrity": "sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-6.0.1.tgz",
+      "integrity": "sha512-Iev3Cfa3MC+06JXXeFzSLew/7yeCXLMhjesyH/BD4EQYlUUDV49Ln3s8hd7p5XK5UesO/dO3K1LFJ7RT7v0Ddg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -3920,9 +3920,9 @@
       }
     },
     "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-8.0.0.tgz",
+      "integrity": "sha512-18wCskrN3DgbuBmp1gr7LBGT8xdz5xhQQqFvFhVxbkl8VBCrMKQ2YtqBWtUal1Zrc1HTuX0011+Brjw78TCFkg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "workspaces": [
@@ -3933,10 +3933,80 @@
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-instrument": "^6.0.2",
-        "test-exclude": "^6.0.0"
+        "test-exclude": "^7.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -13317,16 +13387,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "21.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.1.2.tgz",
-      "integrity": "sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
+      "integrity": "sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.3.2",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@sinonjs/samsam": "^10.0.2",
-        "diff": "^8.0.4"
+        "diff": "^9.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13334,9 +13404,9 @@
       }
     },
     "node_modules/sinon/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -14245,9 +14315,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@azure/core-auth": "^1.7.2",
     "@azure/identity": "^4.2.1",
     "@azure/keyvault-keys": "^4.4.0",
-    "@js-joda/core": "^5.6.5",
+    "@js-joda/core": "^6.0.1",
     "@types/node": ">=18",
     "bl": "^6.1.4",
     "iconv-lite": "^0.7.0",
@@ -79,7 +79,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.46.3",
     "async": "^3.2.6",
-    "babel-plugin-istanbul": "^7.0.1",
+    "babel-plugin-istanbul": "^8.0.0",
     "chai": "^4.5.0",
     "codecov": "^3.8.3",
     "eslint": "^9.39.1",
@@ -88,9 +88,9 @@
     "nyc": "^17.1.0",
     "rimraf": "^5.0.10",
     "semantic-release": "^22.0.12",
-    "sinon": "^21.0.0",
+    "sinon": "^22.0.0",
     "typedoc": "^0.28.14",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "docs": "typedoc",

--- a/tsconfig.build-types.json
+++ b/tsconfig.build-types.json
@@ -8,7 +8,8 @@
     // Enable features needed for type declaration generation
     "declaration": true,
     "emitDeclarationOnly": true,
-    "declarationDir": "lib"
+    "declarationDir": "lib",
+    "rootDir": "./src"
   },
 
   "include": ["types/*.d.ts", "src/tedious.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "target": "esnext",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "types": [ "node", "mocha" ],
     "allowJs": true,
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
## Summary

Updates the outdated dependencies whose latest versions still support the current Node floor (`>=18.17`). Dependencies whose latest releases now require Node ≥20 are intentionally left alone.

### Updated
- `@js-joda/core` `^5.6.5` → `^6.0.1` (major)
- `babel-plugin-istanbul` `^7.0.1` → `^8.0.0` (major)
- `sinon` `^21.0.0` → `^22.0.0` (major)
- `typescript` `^5.9.3` → `^6.0.3` (major)

### TypeScript 6 config adaptations
TS 6 introduced breaking changes that required tsconfig updates:
- `types: ["node", "mocha"]` — TS6 changed the default `types` from "all of `@types`" to `[]`; without this, ~1,500 references to mocha/Node globals (`describe`, `it`, `process`, …) fail to resolve.
- `ignoreDeprecations: "6.0"` — keeps `moduleResolution: "node"` (node10) working; TS6 deprecates it ahead of removal in TS7.
- `rootDir: "./src"` in `tsconfig.build-types.json` — now required explicitly to preserve the existing flat `lib/*.d.ts` output layout.

### Left untouched (would drop Node 18 support)
Latest versions require Node ≥20: `@azure/core-auth`, `@azure/identity`, `@azure/keyvault-keys`, `bl`, `eslint`, `nyc`, `rimraf`, `semantic-release`. `chai` 5/6 is ESM-only and out of scope here.

## Test plan
- [x] `npm run lint` (eslint + tsc) — clean
- [x] `npm test` — 394 unit tests passing
- [x] `npm run build` (babel + d.ts emit) — succeeds, `lib/tedious.d.ts` generated correctly
- [ ] Integration tests — not run locally (require a live SQL Server)

> Note: `@js-joda/core` 6 and `sinon` 22 are major bumps. The full unit suite and build pass, but their changelogs are worth a glance before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)