### PR TITLE
refactor: resolve parameter lengths for all types that can resolve one

### DIFF
--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -429,10 +429,13 @@ class BulkLoad extends EventEmitter {
       collation: this.collation
     };
 
-    if ((type.id & 0x30) === 0x20) {
-      if (column.length == null && type.resolveLength) {
-        column.length = type.resolveLength(column);
-      }
+    // Note: this is deliberately not keyed off the legacy variable-length
+    // type id bit pattern ((type.id & 0x30) === 0x20), as that pattern does
+    // not hold for type ids introduced in TDS 7.2 and later (e.g. XMLTYPE
+    // 0xF1 or VECTORTYPE 0xF5). A type has a length whenever it can resolve
+    // one, mirroring how precision and scale are resolved below.
+    if (column.length == null && type.resolveLength) {
+      column.length = type.resolveLength(column);
     }
 
     if (type.resolvePrecision && column.precision == null) {

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -88,12 +88,15 @@ class RpcRequestPayload implements Iterable<Buffer> {
 
     const type = parameter.type;
 
-    if ((type.id & 0x30) === 0x20) {
-      if (parameter.length) {
-        param.length = parameter.length;
-      } else if (type.resolveLength) {
-        param.length = type.resolveLength(parameter);
-      }
+    // Note: this is deliberately not keyed off the legacy variable-length
+    // type id bit pattern ((type.id & 0x30) === 0x20), as that pattern does
+    // not hold for type ids introduced in TDS 7.2 and later (e.g. XMLTYPE
+    // 0xF1 or VECTORTYPE 0xF5). A type has a length whenever it can resolve
+    // one, mirroring how precision and scale are resolved below.
+    if (parameter.length) {
+      param.length = parameter.length;
+    } else if (type.resolveLength) {
+      param.length = type.resolveLength(parameter);
     }
 
     if (parameter.precision) {

--- a/test/unit/rpcrequest-payload-test.ts
+++ b/test/unit/rpcrequest-payload-test.ts
@@ -1,0 +1,92 @@
+import { assert } from 'chai';
+
+import RpcRequestPayload from '../../src/rpcrequest-payload';
+import { typeByName as TYPES, type DataType, type Parameter, type ParameterData } from '../../src/data-type';
+import { type InternalConnectionOptions } from '../../src/connection';
+
+const options = { tdsVersion: '7_4' } as InternalConnectionOptions;
+const txnDescriptor = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
+
+describe('RpcRequestPayload', function() {
+  describe('parameter length resolution', function() {
+    // A stub type whose id does _not_ match the legacy variable-length type
+    // id bit pattern ((id & 0x30) === 0x20), like the type ids introduced
+    // in TDS 7.2 and later (e.g. XMLTYPE 0xF1 or VECTORTYPE 0xF5).
+    function buildModernIdType(receivedLengths: (number | undefined)[]): DataType {
+      return {
+        id: 0xF5,
+        type: 'STUB',
+        name: 'Stub',
+
+        declaration() {
+          return 'stub';
+        },
+
+        resolveLength(parameter: Parameter) {
+          return (parameter.value as { length: number }).length;
+        },
+
+        generateTypeInfo(parameter: ParameterData) {
+          receivedLengths.push(parameter.length);
+          return Buffer.from([this.id]);
+        },
+
+        generateParameterLength(parameter: ParameterData) {
+          receivedLengths.push(parameter.length);
+          return Buffer.alloc(0);
+        },
+
+        * generateParameterData(parameter: ParameterData) {
+          receivedLengths.push(parameter.length);
+        },
+
+        validate(value) {
+          return value;
+        }
+      };
+    }
+
+    it('resolves the length for types with ids outside the legacy variable-length id bit pattern', function() {
+      const receivedLengths: (number | undefined)[] = [];
+      const parameter: Parameter = {
+        type: buildModernIdType(receivedLengths),
+        name: 'value',
+        value: { length: 3 },
+        output: false
+      };
+
+      assert.isNotEmpty([...new RpcRequestPayload('proc', [parameter], txnDescriptor, options, undefined)]);
+      assert.deepEqual(receivedLengths, [3, 3, 3]);
+    });
+
+    it('prefers an explicitly specified length', function() {
+      const receivedLengths: (number | undefined)[] = [];
+      const parameter: Parameter = {
+        type: buildModernIdType(receivedLengths),
+        name: 'value',
+        value: { length: 3 },
+        length: 42,
+        output: false
+      };
+
+      assert.isNotEmpty([...new RpcRequestPayload('proc', [parameter], txnDescriptor, options, undefined)]);
+      assert.deepEqual(receivedLengths, [42, 42, 42]);
+    });
+
+    it('keeps resolving the length for legacy variable-length type ids', function() {
+      const parameter: Parameter = {
+        type: TYPES.VarBinary,
+        name: 'value',
+        value: Buffer.from([1, 2, 3]),
+        output: false
+      };
+
+      const data = Buffer.concat([...new RpcRequestPayload('proc', [parameter], txnDescriptor, options, undefined)]);
+
+      // TYPE_INFO for a varbinary(3) parameter: BIGVARBINARYTYPE with a
+      // maximum length of 3 bytes, followed by the 3 byte value.
+      const typeInfo = Buffer.from([0xA5, 0x03, 0x00]);
+      assert.notStrictEqual(data.indexOf(typeInfo), -1);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

RPC request and bulk load parameter serialization only resolve a parameter's length when the type's id matches the legacy variable-length type id bit pattern:

```ts
if ((type.id & 0x30) === 0x20) {
```

Validated against [MS-TDS] v20260617 s2.2.5.4.2 (Variable-Length Data Types): every BYTELEN/USHORTLEN/LONGLEN type id defined up to TDS 7.1 does match that pattern (`0x2X`/`0x6X`/`0xAX`/`0xEX` — e.g. `BIGVARBINARYTYPE 0xA5`, `NVARCHARTYPE 0xE7`, `TEXTTYPE 0x23`), but the type ids introduced in TDS 7.2 and later do **not**: `UDTTYPE 0xF0`, `XMLTYPE 0xF1`, `JSONTYPE 0xF4`, and `VECTORTYPE 0xF5` all have `(id & 0x30) === 0x30`.

For a modern-id type that has a length, the length is therefore silently never resolved, and its `generateTypeInfo` computes with `undefined` — concretely, `Buffer.writeUInt16LE(NaN)` writes a **zero** max length into the TYPE_INFO, which the server rejects with an opaque protocol error (`Data type 0xF5 has an invalid data length or metadata length`). This was discovered while implementing the SQL Server 2025 `vector` type (`VECTORTYPE 0xF5`, the first modern-id type with a length), where it broke RPC parameters and bulk load columns; the `json` type (`JSONTYPE 0xF4`) would hit the same landmine.

## Change

Resolve lengths based on whether the type can resolve one (`type.resolveLength`), mirroring how `precision` and `scale` are already resolved in the same functions, in both `src/rpcrequest-payload.ts` and `src/bulk-load.ts`.

This is a refactor, not a fix, for anything tedious ships today: no existing type is affected. Every type currently implementing `resolveLength` (Binary, Char, Image, NChar, NText, NVarChar, Text, UniqueIdentifier, VarBinary, VarChar) has a legacy-pattern id, and the three shipped modern-id types (TVP, UDT, Xml) have no `resolveLength`, so the new condition is false for them exactly as the old one was. It removes the gate ahead of the first type that would trip over it.

Verified two ways:

- No type without `resolveLength` reads a resolved length (the mask-matching N-types, date/time types, and sql_variant never consume `param.length`).
- The full unit suite plus the parameter-related integration suites (parameterised statements, RPC, bulk load, prepare/execute, TVP — 215 tests) pass unchanged against SQL Server 2022.

New unit tests cover length resolution for a modern-id type, explicit-length precedence, and the unchanged legacy-type byte output.

#1774 carries the same change in its `resolveParameter` and `BulkLoad.addColumn`; whichever lands first, the other's merge is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxv5h4UMCGJEpjgCKcAxug