### PR TITLE
ci: correctly read latest dist-tag in the promotion job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,18 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: |
-        read next latest <<< $(npm info tedious --json | jq -r '."dist-tags".next, ."dist-tags".latest')
+        info=$(npm info tedious --json)
+        next=$(jq -r '."dist-tags".next' <<< "$info")
+        latest=$(jq -r '."dist-tags".latest' <<< "$info")
+
+        # Only promote when `next` is strictly newer than the current `latest`.
         if [ "$(printf '%s\n' "$latest" "$next" | sort -V | tail -n 1)" != "$latest" ]; then
           date_format="%Y-%m-%dT%H:%M:%SZ"
 
-          publish_date=$(date -d $(npm info tedious --json | jq -r '.time["'"$next"'"]') +$date_format)
-          week_ago=$(date -d '-7 days' +$date_format)
+          publish_date=$(date -d "$(jq -r '.time["'"$next"'"]' <<< "$info")" +"$date_format")
+          week_ago=$(date -d '-7 days' +"$date_format")
 
+          # ...and only once it has soaked on `next` for at least a week.
           if [[ "$publish_date" < "$week_ago" || "$publish_date" == "$week_ago" ]]; then
             npm dist-tag add "tedious@$next" latest
           fi


### PR DESCRIPTION
## Problem

The nightly promotion job reads the current dist-tags like this:

```bash
read next latest <<< $(npm info tedious --json | jq -r '."dist-tags".next, ."dist-tags".latest')
```

`jq` prints the two values on **two lines**, but `read` (without `-d`) consumes only the **first** line. So `next` gets the next version and **`latest` is always empty**.

With `latest` empty, the guard

```bash
if [ "$(printf '%s\n' "$latest" "$next" | sort -V | tail -n 1)" != "$latest" ]; then
```

always evaluates true (`max("", next) != ""`), so the job unconditionally re-pins `latest` to `next` whenever `next` has been published for ≥7 days — **overwriting a newer `latest` with a stale `next`**.

This was masked while the job was failing on auth (it never reached the `dist-tag` call). Once auth was restored (#1743), the very first successful run downgraded `latest` from **19.2.1** back to the stale `next` (**19.1.3**).

## Fix

Capture `npm info` once and read each dist-tag with its own `jq` query, so `latest` is actually populated and the version comparison works again — promote only when `next` is strictly newer than `latest` *and* has soaked for a week. Also quotes the `date` command substitutions.

## Verification

Simulated the corrected logic across scenarios:

| next | latest | next age | result |
|------|--------|----------|--------|
| 19.1.3 | 19.2.1 | old | **no-op** (was: downgrade) |
| 19.3.0 | 19.2.1 | >7d | promote → 19.3.0 |
| 19.3.0 | 19.2.1 | 2d | wait |
| 19.2.1 | 19.2.1 | — | no-op |

## Context

Part of restoring the soak-on-`next` release model, together with #1745 (make semantic-release publish to the `next` dist-tag). Both are needed for the model to work; this PR ensures the promotion half never downgrades `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)