### PR TITLE
fix: bound stalled responses and surface token parse failures

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3731,10 +3731,41 @@ Connection.prototype.STATE = {
           });
           return;
         }
-        // request timer is stopped on first data package
-        this.clearRequestTimer();
+        // The request timer was armed when the request was made and would
+        // otherwise fire even while the response is being consumed. Now that
+        // the first response packet has arrived, re-arm it on every further
+        // chunk of socket data instead, so that `requestTimeout` bounds
+        // *inactivity* rather than only time-to-first-packet: a response that
+        // stops making progress mid-message (or an incoming pipeline that
+        // stops consuming — its backpressure pauses the socket within one
+        // `highWaterMark`) fails the request through the existing timeout
+        // path instead of leaving it pending forever. The timer is cleared
+        // for real when this state is exited.
+        this.createRequestTimer();
+
+        const onSocketData = () => {
+          if (this.request) {
+            this.createRequestTimer();
+          }
+        };
+        this.socket?.on('data', onSocketData);
 
         const tokenStreamParser = this.createTokenStreamParser(message, new RequestTokenHandler(this, this.request!));
+
+        // A token parse failure leaves the connection at an undefined
+        // position in the TDS stream, so it cannot be recovered at the
+        // request level — treat it like a socket error. Without a listener
+        // here, a parse failure would surface as an unhandled `'error'`
+        // event on the parser's internal stream and crash the process.
+        const onParserError = (err: Error) => {
+          this.socket?.removeListener('data', onSocketData);
+
+          this.dispatchEvent('socketError', err);
+          process.nextTick(() => {
+            this.emit('error', this.wrapSocketError(err));
+          });
+        };
+        tokenStreamParser.on('error', onParserError);
 
         // If the request was canceled after the request message was
         // fully sent off, an attention message was sent to the server.
