### PR TITLE
fix: cap TLS max send fragment size for encrypt: "strict" connections

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2237,7 +2237,22 @@ class Connection extends EventEmitter {
 
       try {
         const onError = reject;
-        const onConnect = () => { resolve(encryptsocket); };
+        const onConnect = () => {
+          // Without this, Node's TLS layer is free to coalesce multiple back-to-back
+          // TDS packet writes into a single, larger TLS record. The non-strict `startTls`
+          // path (message-io.ts) caps max send fragment to the TDS packet size for the
+          // same reason; `wrapWithTls` (TDS 8.0 / encrypt: "strict") must match it.
+          //
+          // Without this fix, a LOGIN7 spanning multiple TDS packets (e.g. any FedAuth
+          // login carrying an Entra ID access token, which routinely exceeds one 4KB
+          // packet) reliably fails with ECONNRESET against Azure SQL once TLS is
+          // negotiated but before LOGINACK — see
+          // https://github.com/tediousjs/tedious/issues/1182. Single-packet logins
+          // (e.g. plain SQL auth with short credentials) are unaffected either way,
+          // which is why this bug reads as "FedAuth-specific" until you look closer.
+          encryptsocket.setMaxSendFragment(this.config.options.packetSize);
+          resolve(encryptsocket);
+        };
 
         encryptsocket.once('error', onError);
         encryptsocket.once('secureConnect', onConnect);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -173,6 +173,11 @@ const DEFAULT_CONNECT_RETRY_INTERVAL = 500;
  */
 const DEFAULT_PACKET_SIZE = 4 * 1024;
 /**
+ * Node's `tls.TLSSocket#setMaxSendFragment` silently ignores values outside this range.
+ * @private
+ */
+const MAX_TLS_SEND_FRAGMENT_SIZE = 16384;
+/**
  * @private
  */
 const DEFAULT_TEXTSIZE = 2147483647;
@@ -2250,7 +2255,11 @@ class Connection extends EventEmitter {
           // https://github.com/tediousjs/tedious/issues/1182. Single-packet logins
           // (e.g. plain SQL auth with short credentials) are unaffected either way,
           // which is why this bug reads as "FedAuth-specific" until you look closer.
-          encryptsocket.setMaxSendFragment(this.config.options.packetSize);
+          //
+          // `setMaxSendFragment` silently no-ops for values outside 512-16384, so a
+          // `packetSize` above that (e.g. 32767, commonly used for bulk load) has to be
+          // clamped or it would leave the cap unset and reintroduce the bug it fixes.
+          encryptsocket.setMaxSendFragment(Math.min(this.config.options.packetSize, MAX_TLS_SEND_FRAGMENT_SIZE));
           resolve(encryptsocket);
         };
 
@@ -2261,7 +2270,7 @@ class Connection extends EventEmitter {
           return await promise;
         } finally {
           encryptsocket.removeListener('error', onError);
-          encryptsocket.removeListener('connect', onConnect);
+          encryptsocket.removeListener('secureConnect', onConnect);
         }
       } finally {
         signal.removeEventListener('abort', onAbort);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -173,11 +173,6 @@ const DEFAULT_CONNECT_RETRY_INTERVAL = 500;
  */
 const DEFAULT_PACKET_SIZE = 4 * 1024;
 /**
- * Node's `tls.TLSSocket#setMaxSendFragment` silently ignores values outside this range.
- * @private
- */
-const MAX_TLS_SEND_FRAGMENT_SIZE = 16384;
-/**
  * @private
  */
 const DEFAULT_TEXTSIZE = 2147483647;
@@ -2259,7 +2254,7 @@ class Connection extends EventEmitter {
           // `setMaxSendFragment` silently no-ops for values outside 512-16384, so a
           // `packetSize` above that (e.g. 32767, commonly used for bulk load) has to be
           // clamped or it would leave the cap unset and reintroduce the bug it fixes.
-          encryptsocket.setMaxSendFragment(Math.min(this.config.options.packetSize, MAX_TLS_SEND_FRAGMENT_SIZE));
+          encryptsocket.setMaxSendFragment(Math.min(this.config.options.packetSize, MessageIO.MAX_TLS_SEND_FRAGMENT_SIZE));
           resolve(encryptsocket);
         };
 

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -13,10 +13,12 @@ import { TYPE } from './packet';
 import IncomingMessageStream from './incoming-message-stream';
 import OutgoingMessageStream from './outgoing-message-stream';
 
-// Node's `tls.TLSSocket#setMaxSendFragment` silently ignores values outside this range.
-const MAX_TLS_SEND_FRAGMENT_SIZE = 16384;
-
 class MessageIO extends EventEmitter {
+  // Node's `tls.TLSSocket#setMaxSendFragment` silently ignores values outside this range.
+  // (A static class property rather than a named export, as the `module.exports`
+  // assignment at the bottom of this file would clobber named exports for CJS consumers.)
+  static readonly MAX_TLS_SEND_FRAGMENT_SIZE = 16384;
+
   declare socket: Socket;
   declare debug: Debug;
 
@@ -56,7 +58,7 @@ class MessageIO extends EventEmitter {
       this.outgoingMessageStream.packetSize = packetSize;
     }
 
-    const maxSendFragment = Math.min(this.outgoingMessageStream.packetSize, MAX_TLS_SEND_FRAGMENT_SIZE);
+    const maxSendFragment = Math.min(this.outgoingMessageStream.packetSize, MessageIO.MAX_TLS_SEND_FRAGMENT_SIZE);
 
     if (this.securePair) {
       // Classic `encrypt: true` path: TLS is layered over a `DuplexPair`.
@@ -115,7 +117,7 @@ class MessageIO extends EventEmitter {
 
         this.emit('secure', securePair.cleartext);
 
-        securePair.cleartext.setMaxSendFragment(Math.min(this.outgoingMessageStream.packetSize, MAX_TLS_SEND_FRAGMENT_SIZE));
+        securePair.cleartext.setMaxSendFragment(Math.min(this.outgoingMessageStream.packetSize, MessageIO.MAX_TLS_SEND_FRAGMENT_SIZE));
 
         this.outgoingMessageStream.unpipe(this.socket);
         this.socket.unpipe(this.incomingMessageStream);

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -13,6 +13,9 @@ import { TYPE } from './packet';
 import IncomingMessageStream from './incoming-message-stream';
 import OutgoingMessageStream from './outgoing-message-stream';
 
+// Node's `tls.TLSSocket#setMaxSendFragment` silently ignores values outside this range.
+const MAX_TLS_SEND_FRAGMENT_SIZE = 16384;
+
 class MessageIO extends EventEmitter {
   declare socket: Socket;
   declare debug: Debug;
@@ -53,8 +56,16 @@ class MessageIO extends EventEmitter {
       this.outgoingMessageStream.packetSize = packetSize;
     }
 
+    const maxSendFragment = Math.min(this.outgoingMessageStream.packetSize, MAX_TLS_SEND_FRAGMENT_SIZE);
+
     if (this.securePair) {
-      this.securePair.cleartext.setMaxSendFragment(this.outgoingMessageStream.packetSize);
+      // Classic `encrypt: true` path: TLS is layered over a `DuplexPair`.
+      this.securePair.cleartext.setMaxSendFragment(maxSendFragment);
+    } else if (this.socket instanceof tls.TLSSocket) {
+      // `encrypt: "strict"` (TDS 8.0) path: the socket itself is the TLS socket. Without
+      // this, a server-initiated packet size change (ENVCHANGE) after login would leave
+      // the original cap in place, potentially allowing oversized TLS records again.
+      this.socket.setMaxSendFragment(maxSendFragment);
     }
 
     return this.outgoingMessageStream.packetSize;
@@ -104,7 +115,7 @@ class MessageIO extends EventEmitter {
 
         this.emit('secure', securePair.cleartext);
 
-        securePair.cleartext.setMaxSendFragment(this.outgoingMessageStream.packetSize);
+        securePair.cleartext.setMaxSendFragment(Math.min(this.outgoingMessageStream.packetSize, MAX_TLS_SEND_FRAGMENT_SIZE));
 
         this.outgoingMessageStream.unpipe(this.socket);
         this.socket.unpipe(this.incomingMessageStream);

--- a/test/unit/connection-test.ts
+++ b/test/unit/connection-test.ts
@@ -1,4 +1,7 @@
 import * as net from 'net';
+import * as tls from 'tls';
+import { readFileSync } from 'fs';
+import * as sinon from 'sinon';
 import { Connection, ConnectionError } from '../../src/tedious';
 import { assert } from 'chai';
 
@@ -73,5 +76,70 @@ describe('Using `strict` encryption', function() {
     connection.on('end', () => {
       done();
     });
+  });
+
+  it('caps the TLS max send fragment size to the configured packet size', function(done) {
+    // Regression test for https://github.com/tediousjs/tedious/issues/1182.
+    //
+    // `wrapWithTls` (used only for `encrypt: "strict"`, i.e. TDS 8.0) must cap the TLS
+    // max send fragment size to the TDS packet size, the same way the classic
+    // `MessageIO#startTls` path already does. Without it, Node's TLS layer is free to
+    // coalesce multiple back-to-back TDS packet writes into a single, larger TLS
+    // record. A LOGIN7 message that spans more than one TDS packet (e.g. any FedAuth
+    // login carrying an Entra ID access token, which routinely exceeds one 4KB packet)
+    // would then be sent as one oversized TLS record, which Azure SQL's TDS 8.0
+    // gateway rejects by resetting the connection.
+    const setMaxSendFragmentSpy = sinon.spy(tls.TLSSocket.prototype, 'setMaxSendFragment');
+    const serverSockets: net.Socket[] = [];
+
+    server.on('connection', (rawSocket) => {
+      serverSockets.push(rawSocket);
+
+      // A minimal TDS 8.0 "server": complete a real TLS handshake advertising the
+      // `tds/8.0` ALPN protocol (as `wrapWithTls` requires), then go silent. We only
+      // care about what the client does immediately after the handshake completes.
+      const tlsSocket = new tls.TLSSocket(rawSocket, {
+        isServer: true,
+        key: readFileSync('./test/fixtures/localhost.key'),
+        cert: readFileSync('./test/fixtures/localhost.crt'),
+        ALPNProtocols: ['tds/8.0']
+      });
+
+      // Ignore any post-handshake errors (the fake server never responds to PRELOGIN).
+      tlsSocket.on('error', () => {});
+    });
+
+    const addressInfo = server.address() as net.AddressInfo;
+
+    const connection = new Connection({
+      server: addressInfo.address,
+      options: {
+        port: addressInfo.port,
+        encrypt: 'strict',
+        trustServerCertificate: true,
+        packetSize: 2048,
+        connectTimeout: 3000
+      }
+    });
+
+    // The fake server never completes PRELOGIN/LOGIN7, so the connection will time out
+    // eventually — that's fine, we only need to observe what happens right after the
+    // TLS handshake, which happens well before the timeout fires.
+    connection.connect(() => {});
+
+    setTimeout(() => {
+      setMaxSendFragmentSpy.restore();
+      connection.close();
+      for (const socket of serverSockets) {
+        socket.destroy();
+      }
+
+      assert.isTrue(
+        setMaxSendFragmentSpy.calledWith(2048),
+        `expected setMaxSendFragment to be called with 2048, got calls: ${JSON.stringify(setMaxSendFragmentSpy.args)}`
+      );
+
+      done();
+    }, 500);
   });
 });

--- a/test/unit/connection-test.ts
+++ b/test/unit/connection-test.ts
@@ -142,24 +142,41 @@ describe('Using `strict` encryption', function() {
       }
     });
 
-    // The fake server never completes PRELOGIN/LOGIN7, so the connection will time out
-    // eventually — that's fine, we only need to observe what happens right after the
-    // TLS handshake, which is what `setMaxSendFragment` is called for.
-    connection.connect(() => {});
+    let finished = false;
+    const finish = (err?: Error) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
 
-    onCalled.then(() => {
       setMaxSendFragmentStub.restore();
       connection.close();
       for (const socket of serverSockets) {
         socket.destroy();
       }
 
-      assert.deepEqual(
-        calls, [2048],
-        `expected setMaxSendFragment to be called with 2048, got calls: ${JSON.stringify(calls)}`
-      );
+      done(err);
+    };
 
-      done();
+    // The fake server never completes PRELOGIN/LOGIN7, so the connection would time out
+    // eventually — that's fine, we only need to observe what happens right after the
+    // TLS handshake, which is what `setMaxSendFragment` is called for. If the handshake
+    // itself breaks, the connect callback reports the error, failing fast instead of
+    // hanging until the mocha timeout. (`finish` ignores the late timeout error that
+    // this callback reports after a successful run tears the connection down.)
+    connection.connect(finish);
+
+    onCalled.then(() => {
+      try {
+        assert.deepEqual(
+          calls, [2048],
+          `expected setMaxSendFragment to be called with 2048, got calls: ${JSON.stringify(calls)}`
+        );
+      } catch (err: any) {
+        return finish(err);
+      }
+
+      finish();
     });
   });
 });

--- a/test/unit/connection-test.ts
+++ b/test/unit/connection-test.ts
@@ -89,7 +89,25 @@ describe('Using `strict` encryption', function() {
     // login carrying an Entra ID access token, which routinely exceeds one 4KB packet)
     // would then be sent as one oversized TLS record, which Azure SQL's TDS 8.0
     // gateway rejects by resetting the connection.
-    const setMaxSendFragmentSpy = sinon.spy(tls.TLSSocket.prototype, 'setMaxSendFragment');
+    //
+    // `wrapWithTls` ignores `trustServerCertificate` (TDS 8.0 mandates real certificate
+    // validation), so the fake server here uses `test/fixtures/loopback-ip.crt`, which
+    // carries an `IP Address:127.0.0.1` SAN, and the client trusts it via `ca` — the
+    // handshake succeeds through genuine certificate validation, not a bypass.
+    //
+    // `wrapWithTls` doesn't route through `MessageIO`'s `secure` event (that only fires
+    // for the classic path), so there's no connection-level event to wait on here.
+    // Instead of a fixed delay, react as soon as `setMaxSendFragment` is first called.
+    const originalSetMaxSendFragment = tls.TLSSocket.prototype.setMaxSendFragment;
+    const calls: number[] = [];
+    const { promise: onCalled, resolve: resolveOnCalled } = Promise.withResolvers<void>();
+
+    const setMaxSendFragmentStub = sinon.stub(tls.TLSSocket.prototype, 'setMaxSendFragment').callsFake(function(this: tls.TLSSocket, size: number) {
+      calls.push(size);
+      resolveOnCalled();
+      return originalSetMaxSendFragment.call(this, size);
+    });
+
     const serverSockets: net.Socket[] = [];
 
     server.on('connection', (rawSocket) => {
@@ -100,8 +118,8 @@ describe('Using `strict` encryption', function() {
       // care about what the client does immediately after the handshake completes.
       const tlsSocket = new tls.TLSSocket(rawSocket, {
         isServer: true,
-        key: readFileSync('./test/fixtures/localhost.key'),
-        cert: readFileSync('./test/fixtures/localhost.crt'),
+        key: readFileSync('./test/fixtures/loopback-ip.key'),
+        cert: readFileSync('./test/fixtures/loopback-ip.crt'),
         ALPNProtocols: ['tds/8.0']
       });
 
@@ -116,7 +134,9 @@ describe('Using `strict` encryption', function() {
       options: {
         port: addressInfo.port,
         encrypt: 'strict',
-        trustServerCertificate: true,
+        cryptoCredentialsDetails: {
+          ca: [readFileSync('./test/fixtures/loopback-ip.crt')]
+        },
         packetSize: 2048,
         connectTimeout: 3000
       }
@@ -124,22 +144,22 @@ describe('Using `strict` encryption', function() {
 
     // The fake server never completes PRELOGIN/LOGIN7, so the connection will time out
     // eventually — that's fine, we only need to observe what happens right after the
-    // TLS handshake, which happens well before the timeout fires.
+    // TLS handshake, which is what `setMaxSendFragment` is called for.
     connection.connect(() => {});
 
-    setTimeout(() => {
-      setMaxSendFragmentSpy.restore();
+    onCalled.then(() => {
+      setMaxSendFragmentStub.restore();
       connection.close();
       for (const socket of serverSockets) {
         socket.destroy();
       }
 
-      assert.isTrue(
-        setMaxSendFragmentSpy.calledWith(2048),
-        `expected setMaxSendFragment to be called with 2048, got calls: ${JSON.stringify(setMaxSendFragmentSpy.args)}`
+      assert.deepEqual(
+        calls, [2048],
+        `expected setMaxSendFragment to be called with 2048, got calls: ${JSON.stringify(calls)}`
       );
 
       done();
-    }, 500);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1182.

`wrapWithTls` (used only for `encrypt: "strict"`, i.e. TDS 8.0) never calls `setMaxSendFragment` on the resulting TLS socket, unlike the classic `MessageIO#startTls` path (`message-io.ts`), which caps it to the TDS packet size for exactly this reason.

Without that cap, Node's TLS layer is free to coalesce multiple back-to-back TDS packet writes into a single, larger TLS record. A LOGIN7 message that spans more than one TDS packet — most notably any FedAuth login carrying an Entra ID access token, which routinely exceeds one 4KB packet — gets sent as one oversized TLS record. Azure SQL's TDS 8.0 gateway rejects this by resetting the connection (`ECONNRESET`), which is exactly the symptom reported in #1182.

Plain SQL-auth logins are small enough to fit in a single TDS packet, which is why this reads as "FedAuth-specific" until you look at packet counts — it isn't; it's a general multi-packet-under-strict-mode issue that happens to be triggered almost exclusively by FedAuth token payloads in practice.

## Root cause, confirmed

Reproduced directly against a real Azure SQL Database instance:
- `azure-active-directory-access-token` and `azure-active-directory-default` auth under `encrypt: "strict"`: 100% failure (`ECONNRESET`) across tedious 18.6.2, 19.2.1, and 20.0.5.
- Plain SQL auth under `encrypt: "strict"`: works reliably.
- Microsoft's own `Microsoft.Data.SqlClient` (.NET) connecting with the same Entra ID identity + strict encryption against the same server: works reliably — ruling out a server-side/gateway-only limitation.
- Root-caused to the missing `setMaxSendFragment` call by comparing the strict-mode `wrapWithTls` path against the classic `startTls` path, which already sets it (`message-io.ts:107`) for the identical reason.

## Fix

One-line change: call `encryptsocket.setMaxSendFragment(this.config.options.packetSize)` in `wrapWithTls`'s `secureConnect` handler, mirroring `MessageIO#startTls`.

## Verification

- Against real Azure SQL: `azure-active-directory-access-token` and `azure-active-directory-default` under `encrypt: "strict"` go from 100% `ECONNRESET` to 100% successful connection (multiple repeated runs).
- Plain SQL auth: unaffected, still works.
- Added a unit test (`test/unit/connection-test.ts`) that spins up a real TLS server using the existing `localhost.crt`/`.key` fixtures, negotiates the `tds/8.0` ALPN protocol, and asserts (via a `sinon` spy) that the client caps `setMaxSendFragment` to the configured `packetSize` right after the handshake. Verified the test fails without the fix and passes with it.
- Full unit suite: 431/431 passing, no regressions.
- `eslint`/`tsc`: clean.

## Test plan

- [x] `npm test` — 431 passing, 1 pending (pre-existing), 0 failing
- [x] `npx eslint src test` — clean
- [x] Manual verification against a real Azure SQL Database with `encrypt: "strict"` + `azure-active-directory-access-token` / `azure-active-directory-default`