### PR TITLE
ci: restore npm auth for dist-tag promotion in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     - cron: '0 12 * * *'
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -20,11 +19,14 @@ jobs:
       with:
         node-version: "20"
         cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Update npm
       run: npm install -g npm@latest
 
     - name: Tag latest release
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
         read next latest <<< $(npm info tedious --json | jq -r '."dist-tags".next, ."dist-tags".latest')
         if [ "$(printf '%s\n' "$latest" "$next" | sort -V | tail -n 1)" != "$latest" ]; then


### PR DESCRIPTION
## Problem

The nightly **Release** workflow (`.github/workflows/release.yml`) has been failing on every scheduled run since #1710. It promotes the `next` dist-tag to `latest` once the `next` release is over a week old via:

```bash
npm dist-tag add "tedious@$next" latest
```

That call fails with:

```
npm error code E401
npm error 401 Unauthorized - PUT https://registry.npmjs.org/-/package/tedious/dist-tags/latest
```

(See the failed run: https://github.com/tediousjs/tedious/actions/runs/27873844265/job/82489984649)

## Root cause

PR #1710 ("ci: update to use oidc tokens for publishing") removed the `NPM_TOKEN` `.npmrc` line from this job and added `id-token: write`, on the assumption that OIDC trusted publishing would authenticate the `dist-tag` call.

However, **npm Trusted Publishing with OIDC only authorizes `npm publish`** — it does **not** cover `npm dist-tag add`:

- npm Trusted Publishers docs list `npm publish` as the only supported command.
- Open request to add dist-tag support: [npm/cli#8547](https://github.com/npm/cli/issues/8547) (still unresolved).

So the job has had no credentials at all since #1710, hence the 401.

## Fix

- Add `registry-url: 'https://registry.npmjs.org'` to the `setup-node` step so it writes an `.npmrc` that reads the token from `NODE_AUTH_TOKEN`.
- Set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on the "Tag latest release" step so `npm dist-tag add` is authenticated.
- Drop the now-unused `id-token: write` permission, since nothing in this workflow uses OIDC.

The OIDC-based publish in `nodejs.yml` (`semantic-release`) is unaffected — trusted publishing still works there for the actual `npm publish`.

## ⚠️ Requires

This assumes the `NPM_TOKEN` repo secret still exists and is a **publish-capable** token (granular/automation token with write access to `tedious`). If it was revoked during the tokenless migration in #1710, a new token must be minted and set as `NPM_TOKEN` for this to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)