### PR TITLE
feat: add support for `TABNAME` and `COLINFO` tokens

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -287,11 +287,10 @@ class Request extends EventEmitter {
       /**
        * @param tableNames
        *   The names of the base tables referenced in the query, in the order the
-       *   `colInfo` event's `tableNum` values refer to them. On TDS 7.2 and newer,
-       *   each name is given as its individual parts (e.g. `['dbo', 'employees']`),
-       *   on older versions as a single string.
+       *   `colInfo` event's `tableNum` values refer to them. Each name is given
+       *   as its individual parts (e.g. `['dbo', 'employees']`).
        */
-      (tableNames: (string | string[])[]) => void
+      (tableNames: string[][]) => void
   ): this
 
   /**
@@ -377,7 +376,7 @@ class Request extends EventEmitter {
   /**
    * @private
    */
-  emit(event: 'tabName', tableNames: (string | string[])[]): boolean
+  emit(event: 'tabName', tableNames: string[][]): boolean
   /**
    * @private
    */

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,7 @@ import Connection from './connection';
 import { type Metadata } from './metadata-parser';
 import { SQLServerStatementColumnEncryptionSetting } from './always-encrypted/types';
 import { type ColumnMetadata } from './token/colmetadata-token-parser';
+import { type ColumnInfo } from './token/token';
 import { Collation } from './collation';
 
 /**
@@ -276,6 +277,39 @@ class Request extends EventEmitter {
       (orderColumns: number[]) => void
   ): this
 
+  /**
+   * This event gives the names of the base tables of the result set, if the query was
+   * executed in browse mode (e.g. with a `FOR BROWSE` clause or `SET NO_BROWSETABLE ON`).
+   */
+  on(
+    event: 'tabName',
+    listener:
+      /**
+       * @param tableNames
+       *   The names of the base tables referenced in the query, in the order the
+       *   `colInfo` event's `tableNum` values refer to them. On TDS 7.2 and newer,
+       *   each name is given as its individual parts (e.g. `['dbo', 'employees']`),
+       *   on older versions as a single string.
+       */
+      (tableNames: (string | string[])[]) => void
+  ): this
+
+  /**
+   * This event describes how the columns of the result set map back to the base tables
+   * given in the `tabName` event, if the query was executed in browse mode (e.g. with a
+   * `FOR BROWSE` clause or `SET NO_BROWSETABLE ON`).
+   */
+  on(
+    event: 'colInfo',
+    listener:
+      /**
+       * @param columns
+       *   One entry for each column in the result set, describing the base table
+       *   the column was derived from.
+       */
+      (columns: ColumnInfo[]) => void
+  ): this
+
   on(event: 'requestCompleted', listener: () => void): this
 
   on(event: 'cancel', listener: () => void): this
@@ -340,6 +374,14 @@ class Request extends EventEmitter {
    * @private
    */
   emit(event: 'order', orderColumns: number[]): boolean
+  /**
+   * @private
+   */
+  emit(event: 'tabName', tableNames: (string | string[])[]): boolean
+  /**
+   * @private
+   */
+  emit(event: 'colInfo', columns: ColumnInfo[]): boolean
   emit(event: string | symbol, ...args: any[]) {
     return super.emit(event, ...args);
   }

--- a/src/token/colinfo-token-parser.ts
+++ b/src/token/colinfo-token-parser.ts
@@ -1,4 +1,4 @@
-// s2.2.7.6
+// s2.2.7.3
 import { type ParserOptions } from './stream-parser';
 
 import { ColInfoToken, type ColumnInfo } from './token';

--- a/src/token/colinfo-token-parser.ts
+++ b/src/token/colinfo-token-parser.ts
@@ -48,6 +48,10 @@ function colInfoParser(buf: Buffer, offset: number, _options: ParserOptions): Re
     });
   }
 
+  if (offset !== end) {
+    throw new Error('Malformed COLINFO token');
+  }
+
   return new Result(new ColInfoToken(columns), offset);
 }
 

