### PR TITLE
ci: allow the Release workflow to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   schedule:
     - cron: '0 12 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add a `workflow_dispatch` trigger to the **Release** workflow alongside the existing nightly `schedule`, so the dist-tag promotion can be run on demand.

This is a useful follow-up to #1743 (which restored npm auth for the `npm dist-tag add` step): once this is on `master`, a **"Run workflow"** button appears on the workflow's Actions page, letting maintainers verify the release auth without waiting for the 12:00 UTC cron.

```yaml
on:
  schedule:
    - cron: '0 12 * * *'
  workflow_dispatch:
```

Note: `workflow_dispatch` only becomes available after this file lands on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)