@@ -3745,6 +3776,10 @@ Connection.prototype.STATE = {
         // attention acknowledgement) is handled by the `SENT_ATTENTION`
         // state.
         if (this.request?.canceled && this.attentionSent) {
+          // The cancel timer bounds the rest of this exchange — stop
+          // re-arming the request timer. The parser error listener stays
+          // attached: the canceled response is still being drained.
+          this.socket?.removeListener('data', onSocketData);
           return this.transitionTo(this.STATE.SENT_ATTENTION);
         }
 
@@ -3772,6 +3807,11 @@ Connection.prototype.STATE = {
             return;
           }
 
+          // The cancel timer bounds the rest of this exchange — stop
+          // re-arming the request timer. The parser error listener stays
+          // attached: the canceled response is still being drained.
+          this.socket?.removeListener('data', onSocketData);
+
           tokenStreamParser.removeListener('end', onEndOfMessage);
 
           if (this.request instanceof Request && this.request.paused) {
@@ -3790,6 +3830,9 @@ Connection.prototype.STATE = {
         };
 
         const onEndOfMessage = () => {
+          this.socket?.removeListener('data', onSocketData);
+          tokenStreamParser.removeListener('error', onParserError);
+
           this.request?.removeListener('cancel', this._cancelAfterRequestSent);
           this.request?.removeListener('cancel', onCancel);
           this.request?.removeListener('pause', onPause);

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -30,6 +30,10 @@ export class Parser extends EventEmitter {
     this.parser.on('end', () => {
       this.emit('end');
     });
+
+    this.parser.on('error', (error: Error) => {
+      this.emit('error', error);
+    });
   }
 
   declare on: (

--- a/test/unit/connection-request-inactivity-test.ts
+++ b/test/unit/connection-request-inactivity-test.ts
@@ -1,0 +1,300 @@
+import { assert } from 'chai';
+import * as net from 'net';
+import { Connection, Request } from '../../src/tedious';
+import IncomingMessageStream from '../../src/incoming-message-stream';
+import OutgoingMessageStream from '../../src/outgoing-message-stream';
+import Debug from '../../src/debug';
+import PreloginPayload from '../../src/prelogin-payload';
+import Message from '../../src/message';
+
+function buildLoginAckToken(): Buffer {
+  const progname = 'Tedious SQL Server';
+
+  const buffer = Buffer.from([
+    0xAD, // Type
+    0x00, 0x00, // Length
+    0x00, // interface number - SQL
+    0x74, 0x00, 0x00, 0x04, // TDS version number
+    Buffer.byteLength(progname, 'ucs2') / 2, ...Buffer.from(progname, 'ucs2'), // Progname
+    0x00, // major
+    0x00, // minor
+    0x00, 0x00, // buildNum
+  ]);
+
+  buffer.writeUInt16LE(buffer.length - 3, 1);
+
+  return buffer;
+}
+
+/**
+ * Builds a final `DONE` token, optionally with a row count.
+ */
+function buildDoneToken(rowCount?: number): Buffer {
+  const buffer = Buffer.alloc(13);
+
+  let offset = 0;
+  offset = buffer.writeUInt8(0xFD, offset); // DONE
+  offset = buffer.writeUInt16LE(rowCount !== undefined ? 0x0010 : 0x0000, offset); // status = DONE_COUNT or DONE_FINAL
+  offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
+  buffer.writeBigUInt64LE(BigInt(rowCount ?? 0), offset); // rowCount
+
+  return buffer;
+}
+
+/**
+ * Builds a `COLMETADATA` token for a single `int` column named `a`.
+ */
+function buildColMetadataToken(): Buffer {
+  return Buffer.from([
+    0x81, // COLMETADATA
+    0x01, 0x00, // column count
+    0x00, 0x00, 0x00, 0x00, // userType
+    0x00, 0x00, // flags
+    0x38, // INT4
+    0x01, 0x61, 0x00 // column name - 'a'
+  ]);
+}
+
+/**
+ * Builds a `ROW` token containing a single `int` value.
+ */
+function buildRowToken(value: number): Buffer {
+  const buffer = Buffer.alloc(5);
+  buffer.writeUInt8(0xD1, 0); // ROW
+  buffer.writeInt32LE(value, 1);
+  return buffer;
+}
+
+/**
+ * Builds a single raw TDS packet (type `0x04` - tabular response) around the
+ * given payload, so the server side can send an individual packet - including
+ * a non-final one - directly to the socket, outside of a `Message`.
+ */
+function buildRawPacket(payload: Buffer, isLast: boolean): Buffer {
+  const header = Buffer.alloc(8);
+  header.writeUInt8(0x04, 0); // type - tabular response
+  header.writeUInt8(isLast ? 0x01 : 0x00, 1); // status - EOM or normal
+  header.writeUInt16BE(8 + payload.length, 2); // length, including header
+
+  return Buffer.concat([header, payload]);
+}
+
+/**
+ * Reads and discards all data of the given message.
+ */
+async function drainMessage(message: Message): Promise<void> {
+  const iterator = message[Symbol.asyncIterator]();
+  while (!(await iterator.next()).done) {
+    // Discard the data.
+  }
+}
+
+/**
+ * Serves the prelogin / login / initial SQL exchange, then hands the raw
+ * socket to `onRequest` when the first request message arrives.
+ */
+function serveUntilRequest(server: net.Server, onRequest: (connection: net.Socket) => void, onError: (err: Error) => void) {
+  server.on('connection', async (connection) => {
+    const debug = new Debug();
+    const incomingMessageStream = new IncomingMessageStream(debug);
+    const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+    connection.pipe(incomingMessageStream);
+    outgoingMessageStream.pipe(connection);
+
+    try {
+      const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+      // PRELOGIN
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x12);
+
+        await drainMessage(message);
+
+        const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+        const responseMessage = new Message({ type: 0x12 });
+        responseMessage.end(responsePayload.data);
+        outgoingMessageStream.write(responseMessage);
+      }
+
+      // LOGIN7
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x10);
+
+        await drainMessage(message);
+
+        const responseMessage = new Message({ type: 0x04 });
+        responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+        outgoingMessageStream.write(responseMessage);
+      }
+
+      // SQL Batch (Initial SQL)
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x01);
+
+        await drainMessage(message);
+
+        const responseMessage = new Message({ type: 0x04 });
+        responseMessage.end();
+        outgoingMessageStream.write(responseMessage);
+      }
+
+      // SQL Batch (the request under test) - from here on, the test
+      // scripts the response itself, writing raw packets to the socket.
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x01);
+
+        await drainMessage(message);
+
+        onRequest(connection);
+      }
+    } catch (err: any) {
+      onError(err);
+    }
+  });
+}
+
+describe('A request whose response has started arriving', function() {
+  let server: net.Server;
+  let _connections: net.Socket[];
+
+  beforeEach(function(done) {
+    _connections = [];
+    server = net.createServer((connection) => {
+      _connections.push(connection);
+    });
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function(done) {
+    _connections.forEach((connection) => {
+      connection.destroy();
+    });
+
+    server.close(done);
+  });
+
+  it('errors after the inactivity budget when the response stalls after the first packet', function(done) {
+    serveUntilRequest(server, (connection) => {
+      // Send the first packet of the response, then go silent forever.
+      connection.write(buildRawPacket(buildColMetadataToken(), false));
+    }, done);
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        requestTimeout: 200,
+        cancelTimeout: 100
+      }
+    });
+
+    connection.on('error', () => {
+      // The forced socket error also surfaces as a connection error.
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const start = Date.now();
+      const request = new Request('select 1', (err) => {
+        // Without the inactivity timer, this callback is never reached:
+        // the request timer was cleared when the first packet arrived,
+        // and nothing else bounds the remainder of the response.
+        assert.instanceOf(err, Error);
+        assert.strictEqual((err as any).code, 'ETIMEOUT');
+
+        // requestTimeout (200ms of silence) plus the cancel timeout (100ms).
+        const elapsed = Date.now() - start;
+        assert.isAtLeast(elapsed, 190);
+
+        connection.close();
+        done();
+      });
+
+      connection.execSqlBatch(request);
+    });
+  });
+
+  it('completes a slow response whose per-chunk gaps stay under the budget', function(done) {
+    serveUntilRequest(server, (connection) => {
+      // Three chunks, 220ms apart: total time (~440ms) exceeds the 300ms
+      // `requestTimeout`, but no single silent gap does. A total-time
+      // interpretation of the timeout would fail this request.
+      connection.write(buildRawPacket(buildColMetadataToken(), false));
+
+      setTimeout(() => {
+        connection.write(buildRawPacket(buildRowToken(8), false));
+
+        setTimeout(() => {
+          connection.write(buildRawPacket(buildDoneToken(1), true));
+        }, 220);
+      }, 220);
+    }, done);
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        requestTimeout: 300
+      }
+    });
+
+    connection.on('error', done);
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const start = Date.now();
+      const request = new Request('select 8 as a', (err, rowCount) => {
+        assert.isUndefined(err);
+        assert.strictEqual(rowCount, 1);
+        assert.isAtLeast(Date.now() - start, 400);
+
+        connection.close();
+        done();
+      });
+
+      connection.execSqlBatch(request);
+    });
+  });
+
+  it('surfaces a token parse failure as a request error instead of an unhandled stream error', function(done) {
+    serveUntilRequest(server, (connection) => {
+      // 0x00 is not a valid token type - parsing this response throws.
+      connection.write(buildRawPacket(Buffer.from([0x00]), true));
+    }, done);
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.on('error', () => {
+      // The parse failure is also surfaced as a connection error.
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, Error);
+        assert.match((err as Error).message, /Unknown type/);
+
+        connection.close();
+        done();
+      });
+
+      connection.execSqlBatch(request);
+    });
+  });
+});