--- a/src/token/colinfo-token-parser.ts
+++ b/src/token/colinfo-token-parser.ts
@@ -1,0 +1,55 @@
+// s2.2.7.6
+import { type ParserOptions } from './stream-parser';
+
+import { ColInfoToken, type ColumnInfo } from './token';
+import { NotEnoughDataError, readBVarChar, readUInt16LE, readUInt8, Result } from './helpers';
+
+const STATUS = {
+  EXPRESSION: 0x04,
+  KEY: 0x08,
+  HIDDEN: 0x10,
+  DIFFERENT_NAME: 0x20
+};
+
+function colInfoParser(buf: Buffer, offset: number, _options: ParserOptions): Result<ColInfoToken> {
+  // length
+  let tokenLength;
+  ({ offset, value: tokenLength } = readUInt16LE(buf, offset));
+
+  if (buf.length < offset + tokenLength) {
+    throw new NotEnoughDataError(offset + tokenLength);
+  }
+
+  const end = offset + tokenLength;
+  const columns: ColumnInfo[] = [];
+
+  while (offset < end) {
+    let colNum;
+    ({ offset, value: colNum } = readUInt8(buf, offset));
+
+    let tableNum;
+    ({ offset, value: tableNum } = readUInt8(buf, offset));
+
+    let status;
+    ({ offset, value: status } = readUInt8(buf, offset));
+
+    let colName;
+    if (status & STATUS.DIFFERENT_NAME) {
+      ({ offset, value: colName } = readBVarChar(buf, offset));
+    }
+
+    columns.push({
+      colNum: colNum,
+      tableNum: tableNum,
+      expression: !!(status & STATUS.EXPRESSION),
+      key: !!(status & STATUS.KEY),
+      hidden: !!(status & STATUS.HIDDEN),
+      colName: colName
+    });
+  }
+
+  return new Result(new ColInfoToken(columns), offset);
+}
+
+export default colInfoParser;
+module.exports = colInfoParser;

--- a/src/token/handler.ts
+++ b/src/token/handler.ts
@@ -5,6 +5,7 @@ import { type ColumnMetadata } from './colmetadata-token-parser';
 import {
   BeginTransactionEnvChangeToken,
   CharsetEnvChangeToken,
+  ColInfoToken,
   CollationChangeToken,
   ColMetadataToken,
   CommitTransactionEnvChangeToken,
@@ -29,6 +30,7 @@ import {
   RoutingEnvChangeToken,
   RowToken,
   SSPIToken,
+  TabNameToken,
   Token
 } from './token';
 import BulkLoad from '../bulk-load';
@@ -127,6 +129,14 @@ export class TokenHandler {
   }
 
   onColMetadata(token: ColMetadataToken) {
+    throw new UnexpectedTokenError(this, token);
+  }
+
+  onTabName(token: TabNameToken) {
+    throw new UnexpectedTokenError(this, token);
+  }
+
+  onColInfo(token: ColInfoToken) {
     throw new UnexpectedTokenError(this, token);
   }
 
@@ -484,6 +494,18 @@ export class RequestTokenHandler extends TokenHandler {
       } else {
         this.request.emit('columnMetadata', token.columns);
       }
+    }
+  }
+
+  onTabName(token: TabNameToken) {
+    if (!this.request.canceled) {
+      this.request.emit('tabName', token.tableNames);
+    }
+  }
+
+  onColInfo(token: ColInfoToken) {
+    if (!this.request.canceled) {
+      this.request.emit('colInfo', token.columns);
     }
   }
 

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -1,8 +1,9 @@
 import Debug from '../debug';
 import { type InternalConnectionOptions } from '../connection';
 
-import { TYPE, ColMetadataToken, DoneProcToken, DoneToken, DoneInProcToken, ErrorMessageToken, InfoMessageToken, RowToken, type EnvChangeToken, LoginAckToken, ReturnStatusToken, OrderToken, FedAuthInfoToken, SSPIToken, ReturnValueToken, NBCRowToken, FeatureExtAckToken, Token } from './token';
+import { TYPE, ColInfoToken, ColMetadataToken, DoneProcToken, DoneToken, DoneInProcToken, ErrorMessageToken, InfoMessageToken, RowToken, type EnvChangeToken, LoginAckToken, ReturnStatusToken, OrderToken, FedAuthInfoToken, SSPIToken, ReturnValueToken, NBCRowToken, FeatureExtAckToken, TabNameToken, Token } from './token';
 
+import colInfoParser from './colinfo-token-parser';
 import colMetadataParser, { type ColumnMetadata } from './colmetadata-token-parser';
 import { doneParser, doneInProcParser, doneProcParser } from './done-token-parser';
 import envChangeParser from './env-change-token-parser';
@@ -16,6 +17,7 @@ import returnValueParser from './returnvalue-token-parser';
 import rowParser from './row-token-parser';
 import nbcRowParser from './nbcrow-token-parser';
 import sspiParser from './sspi-token-parser';
+import tabNameParser from './tabname-token-parser';
 import { NotEnoughDataError } from './helpers';
 
 export type ParserOptions = Pick<InternalConnectionOptions, 'useUTC' | 'lowerCaseGuids' | 'tdsVersion' | 'useColumnNames' | 'columnNameReplacer' | 'camelCaseColumns'>;
@@ -122,6 +124,14 @@ class Parser {
         return this.readFeatureExtAckToken();
       }
 
+      case TYPE.TABNAME: {
+        return this.readTabNameToken();
+      }
+
+      case TYPE.COLINFO: {
+        return this.readColInfoToken();
+      }
+
       default: {
         throw new Error('Unknown type: ' + type);
       }
