### PR TITLE
fix: complete canceled requests when the server does not respond

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3882,6 +3882,15 @@ Connection.prototype.STATE = {
     name: 'SentAttention',
     enter: function() {
       (async () => {
+        // TDS is a request-response protocol at the message level: every
+        // client message - including the attention message - receives
+        // exactly one response message. By the time we enter this state,
+        // the response to the canceled request itself was already consumed
+        // in the `SentClientRequest` state, so the single message read here
+        // is the attention message's own response, containing the attention
+        // acknowledgement. Reading more than one message would consume the
+        // response belonging to the next request and desynchronize the
+        // message stream - so don't turn this into a loop.
         let message;
         try {
           message = await this.messageIo.readMessage();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3225,6 +3225,12 @@ class Connection extends EventEmitter {
         message.ignore = true;
         message.end();
 
+        // The server responds to the ignored message like to any other
+        // request message. If that response never arrives (e.g. because
+        // the server has become unresponsive), the cancel timer ensures
+        // the canceled request still completes.
+        this.createCancelTimer();
+
         if (request instanceof Request && request.paused) {
           // resume the request if it was paused so we can read the remaining tokens
           request.resume();
@@ -3835,6 +3841,12 @@ Connection.prototype.STATE = {
           this.request?.removeListener('cancel', onCancel);
           this.request?.removeListener('pause', onPause);
           this.request?.removeListener('resume', onResume);
+
+          // If the request was canceled before its request message was
+          // fully sent, this response belongs to the ignored message and
+          // a cancel timer is running - the response's arrival is what
+          // completes the cancellation.
+          this.clearCancelTimer();
 
           this.transitionTo(this.STATE.LOGGED_IN);
           const sqlRequest = this.request as Request;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2172,15 +2172,17 @@ class Connection extends EventEmitter {
         this.emit('end');
       });
 
+      // Mark the connection as closed and detach the active request
+      // before invoking its callback, so that a callback that synchronously
+      // calls `close` does not re-enter this cleanup logic.
       const request = this.request;
-      if (request) {
-        const err = new RequestError('Connection closed before request completed.', 'ECLOSE');
-        request.callback(err);
-        this.request = undefined;
-      }
-
+      this.request = undefined;
       this.attentionSent = false;
       this.closed = true;
+
+      if (request) {
+        request.callback(new RequestError('Connection closed before request completed.', 'ECLOSE'));
+      }
     }
   }
 

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import * as net from 'net';
-import { Connection, Request, RequestError, TYPES } from '../../src/tedious';
+import { Connection, ConnectionError, Request, RequestError, TYPES } from '../../src/tedious';
 import IncomingMessageStream from '../../src/incoming-message-stream';
 import OutgoingMessageStream from '../../src/outgoing-message-stream';
 import Debug from '../../src/debug';
@@ -494,7 +494,10 @@ describe('Canceling a request', function() {
         clearTimeout(guardTimer);
 
         try {
-          assert.instanceOf(err, Error);
+          // The cancel timer tears down the connection via a synthetic
+          // socket error.
+          assert.instanceOf(err, ConnectionError);
+          assert.strictEqual((err as ConnectionError).code, 'ETIMEOUT');
         } catch (assertionError: any) {
           failure ??= assertionError;
         }
@@ -507,6 +510,150 @@ describe('Canceling a request', function() {
       // Cancel the request immediately, before the request message
       // was fully sent off.
       connection.cancel();
+
+      connection.on('end', () => {
+        done(failure);
+      });
+    });
+  });
+
+  it('should complete the request within `cancelTimeout` when the request timeout expires while the request message is being sent and the server never responds', function(done) {
+    // When the request timeout expires, the request is canceled. If the
+    // request message was not fully sent yet at that point, it is
+    // terminated with the `IGNORE` bit set and the client waits for the
+    // server's response to the ignored message. If the server never sends
+    // that response, the `cancelTimeout` backstop must kick in and fail
+    // the request - the request timeout must not leave the request
+    // pending indefinitely.
+    this.timeout(3000);
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          await drainMessage(message);
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`insert bulk ...`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // Bulk Load - the request timeout expires while the bulk load
+        // message is still being sent, so its final packet carries the
+        // `IGNORE` bit. The message is received but never responded to,
+        // like a server that has become unresponsive.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x07);
+
+          await drainMessage(message);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        requestTimeout: 200,
+        cancelTimeout: 300
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      let failure: Error | undefined;
+
+      // If the request is still pending well after `requestTimeout` plus
+      // `cancelTimeout` have elapsed, the backstop did not kick in - fail
+      // the test and close the connection ourselves so it can be torn
+      // down cleanly.
+      const guardTimer = setTimeout(() => {
+        failure = new Error('Timed out request was not completed within `cancelTimeout`');
+        connection.close();
+      }, 1500);
+
+      const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
+        clearTimeout(guardTimer);
+
+        try {
+          // The cancel timer tears down the connection via a synthetic
+          // socket error.
+          assert.instanceOf(err, ConnectionError);
+          assert.strictEqual((err as ConnectionError).code, 'ETIMEOUT');
+        } catch (assertionError: any) {
+          failure ??= assertionError;
+        }
+
+        connection.close();
+      });
+
+      bulkLoad.addColumn('a', TYPES.VarBinary, { length: 8000, nullable: false });
+
+      // A row stream that never completes, so the bulk load message is
+      // still being sent when the request timeout expires. The first row
+      // is large enough to fill a packet, so the server starts receiving
+      // the bulk load message right away.
+      connection.execBulkLoad(bulkLoad, (async function*() {
+        yield [Buffer.alloc(8000)];
+
+        await new Promise<unknown>(() => {
+          // This promise never resolves.
+        });
+      })());
 
       connection.on('end', () => {
         done(failure);

--- a/test/unit/connection-cancel-test.ts
+++ b/test/unit/connection-cancel-test.ts
@@ -396,6 +396,124 @@ describe('Canceling a request', function() {
     });
   });
 
+  it('should complete the canceled request within `cancelTimeout` when canceled before the request message was fully sent and the server never responds', function(done) {
+    // A request that is canceled before its request message was fully sent
+    // is terminated by setting the `IGNORE` bit on the message's final
+    // packet. The client then waits for the server's response to the
+    // ignored message. If the server never sends that response, the
+    // `cancelTimeout` backstop must kick in and fail the request - the
+    // request must not be left waiting indefinitely.
+    this.timeout(2000);
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          await drainMessage(message);
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`select 1`) - the request message was canceled while
+        // it was being sent, so its final packet carries the `IGNORE` bit.
+        // The message is received but never responded to, like a server
+        // that has become unresponsive.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 300
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      let failure: Error | undefined;
+
+      // If the request is still pending well after `cancelTimeout` has
+      // elapsed, the backstop did not kick in - fail the test and close
+      // the connection ourselves so it can be torn down cleanly.
+      const guardTimer = setTimeout(() => {
+        failure = new Error('Canceled request was not completed within `cancelTimeout`');
+        connection.close();
+      }, 1000);
+
+      const request = new Request('select 1', (err) => {
+        clearTimeout(guardTimer);
+
+        try {
+          assert.instanceOf(err, Error);
+        } catch (assertionError: any) {
+          failure ??= assertionError;
+        }
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request);
+
+      // Cancel the request immediately, before the request message
+      // was fully sent off.
+      connection.cancel();
+
+      connection.on('end', () => {
+        done(failure);
+      });
+    });
+  });
+
   it('should complete the request with `ECANCEL` when canceled while the request message is being sent and the response already started arriving', function(done) {
     // Used by the client side to signal to the server side that the request
     // was canceled.

--- a/test/unit/connection-close-test.ts
+++ b/test/unit/connection-close-test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import * as net from 'net';
-import { Connection, ConnectionError } from '../../src/tedious';
+import { Connection, ConnectionError, Request, RequestError } from '../../src/tedious';
 import IncomingMessageStream from '../../src/incoming-message-stream';
 import OutgoingMessageStream from '../../src/outgoing-message-stream';
 import Debug from '../../src/debug';
@@ -181,6 +181,141 @@ describe('Closing a connection while connecting', function() {
 
       // Ensure no additional `end` event is emitted afterwards.
       setImmediate(() => {
+        assert.strictEqual(endCount, 1);
+
+        done();
+      });
+    });
+  });
+});
+
+describe('Closing a connection with an active request', function() {
+  let server: net.Server;
+  let _connections: net.Socket[];
+
+  beforeEach(function(done) {
+    _connections = [];
+    server = net.createServer((connection) => {
+      _connections.push(connection);
+    });
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function(done) {
+    _connections.forEach((connection) => {
+      connection.destroy();
+    });
+
+    server.close(done);
+  });
+
+  it('should complete the request with `ECLOSE` exactly once, even when the request callback calls `close` again', function(done) {
+    // A server that responds to the full login sequence, but not to any
+    // requests made afterwards.
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message, done } = await messageIterator.next();
+          if (done) {
+            return;
+          }
+          assert.strictEqual(message.type, 0x12);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message, done } = await messageIterator.next();
+          if (done) {
+            return;
+          }
+          assert.strictEqual(message.type, 0x10);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildLoginAckToken());
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message, done } = await messageIterator.next();
+          if (done) {
+            return;
+          }
+          assert.strictEqual(message.type, 0x01);
+
+          const chunks: Buffer[] = [];
+          for await (const data of message) {
+            chunks.push(data);
+          }
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    let endCount = 0;
+    connection.on('end', () => {
+      endCount += 1;
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      let callCount = 0;
+      const request = new Request('select 1', (err) => {
+        callCount += 1;
+
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'ECLOSE');
+
+        // Calling `close` from a request callback that is invoked as part
+        // of the connection cleanup must not re-enter the cleanup logic
+        // and complete the request a second time.
+        connection.close();
+      });
+
+      connection.execSqlBatch(request);
+      connection.close();
+
+      setImmediate(() => {
+        assert.strictEqual(callCount, 1);
         assert.strictEqual(endCount, 1);
 
         done();


### PR DESCRIPTION
This fixes two hang scenarios around request cancellation and connection closing, found while reviewing `Connection` for stalls.

## Canceled requests could hang indefinitely (no cancel-timer backstop)

When a request is canceled *before* its request message was fully sent, the message is terminated with the `IGNORE` bit set and the connection then waits for the server's response to the ignored message. Unlike the attention-based cancellation path (cancel *after* the message was fully sent, via `_cancelAfterRequestSent`), this path never armed the cancel timer. If the server never responds - e.g. it has become unresponsive - the request callback is never invoked: the request timer was already consumed by the cancellation, TCP keep-alive only detects a dead peer, and nothing else is pending. This also means `requestTimeout` did not actually bound a request against a hung server, since the timeout itself cancels the request through this path.

The fix arms the cancel timer when terminating the request message with the `IGNORE` bit, and clears it when the response to the ignored message arrives, mirroring the attention-based path (which clears it upon receiving the attention acknowledgement).

## Re-entrant connection cleanup on `close` from a request callback

`cleanupConnection` invoked the active request's callback *before* clearing `request` and setting the `closed` flag. A request callback that synchronously calls `connection.close()` would re-enter the cleanup logic and invoke the same callback again, recursing until the call stack overflows. The fix marks the connection as closed and detaches the request before invoking the callback.

One minor behavioral note (not visible in the tests): before this change, `connection.closed` was `false` while the `ECLOSE` request callback ran; now it is `true`. This seems like the more correct behavior - the connection *is* closing - but if any downstream code inspects `connection.closed` from within a request callback, this is a subtle observable change.

## Tests

Both fixes come with tests following the existing mock-server pattern:

- `test/unit/connection-cancel-test.ts`: cancels a request before its message was fully sent, against a server that never responds to the ignored message. Fails with "Canceled request was not completed within `cancelTimeout`" before the fix; completes within `cancelTimeout` (~300ms) with a `ConnectionError` with code `ETIMEOUT` after.
- `test/unit/connection-cancel-test.ts`: lets the request timeout expire while a bulk load message is still being sent, against a server that never responds to the ignored message - covering the `requestTimeout` path, which cancels the request through the same `IGNORE`-bit path. Fails the same way before the fix; completes within `requestTimeout` plus `cancelTimeout` (~500ms) after.
- `test/unit/connection-close-test.ts`: closes a connection with an active request, where the request callback synchronously calls `close` again. Fails with `RangeError: Maximum call stack size exceeded` before the fix; asserts the callback runs exactly once with `ECLOSE` and `end` is emitted exactly once after.

Also includes a `docs` commit adding a comment to the `SentAttention` state explaining that TDS is a request-response protocol at the message level, so the single `readMessage` call there is intentional and must not be turned into a read loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