### PR DESCRIPTION
Once a query's response starts arriving, tedious currently has no timer and no error path left for the remainder of that response:

1. **The request timer is cleared on the first data packet.** In `SentClientRequest`, the `await this.messageIo.readMessage()` is bounded by the request timer, but the moment the first packet arrives the timer is cleared (`// request timer is stopped on first data package`) and nothing bounds the token-parsing consumption of the rest of the message. `requestTimeout` therefore only bounds *time to first packet* — not what its documentation leads users to expect, and not what other drivers (e.g. Microsoft.Data.SqlClient) do.
2. **The token parser's stream has no `'error'` listener.** `Parser` builds its internal stream with `Readable.from(StreamParser.parseTokens(...))` and subscribes only `data`/`drain`/`end`, so a parse failure is an unhandled `'error'` event on a stream nobody listens to — a process-level crash rather than a request error.

Between those two facts, the window from "first response packet arrived" to "message fully parsed" is the only wait in the request path that is unbounded and unerrored. Additionally, the incoming pipeline can jam legitimately and permanently with the socket healthy: `IncomingMessageStream` withholds its transform callback until the current message is fully consumed, so a single stalled consumer freezes the connection's entire incoming pipeline while TCP keep-alive keeps the socket ESTABLISHED indefinitely.