@@ -137,6 +147,44 @@ class Parser {
       if (err instanceof NotEnoughDataError) {
         return this.waitForChunk().then(() => {
           return this.readFeatureExtAckToken();
+        });
+      }
+
+      throw err;
+    }
+
+    this.position = result.offset;
+    return result.value;
+  }
+
+  readTabNameToken(): TabNameToken | Promise<TabNameToken> {
+    let result;
+
+    try {
+      result = tabNameParser(this.buffer, this.position, this.options);
+    } catch (err: any) {
+      if (err instanceof NotEnoughDataError) {
+        return this.waitForChunk().then(() => {
+          return this.readTabNameToken();
+        });
+      }
+
+      throw err;
+    }
+
+    this.position = result.offset;
+    return result.value;
+  }
+
+  readColInfoToken(): ColInfoToken | Promise<ColInfoToken> {
+    let result;
+
+    try {
+      result = colInfoParser(this.buffer, this.position, this.options);
+    } catch (err: any) {
+      if (err instanceof NotEnoughDataError) {
+        return this.waitForChunk().then(() => {
+          return this.readColInfoToken();
         });
       }
 

--- a/src/token/tabname-token-parser.ts
+++ b/src/token/tabname-token-parser.ts
@@ -1,4 +1,4 @@
-// s2.2.7.23
+// s2.2.7.20
 import { type ParserOptions } from './stream-parser';
 
 import { TabNameToken } from './token';

--- a/src/token/tabname-token-parser.ts
+++ b/src/token/tabname-token-parser.ts
@@ -4,7 +4,7 @@ import { type ParserOptions } from './stream-parser';
 import { TabNameToken } from './token';
 import { NotEnoughDataError, readUInt16LE, readUInt8, readUsVarChar, Result } from './helpers';
 
-function tabNameParser(buf: Buffer, offset: number, options: ParserOptions): Result<TabNameToken> {
+function tabNameParser(buf: Buffer, offset: number, _options: ParserOptions): Result<TabNameToken> {
   // length
   let tokenLength;
   ({ offset, value: tokenLength } = readUInt16LE(buf, offset));
@@ -14,28 +14,28 @@ function tabNameParser(buf: Buffer, offset: number, options: ParserOptions): Res
   }
 
   const end = offset + tokenLength;
-  const tableNames: (string | string[])[] = [];
+  const tableNames: string[][] = [];
 
+  // Table names are sent as their individual parts. (While TDS versions
+  // before 7.1 Revision 1 sent each name as a single string, all servers
+  // that speak TDS 7.1 or newer use the multi-part format.)
   while (offset < end) {
-    if (options.tdsVersion < '7_2') {
-      let tableName;
-      ({ offset, value: tableName } = readUsVarChar(buf, offset));
+    let numberOfTableNameParts;
+    ({ offset, value: numberOfTableNameParts } = readUInt8(buf, offset));
 
-      tableNames.push(tableName);
-    } else {
-      let numberOfTableNameParts;
-      ({ offset, value: numberOfTableNameParts } = readUInt8(buf, offset));
+    const tableName: string[] = [];
+    for (let i = 0; i < numberOfTableNameParts; i++) {
+      let tableNamePart;
+      ({ offset, value: tableNamePart } = readUsVarChar(buf, offset));
 
-      const tableName: string[] = [];
-      for (let i = 0; i < numberOfTableNameParts; i++) {
-        let tableNamePart;
-        ({ offset, value: tableNamePart } = readUsVarChar(buf, offset));
-
-        tableName.push(tableNamePart);
-      }
-
-      tableNames.push(tableName);
+      tableName.push(tableNamePart);
     }
+
+    tableNames.push(tableName);
+  }
+
+  if (offset !== end) {
+    throw new Error('Malformed TABNAME token');
   }
 
   return new Result(new TabNameToken(tableNames), offset);

--- a/src/token/tabname-token-parser.ts
+++ b/src/token/tabname-token-parser.ts
@@ -1,0 +1,45 @@
+// s2.2.7.23
+import { type ParserOptions } from './stream-parser';
+
+import { TabNameToken } from './token';
+import { NotEnoughDataError, readUInt16LE, readUInt8, readUsVarChar, Result } from './helpers';
+
+function tabNameParser(buf: Buffer, offset: number, options: ParserOptions): Result<TabNameToken> {
+  // length
+  let tokenLength;
+  ({ offset, value: tokenLength } = readUInt16LE(buf, offset));
+
+  if (buf.length < offset + tokenLength) {
+    throw new NotEnoughDataError(offset + tokenLength);
+  }
+
+  const end = offset + tokenLength;
+  const tableNames: (string | string[])[] = [];
+
+  while (offset < end) {
+    if (options.tdsVersion < '7_2') {
+      let tableName;
+      ({ offset, value: tableName } = readUsVarChar(buf, offset));
+
+      tableNames.push(tableName);
+    } else {
+      let numberOfTableNameParts;
+      ({ offset, value: numberOfTableNameParts } = readUInt8(buf, offset));
+
+      const tableName: string[] = [];
+      for (let i = 0; i < numberOfTableNameParts; i++) {
+        let tableNamePart;
+        ({ offset, value: tableNamePart } = readUsVarChar(buf, offset));
+
+        tableName.push(tableNamePart);
+      }
+
+      tableNames.push(tableName);
+    }
+  }
+
+  return new Result(new TabNameToken(tableNames), offset);
+}
+
+export default tabNameParser;
+module.exports = tabNameParser;

--- a/src/token/token.ts
+++ b/src/token/token.ts
@@ -39,6 +39,55 @@ export abstract class Token {
   }
 }
 
+export interface ColumnInfo {
+  /**
+   * The column's ordinal position in the result set.
+   */
+  colNum: number;
+
+  /**
+   * The number of the base table this column was derived from, as a
+   * one-based index into the table list reported by the `TABNAME` token.
+   * `0` if the column is the result of an expression.
+   */
+  tableNum: number;
+
+  /**
+   * Whether the column was the result of an expression.
+   */
+  expression: boolean;
+
+  /**
+   * Whether the column is part of a key for the associated table.
+   */
+  key: boolean;
+
+  /**
+   * Whether the column was not requested, but was added because it was
+   * part of a key for the associated table.
+   */
+  hidden: boolean;
+
+  /**
+   * The column's name in the base table. Only set if it differs from the
+   * name in the result set (e.g. because a column alias was used).
+   */
+  colName: string | undefined;
+}
+
+export class ColInfoToken extends Token {
+  declare name: 'COLINFO';
+  declare handlerName: 'onColInfo';
+
+  declare columns: ColumnInfo[];
+
+  constructor(columns: ColumnInfo[]) {
+    super('COLINFO', 'onColInfo');
+
+    this.columns = columns;
+  }
+}
+
 export class ColMetadataToken extends Token {
   declare name: 'COLMETADATA';
   declare handlerName: 'onColMetadata';
@@ -492,6 +541,25 @@ export class RowToken extends Token {
     super('ROW', 'onRow');
 
     this.columns = columns;
+  }
+}
+
+export class TabNameToken extends Token {
+  declare name: 'TABNAME';
+  declare handlerName: 'onTabName';
+
+  /**
+   * The names of the base tables referenced in the query, in the order the
+   * `COLINFO` token's `tableNum` values refer to them. On TDS 7.2 and newer,
+   * each name is given as its individual parts (e.g. `['dbo', 'employees']`),
+   * on older versions as a single string.
+   */
+  declare tableNames: (string | string[])[];
+
+  constructor(tableNames: (string | string[])[]) {
+    super('TABNAME', 'onTabName');
+
+    this.tableNames = tableNames;
   }
 }
 

--- a/src/token/token.ts
+++ b/src/token/token.ts
@@ -550,13 +550,12 @@ export class TabNameToken extends Token {
 
   /**
    * The names of the base tables referenced in the query, in the order the
-   * `COLINFO` token's `tableNum` values refer to them. On TDS 7.2 and newer,
-   * each name is given as its individual parts (e.g. `['dbo', 'employees']`),
-   * on older versions as a single string.
+   * `COLINFO` token's `tableNum` values refer to them. Each name is given
+   * as its individual parts (e.g. `['dbo', 'employees']`).
    */
-  declare tableNames: (string | string[])[];
+  declare tableNames: string[][];
 
-  constructor(tableNames: (string | string[])[]) {
+  constructor(tableNames: string[][]) {
     super('TABNAME', 'onTabName');
 
     this.tableNames = tableNames;

--- a/test/integration/browse-mode-test.ts
+++ b/test/integration/browse-mode-test.ts
@@ -18,6 +18,12 @@ const config = {
   }
 };
 
+// Table names are reported as their individual parts, with the table's own
+// name as the last part.
+function lastPart(tableName: string[]): string {
+  return tableName[tableName.length - 1];
+}
+
 describe('Browse mode', function() {
   let connection: Connection;
 
@@ -65,7 +71,7 @@ describe('Browse mode', function() {
       done();
     });
 
-    let tableNames: (string | string[])[] = [];
+    let tableNames: string[][] = [];
     request.on('tabName', (names) => {
       tableNames = names;
     });
@@ -89,8 +95,7 @@ describe('Browse mode', function() {
         return done(err);
       }
 
-      assert.strictEqual(tableNames.length, 2);
-      assert.sameDeepMembers(tableNames, [['#browse'], ['#other']]);
+      assert.sameMembers(tableNames.map(lastPart), ['#browse', '#other']);
 
       // The two selected columns map to the two different base tables.
       const visible = columnInfo.filter((column) => !column.hidden);
@@ -103,7 +108,7 @@ describe('Browse mode', function() {
       done();
     });
 
-    let tableNames: (string | string[])[] = [];
+    let tableNames: string[][] = [];
     request.on('tabName', (names) => {
       tableNames = names;
     });
@@ -158,7 +163,7 @@ describe('Browse mode', function() {
       assert.strictEqual(columnInfo.length, tableNames.length);
 
       for (const names of tableNames) {
-        assert.deepEqual(names, [['#browse']]);
+        assert.deepEqual(names.map(lastPart), ['#browse']);
       }
 
       for (const columns of columnInfo) {
@@ -168,7 +173,7 @@ describe('Browse mode', function() {
       done();
     });
 
-    const tableNames: (string | string[])[][] = [];
+    const tableNames: string[][][] = [];
     request.on('tabName', (names) => {
       tableNames.push(names);
     });
@@ -197,7 +202,7 @@ describe('Browse mode', function() {
       done();
     });
 
-    let tableNames: (string | string[])[] = [];
+    let tableNames: string[][] = [];
     request.on('tabName', (names) => {
       tableNames = names;
     });

--- a/test/integration/browse-mode-test.ts
+++ b/test/integration/browse-mode-test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 
 import Connection from '../../src/connection';
 import Request from '../../src/request';
+import { typeByName as TYPES } from '../../src/data-type';
 import { type ColumnInfo } from '../../src/token/token';
 
 import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
@@ -77,6 +78,104 @@ describe('Browse mode', function() {
     const values: unknown[] = [];
     request.on('row', (columns) => {
       values.push(columns[0].value);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('reports the base tables of joined columns', function(done) {
+    const request = new Request('CREATE TABLE #other ([id] int PRIMARY KEY, [title] nvarchar(50)); INSERT INTO #other VALUES (1, N\'first\'); SELECT b.[name], o.[title] FROM #browse b JOIN #other o ON o.[id] = b.[id] FOR BROWSE', function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(tableNames.length, 2);
+      assert.sameDeepMembers(tableNames, [['#browse'], ['#other']]);
+
+      // The two selected columns map to the two different base tables.
+      const visible = columnInfo.filter((column) => !column.hidden);
+      assert.deepEqual(visible.map((column) => column.tableNum), [1, 2]);
+
+      // The server appends the key columns of both base tables.
+      const hiddenKeyTables = columnInfo.filter((column) => column.key && column.hidden).map((column) => column.tableNum);
+      assert.sameMembers(hiddenKeyTables, [1, 2]);
+
+      done();
+    });
+
+    let tableNames: (string | string[])[] = [];
+    request.on('tabName', (names) => {
+      tableNames = names;
+    });
+
+    let columnInfo: ColumnInfo[] = [];
+    request.on('colInfo', (columns) => {
+      columnInfo = columns;
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('flags expression columns, also for parameterised statements', function(done) {
+    const request = new Request('SELECT [id] + @delta AS [shifted] FROM #browse FOR BROWSE', function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.deepEqual(values, [11, 12]);
+
+      // The expression column belongs to no base table.
+      assert.isTrue(columnInfo.some((column) => column.expression && column.tableNum === 0));
+      // The base table's key column is still appended.
+      assert.isTrue(columnInfo.some((column) => column.key && column.hidden && column.tableNum === 1));
+
+      done();
+    });
+
+    request.addParameter('delta', TYPES.Int, 10);
+
+    let columnInfo: ColumnInfo[] = [];
+    request.on('colInfo', (columns) => {
+      columnInfo = columns;
+    });
+
+    const values: unknown[] = [];
+    request.on('row', (columns) => {
+      values.push(columns[0].value);
+    });
+
+    connection.execSql(request);
+  });
+
+  it('supports API cursors created via `sp_cursoropen`', function(done) {
+    const request = new Request('DECLARE @cursor int; EXEC sp_cursoropen @cursor OUTPUT, N\'SELECT [id], [name] FROM #browse\', 2, 8193; EXEC sp_cursorfetch @cursor, 2, 0, 2; EXEC sp_cursorclose @cursor', function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      // Both the cursor open and the fetch report the result set's base tables.
+      assert.isAtLeast(tableNames.length, 1);
+      assert.strictEqual(columnInfo.length, tableNames.length);
+
+      for (const names of tableNames) {
+        assert.deepEqual(names, [['#browse']]);
+      }
+
+      for (const columns of columnInfo) {
+        assert.isTrue(columns.some((column) => column.key && column.tableNum === 1));
+      }
+
+      done();
+    });
+
+    const tableNames: (string | string[])[][] = [];
+    request.on('tabName', (names) => {
+      tableNames.push(names);
+    });
+
+    const columnInfo: ColumnInfo[][] = [];
+    request.on('colInfo', (columns) => {
+      columnInfo.push(columns);
     });
 
     connection.execSqlBatch(request);

--- a/test/integration/browse-mode-test.ts
+++ b/test/integration/browse-mode-test.ts
@@ -1,0 +1,118 @@
+import { assert } from 'chai';
+
+import Connection from '../../src/connection';
+import Request from '../../src/request';
+import { type ColumnInfo } from '../../src/token/token';
+
+import { debugOptionsFromEnv } from '../helpers/debug-options-from-env';
+
+import defaultConfig from '../config';
+
+const config = {
+  ...defaultConfig,
+  options: {
+    ...defaultConfig.options,
+    debug: debugOptionsFromEnv(),
+    tdsVersion: process.env.TEDIOUS_TDS_VERSION
+  }
+};
+
+describe('Browse mode', function() {
+  let connection: Connection;
+
+  beforeEach(function(done) {
+    connection = new Connection(config);
+
+    connection.on('errorMessage', function(error) {
+      console.log(`${error.number} : ${error.message}`);
+    });
+
+    if (process.env.TEDIOUS_DEBUG) {
+      connection.on('debug', console.log);
+    }
+
+    connection.connect(done);
+  });
+
+  beforeEach(function(done) {
+    const request = new Request('CREATE TABLE #browse ([id] int PRIMARY KEY, [name] nvarchar(50)); INSERT INTO #browse ([id], [name]) VALUES (1, N\'one\'), (2, N\'two\')', done);
+    connection.execSqlBatch(request);
+  });
+
+  afterEach(function(done) {
+    if (!connection.closed) {
+      connection.on('end', done);
+      connection.close();
+    } else {
+      done();
+    }
+  });
+
+  it('supports queries with a `FOR BROWSE` clause', function(done) {
+    const request = new Request('SELECT [name] FROM #browse ORDER BY [id] FOR BROWSE', function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.deepEqual(values, ['one', 'two']);
+
+      // In browse mode, the server reports the base tables of the result set
+      // and appends the tables' key columns to the rows.
+      assert.strictEqual(tableNames.length, 1);
+      assert.isTrue(columnInfo.some((column) => column.key && column.hidden));
+
+      done();
+    });
+
+    let tableNames: (string | string[])[] = [];
+    request.on('tabName', (names) => {
+      tableNames = names;
+    });
+
+    let columnInfo: ColumnInfo[] = [];
+    request.on('colInfo', (columns) => {
+      columnInfo = columns;
+    });
+
+    const values: unknown[] = [];
+    request.on('row', (columns) => {
+      values.push(columns[0].value);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('supports queries with `SET NO_BROWSETABLE ON`', function(done) {
+    // Regression test for a fatal `Unknown type: 164` parser error
+    // (https://github.com/tediousjs/tedious/issues/410).
+    const request = new Request('SET NO_BROWSETABLE ON; SELECT [id], [name] AS [alias] FROM #browse ORDER BY [id]; SET NO_BROWSETABLE OFF', function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.deepEqual(values, [1, 2]);
+
+      assert.strictEqual(tableNames.length, 1);
+      assert.isTrue(columnInfo.some((column) => column.colName === 'name'));
+
+      done();
+    });
+
+    let tableNames: (string | string[])[] = [];
+    request.on('tabName', (names) => {
+      tableNames = names;
+    });
+
+    let columnInfo: ColumnInfo[] = [];
+    request.on('colInfo', (columns) => {
+      columnInfo = columns;
+    });
+
+    const values: unknown[] = [];
+    request.on('row', (columns) => {
+      values.push(columns[0].value);
+    });
+
+    connection.execSqlBatch(request);
+  });
+});

--- a/test/unit/token/colinfo-token-parser-test.ts
+++ b/test/unit/token/colinfo-token-parser-test.ts
@@ -86,6 +86,29 @@ describe('ColInfo Token Parser', function() {
     assert.isTrue((await parser.next()).done);
   });
 
+  it('should reject a token whose contents overrun its declared length', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa5);
+    buffer.writeUInt16LE(3); // declared length only covers the fixed fields
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0x20); // DIFFERENT_NAME
+    buffer.writeBVarchar('name');
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+
+    let error;
+    try {
+      await parser.next();
+    } catch (err: any) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Malformed COLINFO token');
+  });
+
   it('should parse a token that arrives in single byte chunks', async function() {
     const buffer = new WritableTrackingBuffer(50, 'ucs2');
 

--- a/test/unit/token/colinfo-token-parser-test.ts
+++ b/test/unit/token/colinfo-token-parser-test.ts
@@ -1,0 +1,113 @@
+import StreamParser, { type ParserOptions } from '../../../src/token/stream-parser';
+import { ColInfoToken } from '../../../src/token/token';
+import WritableTrackingBuffer from '../../../src/tracking-buffer/writable-tracking-buffer';
+import Debug from '../../../src/debug';
+import { assert } from 'chai';
+
+describe('ColInfo Token Parser', function() {
+  const options = { tdsVersion: '7_4' } as ParserOptions;
+
+  it('should parse a single column', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa5);
+    buffer.writeUInt16LE(3);
+    buffer.writeUInt8(1); // colNum
+    buffer.writeUInt8(1); // tableNum
+    buffer.writeUInt8(0x00); // status
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, ColInfoToken);
+    assert.deepEqual(token.columns, [
+      { colNum: 1, tableNum: 1, expression: false, key: false, hidden: false, colName: undefined }
+    ]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse the column status flags', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa5);
+    buffer.writeUInt16LE(3 * 3);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0);
+    buffer.writeUInt8(0x04); // EXPRESSION
+    buffer.writeUInt8(2);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0x08); // KEY
+    buffer.writeUInt8(3);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0x08 | 0x10); // KEY | HIDDEN
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, ColInfoToken);
+    assert.deepEqual(token.columns, [
+      { colNum: 1, tableNum: 0, expression: true, key: false, hidden: false, colName: undefined },
+      { colNum: 2, tableNum: 1, expression: false, key: true, hidden: false, colName: undefined },
+      { colNum: 3, tableNum: 1, expression: false, key: true, hidden: true, colName: undefined }
+    ]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse the base column name for aliased columns', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa5);
+    buffer.writeUInt16LE(3 + 1 + ('name'.length * 2) + 3);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0x20); // DIFFERENT_NAME
+    buffer.writeBVarchar('name');
+    buffer.writeUInt8(2);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0x00);
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, ColInfoToken);
+    assert.deepEqual(token.columns, [
+      { colNum: 1, tableNum: 1, expression: false, key: false, hidden: false, colName: 'name' },
+      { colNum: 2, tableNum: 1, expression: false, key: false, hidden: false, colName: undefined }
+    ]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse a token that arrives in single byte chunks', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa5);
+    buffer.writeUInt16LE(3 + 1 + ('name'.length * 2));
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(0x20); // DIFFERENT_NAME
+    buffer.writeBVarchar('name');
+
+    const chunks = Array.from(buffer.data, (byte) => Buffer.from([byte]));
+
+    const parser = StreamParser.parseTokens(chunks, new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, ColInfoToken);
+    assert.deepEqual(token.columns, [
+      { colNum: 1, tableNum: 1, expression: false, key: false, hidden: false, colName: 'name' }
+    ]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+});

--- a/test/unit/token/tabname-token-parser-test.ts
+++ b/test/unit/token/tabname-token-parser-test.ts
@@ -67,11 +67,14 @@ describe('TabName Token Parser', function() {
     assert.isTrue((await parser.next()).done);
   });
 
-  it('should parse a table name as a plain string on TDS 7.1', async function() {
+  it('should parse the multi-part table name format on TDS 7.1', async function() {
+    // Servers speaking TDS 7.1 already use the multi-part format, which was
+    // introduced in TDS 7.1 Revision 1.
     const buffer = new WritableTrackingBuffer(50, 'ucs2');
 
     buffer.writeUInt8(0xa4);
-    buffer.writeUInt16LE(2 + ('employees'.length * 2));
+    buffer.writeUInt16LE(1 + 2 + ('employees'.length * 2));
+    buffer.writeUInt8(1);
     buffer.writeUsVarchar('employees');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), { tdsVersion: '7_1' } as ParserOptions);
@@ -80,9 +83,30 @@ describe('TabName Token Parser', function() {
     const token = result.value;
 
     assert.instanceOf(token, TabNameToken);
-    assert.deepEqual(token.tableNames, ['employees']);
+    assert.deepEqual(token.tableNames, [['employees']]);
 
     assert.isTrue((await parser.next()).done);
+  });
+
+  it('should reject a token whose contents overrun its declared length', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa4);
+    buffer.writeUInt16LE(1); // declared length only covers the part count
+    buffer.writeUInt8(1);
+    buffer.writeUsVarchar('employees');
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+
+    let error;
+    try {
+      await parser.next();
+    } catch (err: any) {
+      error = err;
+    }
+
+    assert.instanceOf(error, Error);
+    assert.strictEqual(error.message, 'Malformed TABNAME token');
   });
 
   it('should parse a token that arrives in single byte chunks', async function() {

--- a/test/unit/token/tabname-token-parser-test.ts
+++ b/test/unit/token/tabname-token-parser-test.ts
@@ -1,0 +1,109 @@
+import StreamParser, { type ParserOptions } from '../../../src/token/stream-parser';
+import { TabNameToken } from '../../../src/token/token';
+import WritableTrackingBuffer from '../../../src/tracking-buffer/writable-tracking-buffer';
+import Debug from '../../../src/debug';
+import { assert } from 'chai';
+
+describe('TabName Token Parser', function() {
+  const options = { tdsVersion: '7_4' } as ParserOptions;
+
+  it('should parse a single one-part table name', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa4);
+    buffer.writeUInt16LE(1 + 2 + ('employees'.length * 2));
+    buffer.writeUInt8(1);
+    buffer.writeUsVarchar('employees');
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, TabNameToken);
+    assert.deepEqual(token.tableNames, [['employees']]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse a multi-part table name', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa4);
+    buffer.writeUInt16LE(1 + 2 + ('dbo'.length * 2) + 2 + ('employees'.length * 2));
+    buffer.writeUInt8(2);
+    buffer.writeUsVarchar('dbo');
+    buffer.writeUsVarchar('employees');
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, TabNameToken);
+    assert.deepEqual(token.tableNames, [['dbo', 'employees']]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse multiple table names', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa4);
+    buffer.writeUInt16LE((1 + 2 + ('employees'.length * 2)) + (1 + 2 + ('teams'.length * 2)));
+    buffer.writeUInt8(1);
+    buffer.writeUsVarchar('employees');
+    buffer.writeUInt8(1);
+    buffer.writeUsVarchar('teams');
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, TabNameToken);
+    assert.deepEqual(token.tableNames, [['employees'], ['teams']]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse a table name as a plain string on TDS 7.1', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa4);
+    buffer.writeUInt16LE(2 + ('employees'.length * 2));
+    buffer.writeUsVarchar('employees');
+
+    const parser = StreamParser.parseTokens([buffer.data], new Debug(), { tdsVersion: '7_1' } as ParserOptions);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, TabNameToken);
+    assert.deepEqual(token.tableNames, ['employees']);
+
+    assert.isTrue((await parser.next()).done);
+  });
+
+  it('should parse a token that arrives in single byte chunks', async function() {
+    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+
+    buffer.writeUInt8(0xa4);
+    buffer.writeUInt16LE(1 + 2 + ('dbo'.length * 2) + 2 + ('employees'.length * 2));
+    buffer.writeUInt8(2);
+    buffer.writeUsVarchar('dbo');
+    buffer.writeUsVarchar('employees');
+
+    const chunks = Array.from(buffer.data, (byte) => Buffer.from([byte]));
+
+    const parser = StreamParser.parseTokens(chunks, new Debug(), options);
+    const result = await parser.next();
+    assert.isFalse(result.done);
+    const token = result.value;
+
+    assert.instanceOf(token, TabNameToken);
+    assert.deepEqual(token.tableNames, [['dbo', 'employees']]);
+
+    assert.isTrue((await parser.next()).done);
+  });
+});


### PR DESCRIPTION
Fixes #242. Fixes #410.

## Problem

SQL Server sends `TABNAME` (0xA4) and `COLINFO` (0xA5) tokens for queries executed in browse mode — a `FOR BROWSE` clause, `SET NO_BROWSETABLE ON`, or the `sp_cursoropen`/`sp_cursorfetch` API cursor procedures ([MS-TDS TABNAME](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/140e3348-da08-409a-b6c3-f0fc9cee2d6e), [MS-TDS COLINFO](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/aa8466c5-ca3d-48ca-a638-7c1becebe754)). These tokens describe how the columns of a result set map back to their base tables.

Previously, tedious had no parsers for either token, so receiving one crashed the token parser with an uncaught `Unknown type: 164` / `Unknown type: 165` error, taking down the whole process. Verified against tedious 20.0.0 and SQL Server 2022:

```sql
CREATE TABLE #t ([id] int PRIMARY KEY);
INSERT INTO #t VALUES (1);
SET NO_BROWSETABLE ON;
SELECT [id] FROM #t; -- uncaught exception: Unknown type: 164
```

## Changes

- **`src/token/tabname-token-parser.ts`** — parses `TABNAME`: the list of base table names referenced by the query, each parsed into its parts (e.g. `['dbo', 'employees']`). The multi-part format is used on all TDS versions: it was introduced in TDS 7.1 Revision 1, and all servers speaking TDS 7.1 or newer send it (verified against SQL Server 2022 on a TDS 7.1 connection).
- **`src/token/colinfo-token-parser.ts`** — parses `COLINFO`: per-column ordinal, base table number (a one-based index into the `TABNAME` list), the `EXPRESSION`/`KEY`/`HIDDEN` status flags, and the base column name when the column is aliased (`DIFFERENT_NAME`).
- Both tokens are wired into the stream parser using the standard `NotEnoughDataError` retry pattern, and surfaced as new documented `tabName` and `colInfo` events on `Request`, following the existing `order` event's pattern. All other token handlers treat them as unexpected tokens, same as every other token type.
- Both parsers throw a descriptive error if a token's contents overrun its declared length, instead of silently desyncing the token stream on malformed data.

## Tests

- **Unit** (`test/unit/token/tabname-token-parser-test.ts`, `test/unit/token/colinfo-token-parser-test.ts`): one-part/multi-part/multiple table names, TDS 7.1 behavior, all status flag combinations, aliased columns, tokens arriving fragmented in single-byte chunks, and malformed-token rejection.
- **Integration** (`test/integration/browse-mode-test.ts`): `FOR BROWSE` queries (including the server-appended hidden key columns being reported via `colInfo`), multi-table joins (multiple `TABNAME` entries and per-table column mapping), expression columns via a parameterised RPC request, API cursors via `sp_cursoropen`, and the exact `SET NO_BROWSETABLE ON` scenario from #410. Verified passing against a real SQL Server 2022 instance on TDS 7.1, 7.2, and 7.4 connections.

Full unit suite, integration suite, `eslint`, and `tsc` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxv5h4UMCGJEpjgCKcAxug