### PR TITLE
docs: align trustServerCertificate default value in docstring

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -838,7 +838,7 @@ export interface ConnectionOptions {
    * the driver raises an error and terminates the connection. Make sure the value passed to serverName exactly
    * matches the Common Name (CN) or DNS name in the Subject Alternate Name in the server certificate for an SSL connection to succeed.
    *
-   * (default: `true`)
+   * (default: `false`)
    */
   trustServerCertificate?: boolean;
 


### PR DESCRIPTION
Small change to the JSDoc comment on trustServerCertificate. The default value of this used to be true, but was changed to false in #1464. The comment was never updated and led to some confusion internally so I thought I'd align the docs.