### Production impact

We hit this in production (via node-mssql 11 / TypeORM on Node 22, against an on-prem SQL Server): an awaited query — byte-identical to ~200,000 executions that succeeded around it — never settled, for 17+ hours until a process restart. No exception anywhere (our `uncaughtException`/`unhandledRejection` handlers never fired), no timeout despite `requestTimeout: 600000`. Server side, the query had completed and the session sat `sleeping`; client side, the TCP connection was ESTABLISHED with empty rx/tx queues and zero retransmits — the response bytes had been consumed into Node userspace before the stall. The stalled connection was permanently leaked as a busy pool resource (tarn never reaps `used` resources), and process shutdown hung on it until SIGKILL. The trigger is a rare race we have not isolated (order of 1-in-10⁵ in our workload); this PR is about bounding the window, not explaining that race.

We reviewed the adjacent hang fixes in 19.2.2/20.0.x (#1736, #1738, #1739) — none matches this fingerprint (ours is post-login, no cancel in flight), but they suggest this defect family is in scope.

### The fix

1. **Treat `requestTimeout` as an inactivity timeout during response consumption.** Instead of clearing the request timer at the first packet, re-arm it on every chunk of incoming socket data while in `SentClientRequest`, and stop when the response message ends (state exit still clears it). This bounds *silence* without bounding legitimately long result streams — data that keeps flowing is never interrupted (our own workload includes 600-second streaming reads, so a total-response-time bound would be unacceptable; this deliberately isn't one). A jammed incoming pipeline backpressures the socket within one `highWaterMark`, so it is caught the same way. `requestTimeout: 0` still disables the timer entirely. On expiry, the existing timeout path runs (cancel → attention, itself bounded by `cancelTimeout`), so the total worst case is `requestTimeout + cancelTimeout`.
2. **Route token-parser stream errors into the request.** `Parser` re-emits its internal stream's `'error'`, and `SentClientRequest` routes it through the existing socket-error path — a parse failure leaves the connection at an undefined position in the TDS stream, so failing the request and closing the connection mirrors how other fatal transport errors are handled, instead of crashing the process.

### Tests

`test/unit/connection-request-inactivity-test.ts` (fake-server pattern from `connection-cancel-test.ts`):

- a response that stalls after its first packet errors with `ETIMEOUT` after the inactivity budget — on current master this test hangs until the mocha timeout;
- a slow multi-chunk response whose per-chunk gaps stay under the budget completes normally, even though its total time exceeds `requestTimeout` — the regression a total-time interpretation would cause;
- a token parse failure surfaces as a request error with the process alive — on current master this dies with an unhandled `Unknown type` stream error.

Full unit suite and lint pass locally.

### Open questions for maintainers

- **Budget semantics/default**: this PR reuses `requestTimeout` as the inactivity budget (making it mean "maximum silence" rather than "time to first packet", which is closer to what users assume). If you'd prefer a separate option (default-on or default-off), happy to rework.
- **Paused requests**: a request deliberately `pause()`d for longer than the budget will eventually backpressure the socket and time out. If that use case matters, the timer could be suspended while the request is paused — opinions welcome.
