### PR TITLE
ci: run Windows tests against SQL Server 2025

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -120,13 +120,13 @@ jobs:
 
     strategy:
       matrix:
-        mssql-version: [2016, 2017, 2019, 2022]
+        mssql-version: [2016, 2017, 2019, 2022, 2025]
         node-version: [22.x, 24.x, 26.x]
       fail-fast: false
 
     steps:
     - name: Install SQL Server ${{ matrix.mssql-version }}
-      uses: tediousjs/setup-sqlserver@v2
+      uses: tediousjs/setup-sqlserver@v4
       with:
         sqlserver-version: ${{ matrix.mssql-version }}
         install-updates: true


### PR DESCRIPTION
## Summary

- Add SQL Server 2025 to the Windows CI test matrix (now 2016, 2017, 2019, 2022, 2025).
- Update `tediousjs/setup-sqlserver` from `@v2` to `@v4` — SQL Server 2025 support was added in [v3.1.0](https://github.com/tediousjs/setup-sqlserver/releases/tag/v3.1.0) of that action. The v3/v4 breaking changes only affect the action's own runtime (Node 24, ESM rewrite); its inputs are unchanged, so this is a drop-in upgrade.

## Notes

- The Linux job already tests against SQL Server 2025 via the `mcr.microsoft.com/mssql/server:2025-latest` container image in `test/Dockerfile`, so no changes were needed there.
- The workflow passes `install-updates: true`, and Microsoft has not published cumulative updates for SQL Server 2025 yet — the action handles this gracefully by logging "Skipping update installation" instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)