### PR TITLE
feat: add AbortSignal support to request execution

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2989,6 +2989,10 @@ class Connection extends EventEmitter {
    * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
   prepare(request: Request, options?: { signal?: AbortSignal }) {
+    // Validated up front, before the request is put into preparation mode -
+    // an invalid signal must not leave a half-prepared request behind.
+    validateAbortSignal(options?.signal);
+
     const parameters: Parameter[] = [];
 
     parameters.push({
@@ -3346,15 +3350,18 @@ class Connection extends EventEmitter {
       const message = 'Requests can only be made in the ' + this.STATE.LOGGED_IN.name + ' state, not the ' + this.state.name + ' state';
       this.debug.log(message);
       request.callback(new RequestError(message, 'EINVALIDSTATE'));
+    } else if (request.canceled) {
+      // Checked before the signal: an earlier cancellation is the failure
+      // cause, and attaching an (already aborted) signal must not change
+      // the outcome of an already-canceled request.
+      process.nextTick(() => {
+        request.callback(new RequestError('Canceled.', 'ECANCEL'));
+      });
     } else if (signal !== undefined && signal.aborted) {
       // The signal was already aborted - fail the request with the abort
       // reason without sending anything to the server.
       process.nextTick(() => {
         request.callback(errorForAbortedSignal(signal));
-      });
-    } else if (request.canceled) {
-      process.nextTick(() => {
-        request.callback(new RequestError('Canceled.', 'ECANCEL'));
       });
     } else {
       if (signal !== undefined) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1878,8 +1878,9 @@ class Connection extends EventEmitter {
       // Stop the request timer: the abort is now the failure cause for
       // this request, and the timer firing later (it only stops once
       // response data arrives) would overwrite the abort reason with an
-      // `ETIMEOUT` error. If the timer fired first, its `ETIMEOUT` error
-      // is already recorded and kept by the `??=` above.
+      // `ETIMEOUT` error. (If the timer fired first, its cancellation
+      // already set `request.canceled`, and this handler returned early
+      // above - the `ETIMEOUT` error stands.)
       this.clearRequestTimer();
 
       request.cancel();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3052,6 +3052,10 @@ class Connection extends EventEmitter {
    * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
   unprepare(request: Request, options?: { signal?: AbortSignal }) {
+    // No state is mutated before `makeRequest` here - validated up front
+    // anyway, for consistency with the other execution methods.
+    validateAbortSignal(options?.signal);
+
     const parameters: Parameter[] = [];
 
     parameters.push({
@@ -3381,8 +3385,9 @@ class Connection extends EventEmitter {
         // The listener is removed when the request completes, via
         // `clearRequestAbortListener`.
         //
-        // This is done before any connection state is mutated: the
-        // duck-typed signal validation above matches Node core's
+        // This is done before any further state is mutated (only the
+        // `request.error` reset above runs earlier): the duck-typed
+        // signal validation above matches Node core's
         // `validateAbortSignal` and doesn't check for the listener
         // methods, so if `addEventListener` throws here, the error
         // surfaces to the caller with the connection left untouched.

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -20,6 +20,7 @@ import { type AccessToken, type TokenCredential, isTokenCredential } from '@azur
 import BulkLoad, { type Options as BulkLoadOptions, type Callback as BulkLoadCallback } from './bulk-load';
 import Debug from './debug';
 import { EventEmitter, once } from 'events';
+import { isNativeError } from 'util/types';
 import { instanceLookup } from './instance-lookup';
 import { TransientErrorLookup } from './transient-error-lookup';
 import { TYPE } from './packet';
@@ -183,7 +184,10 @@ const DEFAULT_PACKET_SIZE = 4 * 1024;
  */
 function errorForAbortedSignal(signal: AbortSignal): Error {
   const reason = signal.reason;
-  return reason instanceof Error ? reason : new RequestError('Aborted.', 'EABORT', { cause: reason });
+  // `isNativeError` also recognizes `Error`s from other realms, which fail
+  // the `instanceof` check; `instanceof` also recognizes objects that
+  // merely have `Error.prototype` in their prototype chain.
+  return reason instanceof Error || isNativeError(reason) ? reason : new RequestError('Aborted.', 'EABORT', { cause: reason });
 }
 /**
  * @private
@@ -1845,6 +1849,13 @@ class Connection extends EventEmitter {
     this._onRequestAbort = () => {
       const request = this.request!;
 
+      // If the request was already canceled - by `request.cancel()` or by
+      // the request timeout - that cancellation is the failure cause, and
+      // the abort arriving later must not change the reported outcome.
+      if (request.canceled) {
+        return;
+      }
+
       // Pre-set the request's error to the abort reason, so the request
       // completes with that reason instead of a generic `ECANCEL` error.
       // An error that was recorded earlier (e.g. a server error or a
@@ -2880,21 +2891,26 @@ class Connection extends EventEmitter {
         throw new Error("Connection.execBulkLoad can't be called with a BulkLoad that already has rows written to it.");
       }
 
-      const rowStream = Readable.from(rows);
+      // If the signal is already aborted, the bulk load will fail right
+      // away in `makeRequest` - don't start consuming the row iterable
+      // for a bulk load that will never be sent.
+      if (options?.signal?.aborted !== true) {
+        const rowStream = Readable.from(rows);
 
-      // Destroy the packet transform if an error happens in the row stream,
-      // e.g. if an error is thrown from within a generator or stream.
-      rowStream.on('error', (err) => {
-        bulkLoad.rowToPacketTransform.destroy(err);
-      });
+        // Destroy the packet transform if an error happens in the row stream,
+        // e.g. if an error is thrown from within a generator or stream.
+        rowStream.on('error', (err) => {
+          bulkLoad.rowToPacketTransform.destroy(err);
+        });
 
-      // Destroy the row stream if an error happens in the packet transform,
-      // e.g. if the bulk load is cancelled.
-      bulkLoad.rowToPacketTransform.on('error', (err) => {
-        rowStream.destroy(err);
-      });
+        // Destroy the row stream if an error happens in the packet transform,
+        // e.g. if the bulk load is cancelled.
+        bulkLoad.rowToPacketTransform.on('error', (err) => {
+          rowStream.destroy(err);
+        });
 
-      rowStream.pipe(bulkLoad.rowToPacketTransform);
+        rowStream.pipe(bulkLoad.rowToPacketTransform);
+      }
     } else if (!bulkLoad.streamingMode) {
       // If the bulkload was not put into streaming mode by the user,
       // we end the rowToPacketTransform here for them.
@@ -3108,9 +3124,11 @@ class Connection extends EventEmitter {
 
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('SET TRANSACTION ISOLATION LEVEL ' + (transaction.isolationLevelToTSQL()) + ';BEGIN TRAN ' + transaction.name, (err) => {
-        this.transactionDepth++;
-        if (this.transactionDepth === 1) {
-          this.inTransaction = true;
+        if (!err) {
+          this.transactionDepth++;
+          if (this.transactionDepth === 1) {
+            this.inTransaction = true;
+          }
         }
         callback(err);
       }), options);
@@ -3137,9 +3155,11 @@ class Connection extends EventEmitter {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('COMMIT TRAN ' + transaction.name, (err) => {
-        this.transactionDepth--;
-        if (this.transactionDepth === 0) {
-          this.inTransaction = false;
+        if (!err) {
+          this.transactionDepth--;
+          if (this.transactionDepth === 0) {
+            this.inTransaction = false;
+          }
         }
 
         callback(err);
@@ -3165,9 +3185,11 @@ class Connection extends EventEmitter {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('ROLLBACK TRAN ' + transaction.name, (err) => {
-        this.transactionDepth--;
-        if (this.transactionDepth === 0) {
-          this.inTransaction = false;
+        if (!err) {
+          this.transactionDepth--;
+          if (this.transactionDepth === 0) {
+            this.inTransaction = false;
+          }
         }
         callback(err);
       }), options);
@@ -3192,7 +3214,9 @@ class Connection extends EventEmitter {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('SAVE TRAN ' + transaction.name, (err) => {
-        this.transactionDepth++;
+        if (!err) {
+          this.transactionDepth++;
+        }
         callback(err);
       }), options);
     }
@@ -3305,6 +3329,20 @@ class Connection extends EventEmitter {
         request.callback(new RequestError('Canceled.', 'ECANCEL'));
       });
     } else {
+      if (signal !== undefined) {
+        // An abort is performed as a cancellation (see `_onRequestAbort`).
+        // The listener is removed when the request completes, via
+        // `clearRequestAbortListener`.
+        //
+        // This is done before any connection state is mutated: the
+        // duck-typed signal validation above matches Node core's
+        // `validateAbortSignal` and doesn't check for the listener
+        // methods, so if `addEventListener` throws here, the error
+        // surfaces to the caller with the connection left untouched.
+        signal.addEventListener('abort', this._onRequestAbort, { once: true });
+        this.requestAbortSignal = signal;
+      }
+
       if (packetType === TYPE.SQL_BATCH) {
         this.isSqlBatch = true;
       } else {
@@ -3343,14 +3381,6 @@ class Connection extends EventEmitter {
       };
 
       request.once('cancel', onCancel);
-
-      if (signal !== undefined) {
-        // An abort is performed as a cancellation (see `_onRequestAbort`).
-        // The listener is removed when the request completes, via
-        // `clearRequestAbortListener`.
-        signal.addEventListener('abort', this._onRequestAbort, { once: true });
-        this.requestAbortSignal = signal;
-      }
 
       this.createRequestTimer();
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2794,6 +2794,10 @@ class Connection extends EventEmitter {
    * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
   execSql(request: Request, options?: { signal?: AbortSignal }) {
+    // Validated up front, so that an invalid signal throws synchronously
+    // even when parameter validation would fail the request first.
+    validateAbortSignal(options?.signal);
+
     try {
       request.validateParameters(this.databaseCollation);
     } catch (error: any) {
@@ -3075,6 +3079,10 @@ class Connection extends EventEmitter {
    * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
   execute(request: Request, parameters?: { [key: string]: unknown }, options?: { signal?: AbortSignal }) {
+    // Validated up front, so that an invalid signal throws synchronously
+    // even when parameter validation would fail the request first.
+    validateAbortSignal(options?.signal);
+
     const executeParameters: Parameter[] = [];
 
     executeParameters.push({
@@ -3118,6 +3126,10 @@ class Connection extends EventEmitter {
    * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
   callProcedure(request: Request, options?: { signal?: AbortSignal }) {
+    // Validated up front, so that an invalid signal throws synchronously
+    // even when parameter validation would fail the request first.
+    validateAbortSignal(options?.signal);
+
     try {
       request.validateParameters(this.databaseCollation);
     } catch (error: any) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -172,6 +172,19 @@ const DEFAULT_CONNECT_RETRY_INTERVAL = 500;
  * @private
  */
 const DEFAULT_PACKET_SIZE = 4 * 1024;
+
+/**
+ * The error a request aborted via its `AbortSignal` completes with: the
+ * signal's abort reason itself (e.g. an `AbortError` or a `TimeoutError`
+ * from `AbortSignal.timeout()`), or a `RequestError` wrapping the reason
+ * when the reason is not an `Error`.
+ *
+ * @private
+ */
+function errorForAbortedSignal(signal: AbortSignal): Error {
+  const reason = signal.reason;
+  return reason instanceof Error ? reason : new RequestError('Aborted.', 'EABORT', { cause: reason });
+}
 /**
  * @private
  */
@@ -1044,6 +1057,23 @@ class Connection extends EventEmitter {
   declare requestTimer: undefined | NodeJS.Timeout;
 
   /**
+   * The `AbortSignal` the currently active request was executed with,
+   * if any.
+   *
+   * @private
+   */
+  declare requestAbortSignal: undefined | AbortSignal;
+  /**
+   * Handles the `abort` event of the currently active request's
+   * [[requestAbortSignal]]. Armed on the signal while the request is in
+   * flight, removed (via [[clearRequestAbortListener]]) when the request
+   * completes.
+   *
+   * @private
+   */
+  declare _onRequestAbort: () => void;
+
+  /**
    * Controller used to abort the connection establishment process
    * when the connection is closed before it was fully established.
    *
@@ -1812,6 +1842,25 @@ class Connection extends EventEmitter {
       this.createCancelTimer();
     };
 
+    this._onRequestAbort = () => {
+      const request = this.request!;
+
+      // Pre-set the request's error to the abort reason, so the request
+      // completes with that reason instead of a generic `ECANCEL` error.
+      // An error that was recorded earlier (e.g. a server error or a
+      // request timeout) takes precedence over the abort reason.
+      request.error ??= errorForAbortedSignal(this.requestAbortSignal!);
+
+      // Stop the request timer: the abort is now the failure cause for
+      // this request, and the timer firing later (it only stops once
+      // response data arrives) would overwrite the abort reason with an
+      // `ETIMEOUT` error. If the timer fired first, its `ETIMEOUT` error
+      // is already recorded and kept by the `??=` above.
+      this.clearRequestTimer();
+
+      request.cancel();
+    };
+
     this._onSocketClose = () => {
       this.socketClose();
     };
@@ -2174,6 +2223,7 @@ class Connection extends EventEmitter {
     if (!this.closed) {
       this.clearRequestTimer();
       this.clearCancelTimer();
+      this.clearRequestAbortListener();
       this.closeConnection();
 
       process.nextTick(() => {
@@ -2357,6 +2407,16 @@ class Connection extends EventEmitter {
     if (this.requestTimer) {
       clearTimeout(this.requestTimer);
       this.requestTimer = undefined;
+    }
+  }
+
+  /**
+   * @private
+   */
+  clearRequestAbortListener() {
+    if (this.requestAbortSignal) {
+      this.requestAbortSignal.removeEventListener('abort', this._onRequestAbort);
+      this.requestAbortSignal = undefined;
     }
   }
 
@@ -2673,9 +2733,20 @@ class Connection extends EventEmitter {
    * In almost all cases, [[execSql]] will be a better choice.
    *
    * @param request A [[Request]] object representing the request.
+   * @param options Optional execution options. `options.signal` is an `AbortSignal` for this
+   *   execution of the request: aborting the signal cancels the request, which then completes
+   *   with the signal's abort reason (e.g. a `TimeoutError` from `AbortSignal.timeout()`)
+   *   instead of a generic `ECANCEL` error - unless the request had already failed with an
+   *   earlier error (e.g. a server error or a request timeout), in which case that error is
+   *   reported. If the signal is already aborted, the request fails immediately with the abort
+   *   reason, without anything being sent to the server. A non-`Error` abort reason is wrapped
+   *   in a `RequestError` with code `EABORT`. Note that a default abort reason is a
+   *   `DOMException`, which carries a legacy *numeric* `code` property - match abort outcomes
+   *   on `err.name` (`'AbortError'`, `'TimeoutError'`) or on the signal's state, not on a
+   *   tedious-style string `code`. The connection remains usable after an aborted request.
    */
-  execSqlBatch(request: Request) {
-    this.makeRequest(request, TYPE.SQL_BATCH, new SqlBatchPayload(request.sqlTextOrProcedure!, this.currentTransactionDescriptor(), this.config.options));
+  execSqlBatch(request: Request, options?: { signal?: AbortSignal }) {
+    this.makeRequest(request, TYPE.SQL_BATCH, new SqlBatchPayload(request.sqlTextOrProcedure!, this.currentTransactionDescriptor(), this.config.options), options);
   }
 
   /**
@@ -2692,8 +2763,9 @@ class Connection extends EventEmitter {
    * See also [issue #24](https://github.com/pekim/tedious/issues/24)
    *
    * @param request A [[Request]] object representing the request.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  execSql(request: Request) {
+  execSql(request: Request, options?: { signal?: AbortSignal }) {
     try {
       request.validateParameters(this.databaseCollation);
     } catch (error: any) {
@@ -2733,7 +2805,7 @@ class Connection extends EventEmitter {
       parameters.push(...request.parameters);
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_ExecuteSql, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_ExecuteSql, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation), options);
   }
 
   /**
@@ -2792,10 +2864,11 @@ class Connection extends EventEmitter {
    *
    * @param bulkLoad A previously created [[BulkLoad]].
    * @param rows A [[Iterable]] or [[AsyncIterable]] that contains the rows that should be bulk loaded.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  execBulkLoad(bulkLoad: BulkLoad, rows: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>): void
+  execBulkLoad(bulkLoad: BulkLoad, rows: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>, options?: { signal?: AbortSignal }): void
 
-  execBulkLoad(bulkLoad: BulkLoad, rows?: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>) {
+  execBulkLoad(bulkLoad: BulkLoad, rows?: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>, options?: { signal?: AbortSignal }) {
     bulkLoad.executionStarted = true;
 
     if (rows) {
@@ -2849,12 +2922,12 @@ class Connection extends EventEmitter {
         return;
       }
 
-      this.makeRequest(bulkLoad, TYPE.BULK_LOAD, payload);
+      this.makeRequest(bulkLoad, TYPE.BULK_LOAD, payload, options);
     });
 
     bulkLoad.once('cancel', onCancel);
 
-    this.execSqlBatch(request);
+    this.execSqlBatch(request, options);
   }
 
   /**
@@ -2865,8 +2938,9 @@ class Connection extends EventEmitter {
    *
    * @param request A [[Request]] object representing the request.
    *   Parameters only require a name and type. Parameter values are ignored.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  prepare(request: Request) {
+  prepare(request: Request, options?: { signal?: AbortSignal }) {
     const parameters: Parameter[] = [];
 
     parameters.push({
@@ -2910,7 +2984,7 @@ class Connection extends EventEmitter {
       }
     });
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Prepare, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Prepare, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation), options);
   }
 
   /**
@@ -2919,8 +2993,9 @@ class Connection extends EventEmitter {
    * @param request A [[Request]] object representing the request.
    *   Parameters only require a name and type.
    *   Parameter values are ignored.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  unprepare(request: Request) {
+  unprepare(request: Request, options?: { signal?: AbortSignal }) {
     const parameters: Parameter[] = [];
 
     parameters.push({
@@ -2934,7 +3009,7 @@ class Connection extends EventEmitter {
       scale: undefined
     });
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Unprepare, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Unprepare, parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation), options);
   }
 
   /**
@@ -2945,8 +3020,9 @@ class Connection extends EventEmitter {
    *   parameters that were added to the [[Request]] before it was prepared.
    *   The object's values are passed as the parameters' values when the
    *   request is executed.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  execute(request: Request, parameters?: { [key: string]: unknown }) {
+  execute(request: Request, parameters?: { [key: string]: unknown }, options?: { signal?: AbortSignal }) {
     const executeParameters: Parameter[] = [];
 
     executeParameters.push({
@@ -2980,15 +3056,16 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Execute, executeParameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(Procedures.Sp_Execute, executeParameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation), options);
   }
 
   /**
    * Call a stored procedure represented by [[Request]].
    *
    * @param request A [[Request]] object representing the request.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  callProcedure(request: Request) {
+  callProcedure(request: Request, options?: { signal?: AbortSignal }) {
     try {
       request.validateParameters(this.databaseCollation);
     } catch (error: any) {
@@ -3002,7 +3079,7 @@ class Connection extends EventEmitter {
       return;
     }
 
-    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation));
+    this.makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request.sqlTextOrProcedure!, request.parameters, this.currentTransactionDescriptor(), this.config.options, this.databaseCollation), options);
   }
 
   /**
@@ -3022,8 +3099,9 @@ class Connection extends EventEmitter {
    *   * `SNAPSHOT`
    *
    *   Optional, and defaults to the Connection's isolation level.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  beginTransaction(callback: BeginTransactionCallback, name = '', isolationLevel = this.config.options.isolationLevel) {
+  beginTransaction(callback: BeginTransactionCallback, name = '', isolationLevel = this.config.options.isolationLevel, options?: { signal?: AbortSignal }) {
     assertValidIsolationLevel(isolationLevel, 'isolationLevel');
 
     const transaction = new Transaction(name, isolationLevel);
@@ -3035,13 +3113,13 @@ class Connection extends EventEmitter {
           this.inTransaction = true;
         }
         callback(err);
-      }));
+      }), options);
     }
 
     const request = new Request(undefined, (err) => {
       return callback(err, this.currentTransactionDescriptor());
     });
-    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.beginPayload(this.currentTransactionDescriptor()));
+    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.beginPayload(this.currentTransactionDescriptor()), options);
   }
 
   /**
@@ -3053,8 +3131,9 @@ class Connection extends EventEmitter {
    * @param callback
    * @param name A string representing a name to associate with the transaction.
    *   Optional, and defaults to an empty string. Required when `isolationLevel`is present.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  commitTransaction(callback: CommitTransactionCallback, name = '') {
+  commitTransaction(callback: CommitTransactionCallback, name = '', options?: { signal?: AbortSignal }) {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('COMMIT TRAN ' + transaction.name, (err) => {
@@ -3064,10 +3143,10 @@ class Connection extends EventEmitter {
         }
 
         callback(err);
-      }));
+      }), options);
     }
     const request = new Request(undefined, callback);
-    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.commitPayload(this.currentTransactionDescriptor()));
+    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.commitPayload(this.currentTransactionDescriptor()), options);
   }
 
   /**
@@ -3080,8 +3159,9 @@ class Connection extends EventEmitter {
    * @param name A string representing a name to associate with the transaction.
    *   Optional, and defaults to an empty string.
    *   Required when `isolationLevel` is present.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  rollbackTransaction(callback: RollbackTransactionCallback, name = '') {
+  rollbackTransaction(callback: RollbackTransactionCallback, name = '', options?: { signal?: AbortSignal }) {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('ROLLBACK TRAN ' + transaction.name, (err) => {
@@ -3090,10 +3170,10 @@ class Connection extends EventEmitter {
           this.inTransaction = false;
         }
         callback(err);
-      }));
+      }), options);
     }
     const request = new Request(undefined, callback);
-    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.rollbackPayload(this.currentTransactionDescriptor()));
+    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.rollbackPayload(this.currentTransactionDescriptor()), options);
   }
 
   /**
@@ -3106,17 +3186,18 @@ class Connection extends EventEmitter {
    * @param name A string representing a name to associate with the transaction.\
    *   Optional, and defaults to an empty string.
    *   Required when `isolationLevel` is present.
+   * @param options Optional execution options. See [[execSqlBatch]] for a description of `options.signal`.
    */
-  saveTransaction(callback: SaveTransactionCallback, name: string) {
+  saveTransaction(callback: SaveTransactionCallback, name: string, options?: { signal?: AbortSignal }) {
     const transaction = new Transaction(name);
     if (this.config.options.tdsVersion < '7_2') {
       return this.execSqlBatch(new Request('SAVE TRAN ' + transaction.name, (err) => {
         this.transactionDepth++;
         callback(err);
-      }));
+      }), options);
     }
     const request = new Request(undefined, callback);
-    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.savePayload(this.currentTransactionDescriptor()));
+    return this.makeRequest(request, TYPE.TRANSACTION_MANAGER, transaction.savePayload(this.currentTransactionDescriptor()), options);
   }
 
   /**
@@ -3196,7 +3277,15 @@ class Connection extends EventEmitter {
   /**
    * @private
    */
-  makeRequest(request: Request | BulkLoad, packetType: number, payload: (Iterable<Buffer> | AsyncIterable<Buffer>) & { toString: (indent?: string) => string }) {
+  makeRequest(request: Request | BulkLoad, packetType: number, payload: (Iterable<Buffer> | AsyncIterable<Buffer>) & { toString: (indent?: string) => string }, options?: { signal?: AbortSignal }) {
+    const { signal } = options ?? {};
+
+    // Duck-typed like Node core's `validateAbortSignal`, so cross-realm
+    // `AbortSignal`s and ponyfills are accepted.
+    if (signal !== undefined && (signal === null || typeof signal !== 'object' || !('aborted' in signal))) {
+      throw new TypeError('The "options.signal" property must be an instance of AbortSignal');
+    }
+
     // Clear any error left over from a previous execution of this request,
     // even if the request is rejected before being sent.
     request.error = undefined;
@@ -3205,6 +3294,12 @@ class Connection extends EventEmitter {
       const message = 'Requests can only be made in the ' + this.STATE.LOGGED_IN.name + ' state, not the ' + this.state.name + ' state';
       this.debug.log(message);
       request.callback(new RequestError(message, 'EINVALIDSTATE'));
+    } else if (signal !== undefined && signal.aborted) {
+      // The signal was already aborted - fail the request with the abort
+      // reason without sending anything to the server.
+      process.nextTick(() => {
+        request.callback(errorForAbortedSignal(signal));
+      });
     } else if (request.canceled) {
       process.nextTick(() => {
         request.callback(new RequestError('Canceled.', 'ECANCEL'));
@@ -3248,6 +3343,14 @@ class Connection extends EventEmitter {
       };
 
       request.once('cancel', onCancel);
+
+      if (signal !== undefined) {
+        // An abort is performed as a cancellation (see `_onRequestAbort`).
+        // The listener is removed when the request completes, via
+        // `clearRequestAbortListener`.
+        signal.addEventListener('abort', this._onRequestAbort, { once: true });
+        this.requestAbortSignal = signal;
+      }
 
       this.createRequestTimer();
 
@@ -3800,6 +3903,7 @@ Connection.prototype.STATE = {
           // a cancel timer is running - the response's arrival is what
           // completes the cancellation.
           this.clearCancelTimer();
+          this.clearRequestAbortListener();
 
           this.transitionTo(this.STATE.LOGGED_IN);
           const sqlRequest = this.request as Request;
@@ -3863,11 +3967,19 @@ Connection.prototype.STATE = {
           this.attentionSent = false;
           this.clearCancelTimer();
 
+          const abortSignal = this.requestAbortSignal;
+          this.clearRequestAbortListener();
+
           const sqlRequest = this.request!;
           this.request = undefined;
           this.transitionTo(this.STATE.LOGGED_IN);
 
           if (sqlRequest.error && sqlRequest.error instanceof RequestError && sqlRequest.error.code === 'ETIMEOUT') {
+            sqlRequest.callback(sqlRequest.error);
+          } else if (sqlRequest.error && abortSignal !== undefined && abortSignal.aborted) {
+            // The cancellation was triggered by the request's `AbortSignal` -
+            // complete the request with the abort reason instead of a
+            // generic `ECANCEL` error.
             sqlRequest.callback(sqlRequest.error);
           } else {
             sqlRequest.callback(new RequestError('Canceled.', 'ECANCEL'));

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -175,14 +175,6 @@ const DEFAULT_CONNECT_RETRY_INTERVAL = 500;
 const DEFAULT_PACKET_SIZE = 4 * 1024;
 
 /**
- * The error a request aborted via its `AbortSignal` completes with: the
- * signal's abort reason itself (e.g. an `AbortError` or a `TimeoutError`
- * from `AbortSignal.timeout()`), or a `RequestError` wrapping the reason
- * when the reason is not an `Error`.
- *
- * @private
- */
-/**
  * Duck-typed like Node core's `validateAbortSignal`, so cross-realm
  * `AbortSignal`s and ponyfills are accepted.
  *
@@ -194,6 +186,14 @@ function validateAbortSignal(signal: AbortSignal | undefined) {
   }
 }
 
+/**
+ * The error a request aborted via its `AbortSignal` completes with: the
+ * signal's abort reason itself (e.g. an `AbortError` or a `TimeoutError`
+ * from `AbortSignal.timeout()`), or a `RequestError` wrapping the reason
+ * when the reason is not an `Error`.
+ *
+ * @private
+ */
 function errorForAbortedSignal(signal: AbortSignal): Error {
   const reason = signal.reason;
   // `isNativeError` also recognizes `Error`s from other realms, which fail
@@ -201,6 +201,7 @@ function errorForAbortedSignal(signal: AbortSignal): Error {
   // merely have `Error.prototype` in their prototype chain.
   return reason instanceof Error || isNativeError(reason) ? reason : new RequestError('Aborted.', 'EABORT', { cause: reason });
 }
+
 /**
  * @private
  */

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -182,6 +182,18 @@ const DEFAULT_PACKET_SIZE = 4 * 1024;
  *
  * @private
  */
+/**
+ * Duck-typed like Node core's `validateAbortSignal`, so cross-realm
+ * `AbortSignal`s and ponyfills are accepted.
+ *
+ * @private
+ */
+function validateAbortSignal(signal: AbortSignal | undefined) {
+  if (signal !== undefined && (signal === null || typeof signal !== 'object' || !('aborted' in signal))) {
+    throw new TypeError('The "options.signal" property must be an instance of AbortSignal');
+  }
+}
+
 function errorForAbortedSignal(signal: AbortSignal): Error {
   const reason = signal.reason;
   // `isNativeError` also recognizes `Error`s from other realms, which fail
@@ -2755,6 +2767,9 @@ class Connection extends EventEmitter {
    *   `DOMException`, which carries a legacy *numeric* `code` property - match abort outcomes
    *   on `err.name` (`'AbortError'`, `'TimeoutError'`) or on the signal's state, not on a
    *   tedious-style string `code`. The connection remains usable after an aborted request.
+   *   If the connection fails while the cancellation is in flight (e.g. the server does not
+   *   acknowledge it within [[ConnectionOptions.cancelTimeout]]), the request completes with
+   *   that connection error instead, like any other request on a failed connection.
    */
   execSqlBatch(request: Request, options?: { signal?: AbortSignal }) {
     this.makeRequest(request, TYPE.SQL_BATCH, new SqlBatchPayload(request.sqlTextOrProcedure!, this.currentTransactionDescriptor(), this.config.options), options);
@@ -2880,7 +2895,14 @@ class Connection extends EventEmitter {
   execBulkLoad(bulkLoad: BulkLoad, rows: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>, options?: { signal?: AbortSignal }): void
 
   execBulkLoad(bulkLoad: BulkLoad, rows?: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>, options?: { signal?: AbortSignal }) {
+    // Validated up front, before the bulk load is marked as started or the
+    // row stream is set up - an invalid signal must not leave a partially
+    // started bulk load behind.
+    validateAbortSignal(options?.signal);
+
     bulkLoad.executionStarted = true;
+
+    let rowStream: Readable | undefined;
 
     if (rows) {
       if (bulkLoad.streamingMode) {
@@ -2895,21 +2917,22 @@ class Connection extends EventEmitter {
       // away in `makeRequest` - don't start consuming the row iterable
       // for a bulk load that will never be sent.
       if (options?.signal?.aborted !== true) {
-        const rowStream = Readable.from(rows);
+        rowStream = Readable.from(rows);
+        const stream = rowStream;
 
         // Destroy the packet transform if an error happens in the row stream,
         // e.g. if an error is thrown from within a generator or stream.
-        rowStream.on('error', (err) => {
+        stream.on('error', (err) => {
           bulkLoad.rowToPacketTransform.destroy(err);
         });
 
         // Destroy the row stream if an error happens in the packet transform,
         // e.g. if the bulk load is cancelled.
         bulkLoad.rowToPacketTransform.on('error', (err) => {
-          rowStream.destroy(err);
+          stream.destroy(err);
         });
 
-        rowStream.pipe(bulkLoad.rowToPacketTransform);
+        stream.pipe(bulkLoad.rowToPacketTransform);
       }
     } else if (!bulkLoad.streamingMode) {
       // If the bulkload was not put into streaming mode by the user,
@@ -2933,6 +2956,13 @@ class Connection extends EventEmitter {
         if (error.code === 'UNKNOWN') {
           error.message += ' This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.';
         }
+
+        // The bulk load message will never be sent - tear down the row
+        // pipeline, so that an already-started row source stops producing
+        // rows and is finalized, instead of remaining paused indefinitely.
+        rowStream?.destroy();
+        bulkLoad.rowToPacketTransform.destroy();
+
         bulkLoad.error = error;
         bulkLoad.callback(error);
         return;
@@ -3304,11 +3334,7 @@ class Connection extends EventEmitter {
   makeRequest(request: Request | BulkLoad, packetType: number, payload: (Iterable<Buffer> | AsyncIterable<Buffer>) & { toString: (indent?: string) => string }, options?: { signal?: AbortSignal }) {
     const { signal } = options ?? {};
 
-    // Duck-typed like Node core's `validateAbortSignal`, so cross-realm
-    // `AbortSignal`s and ponyfills are accepted.
-    if (signal !== undefined && (signal === null || typeof signal !== 'object' || !('aborted' in signal))) {
-      throw new TypeError('The "options.signal" property must be an instance of AbortSignal');
-    }
+    validateAbortSignal(signal);
 
     // Clear any error left over from a previous execution of this request,
     // even if the request is rejected before being sent.

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3418,6 +3418,16 @@ class Connection extends EventEmitter {
 
   /**
    * Cancel currently executed request.
+   *
+   * The canceled request completes with a [[RequestError]] with code
+   * `ECANCEL`.
+   *
+   * For new code, prefer passing an `AbortSignal` when executing the
+   * request (see [[execSqlBatch]]): a signal targets one specific
+   * execution rather than "whatever request happens to be in flight",
+   * composes with `AbortSignal.timeout()` and `AbortSignal.any()`, and
+   * completes the request with the signal's abort reason instead of a
+   * generic `ECANCEL` error.
    */
   cancel() {
     if (!this.request) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -494,6 +494,15 @@ class Request extends EventEmitter {
 
   /**
    * Cancels a request while waiting for a server response.
+   *
+   * The request completes with a [[RequestError]] with code `ECANCEL`.
+   *
+   * For new code, prefer passing an `AbortSignal` when executing the
+   * request (see [[Connection.execSqlBatch]]): a signal composes with
+   * `AbortSignal.timeout()` and `AbortSignal.any()`, and completes the
+   * request with the signal's abort reason instead of a generic `ECANCEL`
+   * error. `cancel` remains as the imperative convenience for canceling a
+   * request without having set up a signal beforehand.
    */
   cancel() {
     if (this.canceled) {

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -386,8 +386,10 @@ export class RequestTokenHandler extends TokenHandler {
   }
 
   onErrorMessage(token: ErrorMessageToken) {
-    this.connection.emit('errorMessage', token);
-
+    // Record the server error before emitting the event: a listener may
+    // react to it synchronously - e.g. by aborting the request's
+    // `AbortSignal` - and the server error, whose token arrived first,
+    // must win over the abort reason.
     if (!this.request.canceled) {
       const error = new RequestError(token.message, 'EREQUEST');
 
@@ -403,6 +405,8 @@ export class RequestTokenHandler extends TokenHandler {
         this.request.error = new AggregateError(this.errors);
       }
     }
+
+    this.connection.emit('errorMessage', token);
   }
 
   onDatabaseChange(token: DatabaseEnvChangeToken) {

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -1944,6 +1944,96 @@ describe('Aborting a request via an `AbortSignal`', function() {
     });
   });
 
+  it('keeps the signals of sequential executions of the same request isolated', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - first execution.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(3));
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`select 1`) - second execution of the same request.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(5));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const controllerA = new AbortController();
+      const controllerB = new AbortController();
+
+      let executions = 0;
+
+      const request = new Request('select 1', (err, rowCount) => {
+        executions += 1;
+
+        if (executions === 1) {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 3);
+
+          // The first execution's signal was disarmed on completion -
+          // aborting it now must not affect the request or the next
+          // execution, which is bound to a different signal.
+          assert.lengthOf(getEventListeners(controllerA.signal, 'abort'), 0);
+          controllerA.abort(new Error('stale abort'));
+
+          connection.execSqlBatch(request, { signal: controllerB.signal });
+        } else {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 5);
+
+          assert.lengthOf(getEventListeners(controllerB.signal, 'abort'), 0);
+
+          connection.close();
+        }
+      });
+
+      connection.execSqlBatch(request, { signal: controllerA.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
   it('removes the `abort` listener from the signal when the request completes normally', function(done) {
     server.on('connection', async (connection) => {
       const debug = new Debug();

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -242,6 +242,34 @@ describe('Aborting a request via an `AbortSignal`', function() {
     assert.strictEqual(rowsConsumed, false);
   });
 
+  it('throws a `TypeError` for an invalid `signal` even when parameter validation would fail the request', function(done) {
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    const request = new Request('select @p', (err) => {
+      done(err ?? new Error('expected the request callback to not be called'));
+    });
+    request.addParameter('p', TYPES.Int, { not: 'a number' });
+
+    // The invalid signal must win over the invalid parameter: a
+    // synchronous `TypeError` instead of an asynchronous `EPARAM`
+    // completion.
+    assert.throws(() => {
+      connection.execSql(request, { signal: {} as AbortSignal });
+    }, TypeError, 'The "options.signal" property must be an instance of AbortSignal');
+
+    // The `EPARAM` completion would be delivered on a later tick - give
+    // it the chance to (incorrectly) fire before finishing the test.
+    setImmediate(() => {
+      done();
+    });
+  });
+
   it('throws a `TypeError` without putting the request into preparation mode when the `signal` option of `prepare` is invalid', function() {
     const connection = new Connection({
       server: (server.address() as net.AddressInfo).address,

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -10,14 +10,14 @@ import PreloginPayload from '../../src/prelogin-payload';
 import Message from '../../src/message';
 import { Packet } from '../../src/packet';
 
-function buildLoginAckToken(): Buffer {
+function buildLoginAckToken(tdsVersion: number[] = [0x74, 0x00, 0x00, 0x04]): Buffer {
   const progname = 'Tedious SQL Server';
 
   const buffer = Buffer.from([
     0xAD, // Type
     0x00, 0x00, // Length
     0x00, // interface number - SQL
-    0x74, 0x00, 0x00, 0x04, // TDS version number
+    ...tdsVersion, // TDS version number
     Buffer.byteLength(progname, 'ucs2') / 2, ...Buffer.from(progname, 'ucs2'), // Progname
     0x00, // major
     0x00, // minor
@@ -31,15 +31,22 @@ function buildLoginAckToken(): Buffer {
 
 /**
  * Builds a final `DONE` token, optionally with a row count.
+ *
+ * The row count is 64 bits wide in TDS 7.2 and later, and 32 bits wide
+ * in earlier versions.
  */
-function buildDoneToken(rowCount?: number): Buffer {
-  const buffer = Buffer.alloc(13);
+function buildDoneToken(rowCount?: number, use64BitRowCount = true): Buffer {
+  const buffer = Buffer.alloc(use64BitRowCount ? 13 : 9);
 
   let offset = 0;
   offset = buffer.writeUInt8(0xFD, offset); // DONE
   offset = buffer.writeUInt16LE(rowCount !== undefined ? 0x0010 : 0x0000, offset); // status = DONE_COUNT or DONE_FINAL
   offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
-  buffer.writeBigUInt64LE(BigInt(rowCount ?? 0), offset); // rowCount
+  if (use64BitRowCount) {
+    buffer.writeBigUInt64LE(BigInt(rowCount ?? 0), offset); // rowCount
+  } else {
+    buffer.writeUInt32LE(rowCount ?? 0, offset); // rowCount
+  }
 
   return buffer;
 }
@@ -97,7 +104,7 @@ async function drainMessage(message: Message): Promise<void> {
  * Handles the connection establishment sequence (`PRELOGIN`, `LOGIN7` and
  * the initial SQL batch) of the fake server.
  */
-async function performHandshake(messageIterator: AsyncIterator<Message>, outgoingMessageStream: OutgoingMessageStream): Promise<void> {
+async function performHandshake(messageIterator: AsyncIterator<Message>, outgoingMessageStream: OutgoingMessageStream, tdsVersion?: number[]): Promise<void> {
   // PRELOGIN
   {
     const { value: message } = await messageIterator.next();
@@ -118,8 +125,12 @@ async function performHandshake(messageIterator: AsyncIterator<Message>, outgoin
 
     await drainMessage(message);
 
+    // The `DONE` token's row count width depends on the TDS version that
+    // the `LOGINACK` token in the same message just negotiated.
+    const use64BitRowCount = tdsVersion === undefined || tdsVersion[0] >= 0x72;
+
     const responseMessage = new Message({ type: 0x04 });
-    responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+    responseMessage.end(Buffer.concat([buildLoginAckToken(tdsVersion), buildDoneToken(undefined, use64BitRowCount)]));
     outgoingMessageStream.write(responseMessage);
   }
 
@@ -625,6 +636,87 @@ describe('Aborting a request via an `AbortSignal`', function() {
         controller.abort(reason);
         signalAborted();
       });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('does not update the emulated transaction state when a legacy transaction request is aborted', function(done) {
+    // With TDS versions below 7.2, transactions are emulated with SQL
+    // batches and client-side `transactionDepth`/`inTransaction`
+    // bookkeeping. That bookkeeping must only be updated when the
+    // statement actually succeeded.
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // Negotiate TDS 7.1, so the transaction methods take the legacy
+        // SQL batch path.
+        await performHandshake(messageIterator, outgoingMessageStream, [0x71, 0x00, 0x00, 0x01]);
+
+        // SQL Batch (`BEGIN TRAN`) - the successful transaction begin.
+        // The aborted transaction requests never reach the server.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(undefined, false));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('transaction was abandoned');
+      const controller = new AbortController();
+      controller.abort(reason);
+
+      // An aborted `BEGIN TRAN` must leave the bookkeeping untouched.
+      connection.beginTransaction((err) => {
+        assert.strictEqual(err, reason);
+        assert.strictEqual(connection.transactionDepth, 0);
+        assert.strictEqual(connection.inTransaction, false);
+
+        // A successful `BEGIN TRAN` updates it.
+        connection.beginTransaction((err) => {
+          assert.isUndefined(err);
+          assert.strictEqual(connection.transactionDepth, 1);
+          assert.strictEqual(connection.inTransaction, true);
+
+          // An aborted `COMMIT TRAN` must leave it untouched as well.
+          connection.commitTransaction((err) => {
+            assert.strictEqual(err, reason);
+            assert.strictEqual(connection.transactionDepth, 1);
+            assert.strictEqual(connection.inTransaction, true);
+
+            connection.close();
+          }, '', { signal: controller.signal });
+        });
+      }, '', undefined, { signal: controller.signal });
     });
 
     connection.on('end', () => {

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -1,0 +1,1438 @@
+import { assert } from 'chai';
+import * as net from 'net';
+import { getEventListeners } from 'events';
+import { Connection, Request, RequestError, TYPES } from '../../src/tedious';
+import IncomingMessageStream from '../../src/incoming-message-stream';
+import OutgoingMessageStream from '../../src/outgoing-message-stream';
+import Debug from '../../src/debug';
+import PreloginPayload from '../../src/prelogin-payload';
+import Message from '../../src/message';
+import { Packet } from '../../src/packet';
+
+function buildLoginAckToken(): Buffer {
+  const progname = 'Tedious SQL Server';
+
+  const buffer = Buffer.from([
+    0xAD, // Type
+    0x00, 0x00, // Length
+    0x00, // interface number - SQL
+    0x74, 0x00, 0x00, 0x04, // TDS version number
+    Buffer.byteLength(progname, 'ucs2') / 2, ...Buffer.from(progname, 'ucs2'), // Progname
+    0x00, // major
+    0x00, // minor
+    0x00, 0x00, // buildNum
+  ]);
+
+  buffer.writeUInt16LE(buffer.length - 3, 1);
+
+  return buffer;
+}
+
+/**
+ * Builds a final `DONE` token, optionally with a row count.
+ */
+function buildDoneToken(rowCount?: number): Buffer {
+  const buffer = Buffer.alloc(13);
+
+  let offset = 0;
+  offset = buffer.writeUInt8(0xFD, offset); // DONE
+  offset = buffer.writeUInt16LE(rowCount !== undefined ? 0x0010 : 0x0000, offset); // status = DONE_COUNT or DONE_FINAL
+  offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
+  buffer.writeBigUInt64LE(BigInt(rowCount ?? 0), offset); // rowCount
+
+  return buffer;
+}
+
+/**
+ * Builds a `DONE` token that acknowledges a previously sent attention message.
+ */
+function buildAttentionAckToken(): Buffer {
+  const buffer = Buffer.alloc(13);
+
+  let offset = 0;
+  offset = buffer.writeUInt8(0xFD, offset); // DONE
+  offset = buffer.writeUInt16LE(0x0020, offset); // status = DONE_ATTN
+  offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
+  buffer.writeBigUInt64LE(0n, offset); // rowCount
+
+  return buffer;
+}
+
+/**
+ * Builds a `COLMETADATA` token for a single `int` column named `a`.
+ */
+function buildColMetadataToken(): Buffer {
+  return Buffer.from([
+    0x81, // COLMETADATA
+    0x01, 0x00, // column count
+    0x00, 0x00, 0x00, 0x00, // userType
+    0x00, 0x00, // flags
+    0x38, // INT4
+    0x01, 0x61, 0x00 // column name - 'a'
+  ]);
+}
+
+/**
+ * Builds a `ROW` token for a single non-null `int` column.
+ */
+function buildRowToken(value: number): Buffer {
+  const buffer = Buffer.alloc(5);
+  buffer.writeUInt8(0xD1, 0); // ROW
+  buffer.writeInt32LE(value, 1);
+  return buffer;
+}
+
+/**
+ * Reads and discards all data of the given message.
+ */
+async function drainMessage(message: Message): Promise<void> {
+  const iterator = message[Symbol.asyncIterator]();
+  while (!(await iterator.next()).done) {
+    // Discard the data.
+  }
+}
+
+/**
+ * Handles the connection establishment sequence (`PRELOGIN`, `LOGIN7` and
+ * the initial SQL batch) of the fake server.
+ */
+async function performHandshake(messageIterator: AsyncIterator<Message>, outgoingMessageStream: OutgoingMessageStream): Promise<void> {
+  // PRELOGIN
+  {
+    const { value: message } = await messageIterator.next();
+    assert.strictEqual(message.type, 0x12);
+
+    await drainMessage(message);
+
+    const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+    const responseMessage = new Message({ type: 0x12 });
+    responseMessage.end(responsePayload.data);
+    outgoingMessageStream.write(responseMessage);
+  }
+
+  // LOGIN7
+  {
+    const { value: message } = await messageIterator.next();
+    assert.strictEqual(message.type, 0x10);
+
+    await drainMessage(message);
+
+    const responseMessage = new Message({ type: 0x04 });
+    responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+    outgoingMessageStream.write(responseMessage);
+  }
+
+  // SQL Batch (Initial SQL)
+  {
+    const { value: message } = await messageIterator.next();
+    assert.strictEqual(message.type, 0x01);
+
+    await drainMessage(message);
+
+    const responseMessage = new Message({ type: 0x04 });
+    responseMessage.end();
+    outgoingMessageStream.write(responseMessage);
+  }
+}
+
+describe('Aborting a request via an `AbortSignal`', function() {
+  let server: net.Server;
+  let _connections: net.Socket[];
+
+  beforeEach(function(done) {
+    _connections = [];
+    server = net.createServer((connection) => {
+      _connections.push(connection);
+    });
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function(done) {
+    _connections.forEach((connection) => {
+      connection.destroy();
+    });
+
+    server.close(done);
+  });
+
+  it('throws a `TypeError` when the `signal` option is not an `AbortSignal`', function() {
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    const request = new Request('select 1', () => {
+      assert.fail('expected the request callback to not be called');
+    });
+
+    assert.throws(() => {
+      connection.execSqlBatch(request, { signal: {} as AbortSignal });
+    }, TypeError, 'The "options.signal" property must be an instance of AbortSignal');
+  });
+
+  it('accepts a cross-realm or ponyfilled `AbortSignal`-like object', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(3));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      // An `AbortSignal`-shaped object that is not an instance of this
+      // realm's `AbortSignal` - like a signal from another realm or a
+      // ponyfill. Validation is duck-typed (matching Node core's
+      // `validateAbortSignal`), so this must be accepted.
+      const added: [string, unknown][] = [];
+      const removed: [string, unknown][] = [];
+      const fakeSignal = {
+        aborted: false,
+        reason: undefined,
+        addEventListener(type: string, listener: unknown) {
+          added.push([type, listener]);
+        },
+        removeEventListener(type: string, listener: unknown) {
+          removed.push([type, listener]);
+        }
+      };
+
+      const request = new Request('select 1', (err, rowCount) => {
+        assert.isUndefined(err);
+        assert.strictEqual(rowCount, 3);
+
+        // The `abort` listener was armed on the signal-like object and
+        // removed again when the request completed.
+        assert.lengthOf(added, 1);
+        assert.strictEqual(added[0][0], 'abort');
+        assert.lengthOf(removed, 1);
+        assert.strictEqual(removed[0][1], added[0][1]);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: fakeSignal as unknown as AbortSignal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('fails the request with the abort reason without sending it when the signal is already aborted', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 2`) - the aborted request must never reach
+        // the server, so the next message is the follow-up request.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('operation was retired');
+      const controller = new AbortController();
+      controller.abort(reason);
+
+      const request = new Request('select 1', (err) => {
+        assert.strictEqual(err, reason);
+
+        // No `abort` listener may be left on the signal.
+        assert.lengthOf(getEventListeners(controller.signal, 'abort'), 0);
+
+        // The connection was not affected by the aborted request: the
+        // next request must complete normally.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('fails the request with an `EABORT` `RequestError` when the abort reason is not an `Error`', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const controller = new AbortController();
+      controller.abort('not an error');
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'EABORT');
+        assert.strictEqual((err as RequestError).cause, 'not an error');
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('fails a transaction request with the abort reason when the signal is already aborted', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 2`) - the aborted transaction request must
+        // never reach the server, so the next message is the follow-up
+        // request.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('transaction was abandoned');
+      const controller = new AbortController();
+      controller.abort(reason);
+
+      connection.beginTransaction((err) => {
+        assert.strictEqual(err, reason);
+
+        // The connection was not affected by the aborted transaction
+        // request: the next request must complete normally.
+        const request = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(request);
+      }, '', undefined, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with the abort reason when aborted after the request was sent', function(done) {
+    // Used by the server side to signal to the client side that the request
+    // message was fully received. Aborting after this point guarantees the
+    // cancellation is performed by sending an attention message.
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - no response is sent before
+        // the attention message arrives.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          signalRequestReceived();
+        }
+
+        // ATTENTION
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          // Every client request receives exactly one response message:
+          // first the response to the aborted request, then a separate
+          // message containing only the `DONE` token that acknowledges
+          // the attention message.
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+
+        // SQL Batch (`select 2`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const controller = new AbortController();
+
+      const request = new Request('select 1', (err) => {
+        // `controller.abort()` was called without an explicit reason, so
+        // the request completes with the default `AbortError`.
+        assert.instanceOf(err, Error);
+        assert.strictEqual(err!.name, 'AbortError');
+        assert.strictEqual(err, controller.signal.reason);
+
+        // No `abort` listener may be left on the signal.
+        assert.lengthOf(getEventListeners(controller.signal, 'abort'), 0);
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response, not the leftover attention
+        // acknowledgement message.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+
+      // Abort the request once the server received the request message.
+      requestReceived.then(() => {
+        controller.abort();
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with a `TimeoutError` when an `AbortSignal.timeout()` signal expires', function(done) {
+    this.timeout(2000);
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - the server never responds, like a
+        // server executing a long-running query. The timeout signal
+        // expires while the client is waiting for the response.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+        }
+
+        // ATTENTION - sent when the timeout signal expired.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const signal = AbortSignal.timeout(200);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, Error);
+        assert.strictEqual(err!.name, 'TimeoutError');
+        assert.strictEqual(err, signal.reason);
+
+        // No `abort` listener may be left on the signal.
+        assert.lengthOf(getEventListeners(signal, 'abort'), 0);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('fails a bulk load with the abort reason without sending it when the signal is already aborted', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 2`) - neither the `insert bulk` statement nor
+        // the bulk load message of the aborted bulk load must reach the
+        // server, so the next message is the follow-up request.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('bulk load was abandoned');
+      const controller = new AbortController();
+      controller.abort(reason);
+
+      const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
+        assert.strictEqual(err, reason);
+
+        // The connection was not affected by the aborted bulk load: the
+        // next request must complete normally.
+        const request = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(request);
+      });
+
+      bulkLoad.addColumn('a', TYPES.Int, { nullable: false });
+
+      connection.execBulkLoad(bulkLoad, [{ a: 1 }], { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes a bulk load with the abort reason when aborted while the bulk load message is being sent', function(done) {
+    // Used by the client side to signal to the server side that the bulk
+    // load was aborted.
+    let signalAborted!: () => void;
+    const bulkLoadAborted = new Promise<void>((resolve) => {
+      signalAborted = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`insert bulk ...`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // Bulk Load
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x07);
+
+          // Send the first packet of the response message right away,
+          // while the client is still sending the bulk load message,
+          // like a server would do when it encounters an error in the
+          // middle of a bulk load.
+          const packet = new Packet(0x04);
+          packet.packetId(1);
+          packet.addData(buildColMetadataToken());
+          connection.write(packet.buffer);
+
+          // Wait until the client aborted the bulk load before reading
+          // the bulk load message, so that the abort is guaranteed
+          // to happen while the bulk load message is still being sent.
+          await bulkLoadAborted;
+
+          // Drain the bulk load message. As the bulk load was aborted
+          // while it was being sent, the message ends with the `IGNORE`
+          // bit set.
+          await drainMessage(message);
+
+          // Finish the response message.
+          const finalPacket = new Packet(0x04);
+          finalPacket.packetId(2);
+          finalPacket.last(true);
+          finalPacket.addData(buildDoneToken());
+          connection.write(finalPacket.buffer);
+        }
+
+        // SQL Batch (`select 2`) - no attention message is expected
+        // in between, as the aborted bulk load message was never
+        // fully sent.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('bulk load was abandoned');
+      const controller = new AbortController();
+
+      const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
+        assert.strictEqual(err, reason);
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      bulkLoad.addColumn('a', TYPES.VarBinary, { length: 8000, nullable: false });
+
+      // A row stream that never completes, so the bulk load message
+      // stays in flight until the bulk load is aborted. The first row
+      // is large enough to fill a packet, so the server starts receiving
+      // the bulk load message right away.
+      connection.execBulkLoad(bulkLoad, (async function*() {
+        yield [Buffer.alloc(8000)];
+
+        await new Promise<unknown>(() => {
+          // This promise never resolves.
+        });
+      })(), { signal: controller.signal });
+
+      // Abort the bulk load once the first part of the response message
+      // has arrived, while the bulk load message is still being sent.
+      bulkLoad.on('columnMetadata', () => {
+        controller.abort(reason);
+        signalAborted();
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with the abort reason when aborted while the response is streaming', function(done) {
+    // Used by the client side to signal to the server side that the
+    // request was aborted.
+    let signalAborted!: () => void;
+    const requestAborted = new Promise<void>((resolve) => {
+      signalAborted = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - the response starts streaming (column
+        // metadata and two rows), but the response message is not
+        // finished before the abort happens.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const packet = new Packet(0x04);
+          packet.packetId(1);
+          packet.addData(Buffer.concat([buildColMetadataToken(), buildRowToken(1), buildRowToken(2)]));
+          connection.write(packet.buffer);
+        }
+
+        // ATTENTION - sent when the client aborted the request while its
+        // response was streaming.
+        {
+          await requestAborted;
+
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          // Finish the (cut short) response to the aborted request, then
+          // acknowledge the attention message in a separate message.
+          const finalPacket = new Packet(0x04);
+          finalPacket.packetId(2);
+          finalPacket.last(true);
+          finalPacket.addData(buildDoneToken());
+          connection.write(finalPacket.buffer);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+
+        // SQL Batch (`select 2`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('no more rows needed');
+      const controller = new AbortController();
+
+      let rowsSeen = 0;
+
+      const request = new Request('select 1', (err) => {
+        assert.strictEqual(err, reason);
+        assert.strictEqual(rowsSeen, 2);
+
+        // No `abort` listener may be left on the signal.
+        assert.lengthOf(getEventListeners(controller.signal, 'abort'), 0);
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response, not the leftover attention
+        // acknowledgement message.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      // Abort the request once the first rows of the response arrived.
+      request.on('row', () => {
+        rowsSeen += 1;
+
+        if (rowsSeen === 2) {
+          controller.abort(reason);
+          signalAborted();
+        }
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with the abort reason when the request timer would fire after the abort', function(done) {
+    this.timeout(2000);
+
+    // Used by the server side to signal to the client side that the
+    // request message was fully received.
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - no response is sent before
+        // the attention message arrives.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          signalRequestReceived();
+        }
+
+        // ATTENTION - sent when the client aborted the request. The
+        // acknowledgement is delayed beyond the request timeout, so a
+        // request timer that was (incorrectly) left running would fire
+        // during this window and overwrite the abort reason with an
+        // `ETIMEOUT` error.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          await new Promise((resolve) => setTimeout(resolve, 250));
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        requestTimeout: 100,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('operation was retired');
+      const controller = new AbortController();
+
+      const request = new Request('select 1', (err) => {
+        assert.strictEqual(err, reason);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+
+      // Abort the request once the server received the request message,
+      // well before the request timeout expires.
+      requestReceived.then(() => {
+        controller.abort(reason);
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with `ETIMEOUT` when the request timeout fired before the signal was aborted', function(done) {
+    this.timeout(2000);
+
+    // Used by the client side to signal to the server side that the
+    // signal was aborted (after the request timeout already canceled the
+    // request).
+    let signalAborted!: () => void;
+    const requestAborted = new Promise<void>((resolve) => {
+      signalAborted = resolve;
+    });
+
+    // Used by the server side to signal to the client side that the
+    // attention message (sent by the request timeout's cancellation)
+    // was received.
+    let signalAttentionReceived!: () => void;
+    const attentionReceived = new Promise<void>((resolve) => {
+      signalAttentionReceived = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - no response is sent, so the request
+        // timeout expires and cancels the request.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+        }
+
+        // ATTENTION - sent by the request timeout's cancellation.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          signalAttentionReceived();
+
+          // Wait until the client aborted the signal, so that the abort
+          // is guaranteed to happen after the timeout.
+          await requestAborted;
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        requestTimeout: 50,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('too late');
+      const controller = new AbortController();
+
+      const request = new Request('select 1', (err) => {
+        // The request timeout fired first, so its `ETIMEOUT` error wins
+        // over the abort reason.
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'ETIMEOUT');
+        assert.notStrictEqual(err, reason);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+
+      // Abort the signal only after the request timeout already canceled
+      // the request.
+      attentionReceived.then(() => {
+        controller.abort(reason);
+        signalAborted();
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('fails a bulk load with the abort reason when aborted during the `insert bulk` statement', function(done) {
+    // Used by the server side to signal to the client side that the
+    // `insert bulk` statement was fully received.
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`insert bulk ...`) - no response is sent before
+        // the attention message arrives.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          signalRequestReceived();
+        }
+
+        // ATTENTION
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+
+        // SQL Batch (`select 2`) - the bulk load message (0x07) must
+        // never be sent, as the bulk load was aborted during its
+        // `insert bulk` statement.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('bulk load was abandoned');
+      const controller = new AbortController();
+
+      const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
+        assert.strictEqual(err, reason);
+
+        // The message stream should still be aligned: the next request
+        // must receive its own response.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      bulkLoad.addColumn('a', TYPES.Int, { nullable: false });
+
+      connection.execBulkLoad(bulkLoad, [{ a: 1 }], { signal: controller.signal });
+
+      // Abort the bulk load once the server received the `insert bulk`
+      // statement, before the bulk load message itself was sent.
+      requestReceived.then(() => {
+        controller.abort(reason);
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('removes the `abort` listener from the signal when the connection is closed while a request is in flight', function(done) {
+    // Used by the server side to signal to the client side that the
+    // request message was fully received.
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - the server never responds; the
+        // connection is closed by the client while the request is in
+        // flight.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          signalRequestReceived();
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    const controller = new AbortController();
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'ECLOSE');
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+
+      // Close the connection once the server received the request
+      // message, while the `abort` listener is armed.
+      requestReceived.then(() => {
+        assert.lengthOf(getEventListeners(controller.signal, 'abort'), 1);
+
+        connection.close();
+      });
+    });
+
+    connection.on('end', () => {
+      // The `abort` listener must have been removed when the connection
+      // was torn down.
+      assert.lengthOf(getEventListeners(controller.signal, 'abort'), 0);
+
+      done();
+    });
+  });
+
+  it('removes the `abort` listener from the signal when the request completes normally', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(3));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const controller = new AbortController();
+
+      const request = new Request('select 1', (err, rowCount) => {
+        assert.isUndefined(err);
+        assert.strictEqual(rowCount, 3);
+
+        // The `abort` listener must have been removed - a long-lived
+        // signal must not accumulate listeners across requests.
+        assert.lengthOf(getEventListeners(controller.signal, 'abort'), 0);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+
+      // While the request is in flight, the `abort` listener is armed.
+      assert.lengthOf(getEventListeners(controller.signal, 'abort'), 1);
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+});

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -81,6 +81,33 @@ function buildColMetadataToken(): Buffer {
 }
 
 /**
+ * Builds an `ERROR` token, as a server would send when it encounters an
+ * error in the middle of processing a request.
+ */
+function buildErrorToken(message: string): Buffer {
+  const messageData = Buffer.from(message, 'ucs2');
+
+  const data = Buffer.alloc(4 + 1 + 1 + 2 + messageData.length + 1 + 1 + 4);
+
+  let offset = 0;
+  offset = data.writeUInt32LE(50000, offset); // number
+  offset = data.writeUInt8(1, offset); // state
+  offset = data.writeUInt8(16, offset); // class
+  offset = data.writeUInt16LE(message.length, offset); // message length (in characters)
+  offset += messageData.copy(data, offset); // message
+  offset = data.writeUInt8(0, offset); // server name length
+  offset = data.writeUInt8(0, offset); // proc name length
+  data.writeUInt32LE(0, offset); // line number (TDS 7.2+)
+
+  const buffer = Buffer.alloc(3 + data.length);
+  buffer.writeUInt8(0xAA, 0); // ERROR
+  buffer.writeUInt16LE(data.length, 1); // token length
+  data.copy(buffer, 3);
+
+  return buffer;
+}
+
+/**
  * Builds a `ROW` token for a single non-null `int` column.
  */
 function buildRowToken(value: number): Buffer {
@@ -213,6 +240,208 @@ describe('Aborting a request via an `AbortSignal`', function() {
     // the row iterable never consumed.
     assert.strictEqual(bulkLoad.executionStarted, false);
     assert.strictEqual(rowsConsumed, false);
+  });
+
+  it('throws a `TypeError` without putting the request into preparation mode when the `signal` option of `prepare` is invalid', function() {
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    const request = new Request('select 1', () => {
+      assert.fail('expected the request callback to not be called');
+    });
+
+    assert.throws(() => {
+      connection.prepare(request, { signal: {} as AbortSignal });
+    }, TypeError, 'The "options.signal" property must be an instance of AbortSignal');
+
+    // The request must be left untouched - in particular, it must not be
+    // stuck in preparation mode.
+    assert.strictEqual(request.preparing, false);
+  });
+
+  it('completes the request with `ECANCEL` when an already-canceled request is executed with an already-aborted signal', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 2`) - the canceled request must never reach
+        // the server, so the next message is the follow-up request.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken(7));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('too late');
+      const controller = new AbortController();
+      controller.abort(reason);
+
+      const request = new Request('select 1', (err) => {
+        // The cancellation happened before the request was executed, so
+        // it wins over the already-aborted signal - attaching a signal
+        // must not change the outcome of an already-canceled request.
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'ECANCEL');
+        assert.notStrictEqual(err, reason);
+
+        // The connection was not affected: the next request must
+        // complete normally.
+        const secondRequest = new Request('select 2', (err, rowCount) => {
+          assert.isUndefined(err);
+          assert.strictEqual(rowCount, 7);
+
+          connection.close();
+        });
+
+        connection.execSqlBatch(secondRequest);
+      });
+
+      request.cancel();
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with the server error when the signal is aborted from within the `errorMessage` event', function(done) {
+    // Used by the client side to signal to the server side that the
+    // signal was aborted.
+    let signalAborted!: () => void;
+    const requestAborted = new Promise<void>((resolve) => {
+      signalAborted = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - the response starts with an `ERROR`
+        // token, but the response message is not finished before the
+        // abort happens.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const packet = new Packet(0x04);
+          packet.packetId(1);
+          packet.addData(buildErrorToken('boom'));
+          connection.write(packet.buffer);
+        }
+
+        // ATTENTION - sent when the client aborted the request from
+        // within the `errorMessage` event.
+        {
+          await requestAborted;
+
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          // Finish the (cut short) response to the aborted request, then
+          // acknowledge the attention message in a separate message.
+          const finalPacket = new Packet(0x04);
+          finalPacket.packetId(2);
+          finalPacket.last(true);
+          finalPacket.addData(buildDoneToken());
+          connection.write(finalPacket.buffer);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('aborted on server error');
+      const controller = new AbortController();
+
+      const request = new Request('select 1', (err) => {
+        // The server error's token arrived before the abort, so it wins
+        // over the abort reason.
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'EREQUEST');
+        assert.strictEqual(err!.message, 'boom');
+        assert.notStrictEqual(err, reason);
+
+        connection.close();
+      });
+
+      // Abort the signal synchronously from within the `errorMessage`
+      // event - the server error must already be recorded at this point.
+      connection.on('errorMessage', () => {
+        controller.abort(reason);
+        signalAborted();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
   });
 
   it('accepts a cross-realm or ponyfilled `AbortSignal`-like object', function(done) {

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -174,6 +174,36 @@ describe('Aborting a request via an `AbortSignal`', function() {
     }, TypeError, 'The "options.signal" property must be an instance of AbortSignal');
   });
 
+  it('throws a `TypeError` without starting a bulk load when its `signal` option is invalid', function() {
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    const bulkLoad = connection.newBulkLoad('#tmp', () => {
+      assert.fail('expected the bulk load callback to not be called');
+    });
+
+    bulkLoad.addColumn('a', TYPES.Int, { nullable: false });
+
+    let rowsConsumed = false;
+
+    assert.throws(() => {
+      connection.execBulkLoad(bulkLoad, (function*() {
+        rowsConsumed = true;
+        yield { a: 1 };
+      })(), { signal: 42 as unknown as AbortSignal });
+    }, TypeError, 'The "options.signal" property must be an instance of AbortSignal');
+
+    // The bulk load must be left untouched: not marked as started, and
+    // the row iterable never consumed.
+    assert.strictEqual(bulkLoad.executionStarted, false);
+    assert.strictEqual(rowsConsumed, false);
+  });
+
   it('accepts a cross-realm or ponyfilled `AbortSignal`-like object', function(done) {
     server.on('connection', async (connection) => {
       const debug = new Debug();
@@ -1363,6 +1393,9 @@ describe('Aborting a request via an `AbortSignal`', function() {
       signalRequestReceived = resolve;
     });
 
+    let rowsStarted = false;
+    let rowsFinalized = false;
+
     server.on('connection', async (connection) => {
       const debug = new Debug();
       const incomingMessageStream = new IncomingMessageStream(debug);
@@ -1453,7 +1486,20 @@ describe('Aborting a request via an `AbortSignal`', function() {
 
       bulkLoad.addColumn('a', TYPES.Int, { nullable: false });
 
-      connection.execBulkLoad(bulkLoad, [{ a: 1 }], { signal: controller.signal });
+      // A row generator that produces rows until backpressure suspends it
+      // at a `yield`. Aborting during the `insert bulk` statement must
+      // tear down the row pipeline and finalize the generator (running
+      // its `finally` block) instead of leaving it paused indefinitely.
+      connection.execBulkLoad(bulkLoad, (function*() {
+        try {
+          while (true) {
+            rowsStarted = true;
+            yield { a: 1 };
+          }
+        } finally {
+          rowsFinalized = true;
+        }
+      })(), { signal: controller.signal });
 
       // Abort the bulk load once the server received the `insert bulk`
       // statement, before the bulk load message itself was sent.
@@ -1463,7 +1509,14 @@ describe('Aborting a request via an `AbortSignal`', function() {
     });
 
     connection.on('end', () => {
-      done();
+      setImmediate(() => {
+        // The row pipeline was already running when the abort happened,
+        // and must have been torn down and finalized.
+        assert.strictEqual(rowsStarted, true);
+        assert.strictEqual(rowsFinalized, true);
+
+        done();
+      });
     });
   });
 

--- a/test/unit/request-abort-signal-test.ts
+++ b/test/unit/request-abort-signal-test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import * as net from 'net';
 import { getEventListeners } from 'events';
+import { runInNewContext } from 'vm';
 import { Connection, Request, RequestError, TYPES } from '../../src/tedious';
 import IncomingMessageStream from '../../src/incoming-message-stream';
 import OutgoingMessageStream from '../../src/outgoing-message-stream';
@@ -441,6 +442,166 @@ describe('Aborting a request via an `AbortSignal`', function() {
     });
   });
 
+  it('preserves the abort reason of an `Error` created in another realm', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      // An `Error` from another realm fails an `instanceof Error` check,
+      // but must still be recognized as an `Error` reason and passed
+      // through unchanged instead of being wrapped in an `EABORT` error.
+      const reason = runInNewContext('new Error("cross-realm failure")');
+      assert.notInstanceOf(reason, Error);
+
+      const controller = new AbortController();
+      controller.abort(reason);
+
+      const request = new Request('select 1', (err) => {
+        assert.strictEqual(err, reason);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
+  it('completes the request with `ECANCEL` when the request was canceled before the signal was aborted', function(done) {
+    // Used by the server side to signal to the client side that the
+    // request message was fully received.
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
+    // Used by the client side to signal to the server side that the
+    // signal was aborted (after the request was already canceled).
+    let signalAborted!: () => void;
+    const requestAborted = new Promise<void>((resolve) => {
+      signalAborted = resolve;
+    });
+
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        await performHandshake(messageIterator, outgoingMessageStream);
+
+        // SQL Batch (`select 1`) - no response is sent before
+        // the attention message arrives.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          signalRequestReceived();
+        }
+
+        // ATTENTION - sent by the manual cancellation. The
+        // acknowledgement is withheld until the signal was aborted, so
+        // the abort is guaranteed to happen while the cancellation is
+        // still waiting for its acknowledgement.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x06);
+
+          await drainMessage(message);
+
+          await requestAborted;
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(buildDoneToken());
+          outgoingMessageStream.write(responseMessage);
+
+          const ackMessage = new Message({ type: 0x04 });
+          ackMessage.end(buildAttentionAckToken());
+          outgoingMessageStream.write(ackMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false,
+        cancelTimeout: 0
+      }
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const reason = new Error('too late');
+      const controller = new AbortController();
+
+      const request = new Request('select 1', (err) => {
+        // The manual cancellation happened first, so the request
+        // completes with the established `ECANCEL` error - attaching a
+        // signal must not change the outcome of an earlier cancellation.
+        assert.instanceOf(err, RequestError);
+        assert.strictEqual((err as RequestError).code, 'ECANCEL');
+        assert.notStrictEqual(err, reason);
+
+        connection.close();
+      });
+
+      connection.execSqlBatch(request, { signal: controller.signal });
+
+      // Cancel the request once the server received the request message,
+      // then abort the signal while the cancellation is waiting for the
+      // attention acknowledgement.
+      requestReceived.then(() => {
+        connection.cancel();
+
+        controller.abort(reason);
+        signalAborted();
+      });
+    });
+
+    connection.on('end', () => {
+      done();
+    });
+  });
+
   it('completes the request with the abort reason when aborted after the request was sent', function(done) {
     // Used by the server side to signal to the client side that the request
     // message was fully received. Aborting after this point guarantees the
@@ -686,8 +847,15 @@ describe('Aborting a request via an `AbortSignal`', function() {
       const controller = new AbortController();
       controller.abort(reason);
 
+      let rowsConsumed = false;
+
       const bulkLoad = connection.newBulkLoad('#tmp', (err) => {
         assert.strictEqual(err, reason);
+
+        // The row iterable of an already-aborted bulk load must never be
+        // started - e.g. a resource-owning generator must not be left
+        // paused without finalization.
+        assert.strictEqual(rowsConsumed, false);
 
         // The connection was not affected by the aborted bulk load: the
         // next request must complete normally.
@@ -703,7 +871,10 @@ describe('Aborting a request via an `AbortSignal`', function() {
 
       bulkLoad.addColumn('a', TYPES.Int, { nullable: false });
 
-      connection.execBulkLoad(bulkLoad, [{ a: 1 }], { signal: controller.signal });
+      connection.execBulkLoad(bulkLoad, (function*() {
+        rowsConsumed = true;
+        yield { a: 1 };
+      })(), { signal: controller.signal });
     });
 
     connection.on('end', () => {


### PR DESCRIPTION
## Summary

Adds `AbortSignal` support to request execution, as laid out in the plan on #1765 (part 2 of the sequencing there): a caller-controlled way to express total-time bounds (`AbortSignal.timeout()`), deadlines, and linked cancellation (`AbortSignal.any()`) — instead of introducing a second driver-level timeout option.

All request-execution entry points accept a new trailing `options?: { signal?: AbortSignal }` argument:

- `execSql`, `execSqlBatch`, `execute`, `callProcedure`, `prepare`, `unprepare`
- `execBulkLoad` (the signal covers both the `insert bulk` statement and the bulk load message)
- `beginTransaction`, `commitTransaction`, `rollbackTransaction`, `saveTransaction`

```js
connection.execSql(request, { signal: AbortSignal.timeout(60_000) });
```

The signal is scoped to that single execution — matching `fetch(url, { signal })` — so a `Request` that is executed multiple times (the prepare/execute flow) gets a fresh signal per execution.

## Semantics

- **Abort mid-flight** cancels the request through the existing graceful cancellation mechanism (terminating the request message with the `IGNORE` bit, or sending an attention message). The connection remains usable afterwards, and the worst case is bounded by `cancelTimeout` (the existing backstop tears the connection down if the server never acknowledges the attention). Connection-fatal errors during the cancellation (socket failure, `cancelTimeout` teardown, `close()`) supersede the request-level outcome, as they do for every other cancellation source.
- **The request completes with the signal's abort reason** (`err === signal.reason`), so a `TimeoutError` from `AbortSignal.timeout()` is distinguishable from a manual `ECANCEL` cancellation. A non-`Error` abort reason is wrapped in a `RequestError` with code `EABORT`; `Error` reasons from other realms are recognized via `util.types.isNativeError` and passed through unchanged.
- **First failure cause wins**: an error recorded before the abort (a server error — including one whose token arrives in the same tick the abort is triggered from, a request timeout's `ETIMEOUT`, or a manual `request.cancel()` before or during execution) takes precedence over the abort reason. Aborting also stops the request timer, so a slow attention acknowledgement can no longer replace the abort reason with a spurious `ETIMEOUT`.
- **An already-aborted signal** fails the request immediately with the abort reason, without anything being sent to the server (for a bulk load, the row iterable is never started).
- **Validation is duck-typed**, byte-for-byte matching Node core's `validateAbortSignal`, so cross-realm `AbortSignal`s and ponyfills are accepted; invalid values throw a `TypeError` synchronously at every entry point, before any request or connection state is touched.
- The `abort` listener is armed per execution and removed on every completion path, so a long-lived signal shared across many requests does not accumulate listeners, and signals of sequential executions of the same `Request` stay isolated.

Note for wrappers switching on `err.code`: a default abort reason is a `DOMException`, whose legacy `code` property is *numeric* — match abort outcomes on `err.name` (`'AbortError'`, `'TimeoutError'`) or on the signal's state. This is called out in the `execSqlBatch` typedoc, which the other methods reference.

## Relationship to the existing cancellation API

`request.cancel()` and `connection.cancel()` stay, undeprecated — they remain the imperative convenience for canceling a request without having set up a signal beforehand (the same coexistence as `SqlCommand.Cancel()` alongside `CancellationToken` in SqlClient, or `Statement.cancel()` alongside query timeouts in JDBC). The docs now recommend `signal` for new code. As part of the async `makeRequest` rework (#1656/#1492), the internal layering should invert: cancellation becomes one internal per-request `AbortController` (feeding `writeMessage`'s `cancelSignal` from #1756), with `request.cancel()`, `requestTimeout`, and the user's signal as its triggers.

## Implementation

The per-execution state lives on the `Connection`, alongside its existing request-scoped state: `requestAbortSignal` mirrors `requestTimer`/`cancelTimer`, the pre-bound `_onRequestAbort` handler mirrors `_cancelAfterRequestSent`, and `clearRequestAbortListener()` is called at the same completion sites as the timer clears (`cleanupConnection`, the end-of-message completion, and the attention-ack delivery). `Request` and `BulkLoad` are untouched apart from docs. This shape is also a rehearsal for the async `makeRequest` rework, where the field collapses into a `try`/`finally` local.

## Testing

24 tests in `test/unit/request-abort-signal-test.ts`, using the fake-server pattern from the cancel tests: already-aborted (request, transaction, bulk load — including that the row iterable is never consumed), non-`Error` reason, cross-realm `Error` reason, abort after send (attention exchange + stream alignment), abort during response streaming, abort from within the `errorMessage` event, `AbortSignal.timeout()` reason identity, abort/`requestTimeout`/manual-cancel precedence in all orderings (pre-execution and in-flight), abort during each bulk-load phase (with generator finalization asserted), the TDS &lt; 7.2 transaction bookkeeping guards, `close()` with an armed listener, listener cleanup, signal isolation across sequential executions of the same `Request`, duck-typed signal acceptance, and synchronous `TypeError` validation at every entry point.

- `npm test`: 451 passing (427 on master + 24), 0 failing; repeat runs green
- `npx eslint src test` + `tsc`: clean

## Independent behavior fixes bundled in this PR (release-note worthy on their own)

- **TDS &lt; 7.2 emulated-transaction bookkeeping**: `transactionDepth`/`inTransaction` are now only updated when the transaction statement succeeded. Previously *any* failure on that path (`ECLOSE`, `ECANCEL`, `EINVALIDSTATE`, server errors) corrupted the client-side counters.
- **Bulk-load row-pipeline teardown**: when the `insert bulk` statement fails — for any reason, not just an abort (e.g. the existing schema-mismatch `UNKNOWN` error) — the row stream and `rowToPacketTransform` are now destroyed, finalizing a suspended row generator instead of leaving it paused indefinitely. This was a pre-existing resource leak on master.
- **Server errors are recorded before the `errorMessage` event is emitted** (`token/handler.ts`), closing a race where a listener reacting synchronously could observe/act before the error was recorded.

## Known trade-offs

- Aborting a transaction method mid-flight can leave the client-side `transactionDepth`/`inTransaction` bookkeeping out of sync with server state if the server already processed the request — the same exposure `requestTimeout` has on those requests today.
- An abort during a bulk load's `insert bulk` phase does not set `bulkLoad.canceled` (the bulk load still completes with the abort reason); an abort during the bulk-load message phase does.
- An aborted execution sets the `Request`'s `canceled` flag, so the same `Request` object cannot be re-executed — matching master's existing behavior for manual cancels and request timeouts; retry with a fresh `Request`.
- Aborting **connection establishment** is out of scope; `connect()` is internally signal-based already, so a public `connect(callback, { signal })` would be a natural follow-up.

Refs #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)