### PR TITLE
ci: publish master releases to the next dist-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,23 @@
     "tag": "next",
     "provenance": true
   },
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      {
+        "name": "master",
+        "channel": "next"
+      },
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ]
+  },
   "dependencies": {
     "@azure/core-auth": "^1.7.2",
     "@azure/identity": "^4.2.1",


### PR DESCRIPTION
## Problem

The nightly **Release** workflow promotes the `next` dist-tag to `latest` after a 7-day soak — it assumes new releases are published to `next` first. They aren't.

With no `release` config in `package.json`, `semantic-release` runs on defaults and publishes the `master` branch to the **default channel**, which `@semantic-release/npm` resolves to `--tag latest`:

```js
// node_modules/@semantic-release/npm/lib/get-channel.js
export default function (channel) {
  return channel ? (semver.validRange(channel) ? `release-${channel}` : channel) : "latest";
}
```

`channel` is `undefined` for `master` → `getChannel(undefined)` → `"latest"`. The `"publishConfig": { "tag": "next" }` is overridden by that explicit `--tag latest`, so it never takes effect.

### Symptoms

- The `next` dist-tag has been frozen at **19.1.3** (2025-11-15) — the last release before this drift started.
- The nightly promotion job (once its auth was fixed in #1743) just keeps re-pinning `latest` to that stale 19.1.3.
- Newer releases **19.2.0** (2025-12-22) and **19.2.1** (2026-02-09) ended up on **no dist-tag at all**.

So `npm install tedious` currently resolves to 19.1.3 instead of 19.2.1.

## Fix

Add an explicit `branches` config that sets the `master` channel to `next`, so the main branch publishes with `--tag next` and the nightly job can promote it to `latest`. This is the supported "main branch with a custom channel" path in semantic-release (`lib/branches/normalize.js`, `release()`: the idx-0 branch uses its configured `channel` as-is).

The maintenance (`*.x` → `release-X.x`), `beta`, and `alpha` channels are preserved to match the previous default behavior.

## Required follow-up (manual, needs publish credentials)

This config only fixes **future** releases. The current dist-tags must be repaired once by hand:

```bash
npm dist-tag add tedious@19.2.1 next
npm dist-tag add tedious@19.2.1 latest
```

## Verification

Worth confirming with a `semantic-release --dry-run` in CI on this branch before merge, to see it report the `master` release going to the `next` channel. The branch config itself validates against semantic-release's normalization rules (1 maintenance pattern, 1 release branch, 2 prerelease branches, no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)