### PR TITLE
perf: rewrite WritableTrackingBuffer as a chunked buffer list

### DIFF
--- a/benchmarks/tracking-buffer/writable-tracking-buffer.js
+++ b/benchmarks/tracking-buffer/writable-tracking-buffer.js
@@ -1,0 +1,38 @@
+// Measures the throughput of `WritableTrackingBuffer` for the kind of data a
+// request payload is made of: many small fixed-width values, short strings,
+// and the occasional buffer.
+//
+//     node benchmarks/tracking-buffer/writable-tracking-buffer.js
+
+const { createBenchmark } = require('../common');
+
+const WritableTrackingBuffer = require('tedious/lib/tracking-buffer/writable-tracking-buffer');
+
+const bench = createBenchmark(main, {
+  n: [100000],
+  pieces: [10, 100, 1000]
+});
+
+const payload = Buffer.alloc(16, 0x42);
+
+function main({ n, pieces }) {
+  bench.start();
+
+  for (let i = 0; i < n; i++) {
+    const buffer = new WritableTrackingBuffer();
+
+    for (let j = 0; j < pieces; j++) {
+      buffer.writeUInt8(0x01);
+      buffer.writeUInt16LE(j);
+      buffer.writeInt32LE(-j);
+      buffer.writeBVarchar('@param' + j, 'ucs2');
+      buffer.writeBuffer(payload);
+    }
+
+    if (buffer.data.length === 0) {
+      throw new Error('no data');
+    }
+  }
+
+  bench.end(n);
+}

--- a/src/all-headers.ts
+++ b/src/all-headers.ts
@@ -10,14 +10,14 @@ const TXNDESCRIPTOR_HEADER_DATA_LEN = 4 + 8;
 
 const TXNDESCRIPTOR_HEADER_LEN = 4 + 2 + TXNDESCRIPTOR_HEADER_DATA_LEN;
 
+const ALL_HEADERS_LEN = 4 + TXNDESCRIPTOR_HEADER_LEN;
+
 export function writeToTrackingBuffer(buffer: WritableTrackingBuffer, txnDescriptor: Buffer, outstandingRequestCount: number) {
-  buffer.writeUInt32LE(0);
+  // TotalLength
+  buffer.writeUInt32LE(ALL_HEADERS_LEN);
   buffer.writeUInt32LE(TXNDESCRIPTOR_HEADER_LEN);
   buffer.writeUInt16LE(TYPE.TXN_DESCRIPTOR);
   buffer.writeBuffer(txnDescriptor);
   buffer.writeUInt32LE(outstandingRequestCount);
-
-  const data = buffer.data;
-  data.writeUInt32LE(data.length, 0);
   return buffer;
 }

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -538,7 +538,7 @@ class BulkLoad extends EventEmitter {
    * @private
    */
   getColMetaData() {
-    const tBuf = new WritableTrackingBuffer(100, null, true);
+    const tBuf = new WritableTrackingBuffer();
     // TokenType
     tBuf.writeUInt8(TOKEN_TYPE.COLMETADATA);
     // Count
@@ -595,7 +595,7 @@ class BulkLoad extends EventEmitter {
    */
   createDoneToken() {
     // It might be nice to make DoneToken a class if anything needs to create them, but for now, just do it here
-    const tBuf = new WritableTrackingBuffer(this.options.tdsVersion < '7_2' ? 9 : 13);
+    const tBuf = new WritableTrackingBuffer();
     tBuf.writeUInt8(TOKEN_TYPE.DONE);
     const status = DONE_STATUS.FINAL;
     tBuf.writeUInt16LE(status);

--- a/src/data-types/bigint.ts
+++ b/src/data-types/bigint.ts
@@ -33,7 +33,7 @@ const BigInt: DataType = {
       return;
     }
 
-    const buffer = new WritableTrackingBuffer(8);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeBigInt64LE(typeof parameter.value === 'bigint' ? parameter.value : globalThis.BigInt(parameter.value));
     yield buffer.data;
   },

--- a/src/data-types/datetime2.ts
+++ b/src/data-types/datetime2.ts
@@ -61,7 +61,7 @@ const DateTime2: DataType & { resolveScale: NonNullable<DataType['resolveScale']
     const value = parameter.value;
     let scale = parameter.scale;
 
-    const buffer = new WritableTrackingBuffer(16);
+    const buffer = new WritableTrackingBuffer();
     scale = scale!;
 
     let timestamp: number;

--- a/src/data-types/datetimeoffset.ts
+++ b/src/data-types/datetimeoffset.ts
@@ -59,7 +59,7 @@ const DateTimeOffset: DataType & { resolveScale: NonNullable<DataType['resolveSc
     const value = parameter.value;
     let scale = parameter.scale;
 
-    const buffer = new WritableTrackingBuffer(16);
+    const buffer = new WritableTrackingBuffer();
     scale = scale!;
 
     let timestamp: number;

--- a/src/data-types/time.ts
+++ b/src/data-types/time.ts
@@ -53,7 +53,7 @@ const Time: DataType = {
       return;
     }
 
-    const buffer = new WritableTrackingBuffer(16);
+    const buffer = new WritableTrackingBuffer();
     const time = parameter.value;
 
     let timestamp;

--- a/src/data-types/tvp.ts
+++ b/src/data-types/tvp.ts
@@ -23,16 +23,11 @@ const TVP: DataType = {
     const schema = parameter.value?.schema ?? '';
     const typeName = parameter.value?.name ?? '';
 
-    const bufferLength = 1 +
-      1 + Buffer.byteLength(databaseName, 'ucs2') +
-      1 + Buffer.byteLength(schema, 'ucs2') +
-      1 + Buffer.byteLength(typeName, 'ucs2');
-
-    const buffer = new WritableTrackingBuffer(bufferLength, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(this.id);
-    buffer.writeBVarchar(databaseName);
-    buffer.writeBVarchar(schema);
-    buffer.writeBVarchar(typeName);
+    buffer.writeBVarchar(databaseName, 'ucs2');
+    buffer.writeBVarchar(schema, 'ucs2');
+    buffer.writeBVarchar(typeName, 'ucs2');
 
     return buffer.data;
   },

--- a/src/data-types/varbinary.ts
+++ b/src/data-types/varbinary.ts
@@ -77,7 +77,7 @@ const VarBinary: { maximumLength: number } & DataType = {
       const buffer = Buffer.alloc(2);
       buffer.writeUInt16LE(length, 0);
       return buffer;
-    } else { // writePLPBody
+    } else {
       return UNKNOWN_PLP_LEN;
     }
   },
@@ -95,7 +95,7 @@ const VarBinary: { maximumLength: number } & DataType = {
       } else {
         yield Buffer.from(value.toString(), 'ucs2');
       }
-    } else { // writePLPBody
+    } else {
       if (!Buffer.isBuffer(value)) {
         value = value.toString();
       }

--- a/src/ntlm-payload.ts
+++ b/src/ntlm-payload.ts
@@ -33,9 +33,7 @@ class NTLMResponsePayload {
     const ntlmData = challenge.ntlmpacket;
     const server_data = ntlmData.target;
     const server_nonce = ntlmData.nonce;
-    const bufferLength = 64 + (domain.length * 2) + (username.length * 2) + lmv2len + ntlmv2len + 8 + 8 + 8 + 4 + server_data.length + 4;
-    const data = new WritableTrackingBuffer(bufferLength);
-    data.position = 0;
+    const data = new WritableTrackingBuffer();
     data.writeString('NTLMSSP\u0000', 'utf8');
     data.writeUInt32LE(0x03);
     const baseIdx = 64;
@@ -66,17 +64,17 @@ class NTLMResponsePayload {
     data.writeString(domain, 'ucs2');
     data.writeString(username, 'ucs2');
     const lmv2Data = this.lmv2Response(domain, username, password, server_nonce, client_nonce);
-    data.copyFrom(lmv2Data);
+    data.writeBuffer(lmv2Data);
     const genTime = new Date().getTime();
     const ntlmDataBuffer = this.ntlmv2Response(domain, username, password, server_nonce, server_data, client_nonce, genTime);
-    data.copyFrom(ntlmDataBuffer);
+    data.writeBuffer(ntlmDataBuffer);
     data.writeUInt32LE(0x0101);
     data.writeUInt32LE(0x0000);
     const timestamp = this.createTimestamp(genTime);
-    data.copyFrom(timestamp);
-    data.copyFrom(client_nonce);
+    data.writeBuffer(timestamp);
+    data.writeBuffer(client_nonce);
     data.writeUInt32LE(0x0000);
-    data.copyFrom(server_data);
+    data.writeBuffer(server_data);
     data.writeUInt32LE(0x0000);
     return data.data;
   }

--- a/src/prelogin-payload.ts
+++ b/src/prelogin-payload.ts
@@ -3,7 +3,6 @@ import { sprintf } from 'sprintf-js';
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import { randomBytes } from 'crypto';
 
-const optionBufferSize = 20;
 const traceIdSize = 36;
 
 const TOKEN = {
@@ -125,7 +124,7 @@ class PreloginPayload {
   }
 
   createVersionOption() {
-    const buffer = new WritableTrackingBuffer(optionBufferSize);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(this.options.version.major);
     buffer.writeUInt8(this.options.version.minor);
     buffer.writeUInt16BE(this.options.version.build);
@@ -137,7 +136,7 @@ class PreloginPayload {
   }
 
   createEncryptionOption() {
-    const buffer = new WritableTrackingBuffer(optionBufferSize);
+    const buffer = new WritableTrackingBuffer();
     if (this.options.encrypt) {
       buffer.writeUInt8(ENCRYPT.ON);
     } else {
@@ -150,7 +149,7 @@ class PreloginPayload {
   }
 
   createInstanceOption() {
-    const buffer = new WritableTrackingBuffer(optionBufferSize);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0x00);
     return {
       token: TOKEN.INSTOPT,
@@ -159,7 +158,7 @@ class PreloginPayload {
   }
 
   createThreadIdOption() {
-    const buffer = new WritableTrackingBuffer(optionBufferSize);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt32BE(0x00);
     return {
       token: TOKEN.THREADID,
@@ -168,7 +167,7 @@ class PreloginPayload {
   }
 
   createMarsOption() {
-    const buffer = new WritableTrackingBuffer(optionBufferSize);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(MARS.OFF);
     return {
       token: TOKEN.MARS,
@@ -177,7 +176,7 @@ class PreloginPayload {
   }
 
   createTraceIdOption() {
-    const buffer = new WritableTrackingBuffer(traceIdSize);
+    const buffer = new WritableTrackingBuffer();
     // Generate a random series of bytes to use as the TraceID.
     // Used for debugging purposes.
     buffer.writeBuffer(randomBytes(traceIdSize));
@@ -188,7 +187,7 @@ class PreloginPayload {
   }
 
   createFedAuthOption() {
-    const buffer = new WritableTrackingBuffer(optionBufferSize);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0x01);
     return {
       token: TOKEN.FEDAUTHREQUIRED,

--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -40,14 +40,14 @@ class RpcRequestPayload implements Iterable<Buffer> {
   }
 
   * generateData() {
-    const buffer = new WritableTrackingBuffer(500);
+    const buffer = new WritableTrackingBuffer();
     if (this.options.tdsVersion >= '7_2') {
       const outstandingRequestCount = 1;
       writeToTrackingBuffer(buffer, this.txnDescriptor, outstandingRequestCount);
     }
 
     if (typeof this.procedure === 'string') {
-      buffer.writeUsVarchar(this.procedure);
+      buffer.writeUsVarchar(this.procedure, 'ucs2');
     } else {
       buffer.writeUShort(0xFFFF);
       buffer.writeUShort(this.procedure);
@@ -68,12 +68,12 @@ class RpcRequestPayload implements Iterable<Buffer> {
   }
 
   * generateParameterData(parameter: Parameter) {
-    const buffer = new WritableTrackingBuffer(1 + 2 + Buffer.byteLength(parameter.name, 'ucs-2') + 1);
+    const buffer = new WritableTrackingBuffer();
 
     if (parameter.name) {
-      buffer.writeBVarchar('@' + parameter.name);
+      buffer.writeBVarchar('@' + parameter.name, 'ucs2');
     } else {
-      buffer.writeBVarchar('');
+      buffer.writeBVarchar('', 'ucs2');
     }
 
     let statusFlags = 0;

--- a/src/sqlbatch-payload.ts
+++ b/src/sqlbatch-payload.ts
@@ -17,7 +17,7 @@ class SqlBatchPayload implements Iterable<Buffer> {
 
   *[Symbol.iterator]() {
     if (this.options.tdsVersion >= '7_2') {
-      const buffer = new WritableTrackingBuffer(18, 'ucs2');
+      const buffer = new WritableTrackingBuffer();
       const outstandingRequestCount = 1;
 
       writeToTrackingBuffer(buffer, this.txnDescriptor, outstandingRequestCount);

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -132,8 +132,11 @@ class WritableTrackingBuffer {
   }
 
   /**
-   * The chunks holding all appended and not yet consumed bytes. The returned
-   * array is not modified by later appends or `consume` calls.
+   * The chunks holding all appended and not yet consumed bytes.
+   *
+   * The returned array is the list's own: later appends can add chunks to
+   * it. `consume` does not modify it, so taking the chunks and consuming
+   * them right away yields a stable snapshot.
    */
   getBuffers(): Buffer[] {
     this._seal();

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -1,12 +1,6 @@
 const SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
 const SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
 
-/**
- * The size of the chunks a `WritableTrackingBuffer` produces, and the size
- * from which appended buffers are referenced rather than copied.
- */
-export const CHUNK_SIZE = 8 * 1024;
-
 // The first chunk starts small and doubles up to `CHUNK_SIZE`: most payloads
 // built through this class are a few dozen bytes.
 const MIN_CHUNK_SIZE = 64;
@@ -28,6 +22,12 @@ export type Encoding = 'utf8' | 'ucs2' | 'ascii';
  * that of `bl`'s `BufferList`.
  */
 class WritableTrackingBuffer {
+  /**
+   * The size of the chunks a `WritableTrackingBuffer` produces, and the size
+   * from which written buffers are referenced rather than copied.
+   */
+  static readonly CHUNK_SIZE = 8 * 1024;
+
   /**
    * The number of bytes appended and not yet consumed.
    */
@@ -61,7 +61,7 @@ class WritableTrackingBuffer {
   private _seal() {
     if (this._pos > 0) {
       this._bufs.push(this._open.subarray(0, this._pos));
-      this._open = Buffer.allocUnsafe(Math.min(this._open.length * 2, CHUNK_SIZE));
+      this._open = Buffer.allocUnsafe(Math.min(this._open.length * 2, WritableTrackingBuffer.CHUNK_SIZE));
       this._pos = 0;
     }
   }
@@ -284,7 +284,7 @@ class WritableTrackingBuffer {
    */
   writeBuffer(value: Buffer) {
     const length = value.length;
-    if (length >= CHUNK_SIZE) {
+    if (length >= WritableTrackingBuffer.CHUNK_SIZE) {
       this._seal();
       this._bufs.push(value);
     } else {
@@ -299,4 +299,3 @@ class WritableTrackingBuffer {
 
 export default WritableTrackingBuffer;
 module.exports = WritableTrackingBuffer;
-module.exports.CHUNK_SIZE = CHUNK_SIZE;

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -11,10 +11,6 @@ export const CHUNK_SIZE = 8 * 1024;
 // built through this class are a few dozen bytes.
 const MIN_CHUNK_SIZE = 64;
 
-// Strings shorter than this are encoded in JavaScript. For short strings the
-// per-call overhead of the native encoder dominates the actual encoding.
-const INLINE_UCS2_LENGTH = 64;
-
 export type Encoding = 'utf8' | 'ucs2' | 'ascii';
 
 /**
@@ -259,24 +255,12 @@ class WritableTrackingBuffer {
   }
 
   writeString(value: string, encoding: Encoding) {
-    if (encoding === 'ucs2' && value.length < INLINE_UCS2_LENGTH) {
-      const length = value.length * 2;
-      this._ensure(length);
-
-      const open = this._open;
-      let pos = this._pos;
-      for (let i = 0; i < value.length; i++) {
-        const code = value.charCodeAt(i);
-        open[pos++] = code & 0xFF;
-        open[pos++] = code >>> 8;
-      }
-
-      this._pos = pos;
-      this.length += length;
-      return;
-    }
-
-    this.writeBuffer(Buffer.from(value, encoding));
+    // UCS-2 is two bytes per UTF-16 code unit.
+    const length = encoding === 'ucs2' ? value.length * 2 : Buffer.byteLength(value, encoding);
+    this._ensure(length);
+    this._open.write(value, this._pos, encoding);
+    this._pos += length;
+    this.length += length;
   }
 
   writeBVarchar(value: string, encoding: Encoding) {

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -169,27 +169,15 @@ class WritableTrackingBuffer {
   }
 
   /**
-   * Copies the given byte range into a new buffer.
+   * Copies all appended and not yet consumed bytes into a new buffer.
    */
-  slice(start = 0, end = this.length): Buffer {
+  slice(): Buffer {
     this._seal();
 
-    const result = Buffer.allocUnsafe(Math.max(end - start, 0));
+    const result = Buffer.allocUnsafe(this.length);
     let position = 0;
-    let offset = 0;
-
     for (const buffer of this._bufs) {
-      if (offset >= end) {
-        break;
-      }
-
-      const from = Math.max(start - offset, 0);
-      const to = Math.min(end - offset, buffer.length);
-      if (to > from) {
-        position += buffer.copy(result, position, from, to);
-      }
-
-      offset += buffer.length;
+      position += buffer.copy(result, position);
     }
 
     return result;

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -1,80 +1,210 @@
 const SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
 const SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
 const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
-const ZERO_LENGTH_BUFFER = Buffer.alloc(0);
+
+/**
+ * The size of the chunks a `WritableTrackingBuffer` produces, and the size
+ * from which appended buffers are referenced rather than copied.
+ */
+export const CHUNK_SIZE = 8 * 1024;
+
+// The first chunk starts small and doubles up to `CHUNK_SIZE`: most payloads
+// built through this class are a few dozen bytes.
+const MIN_CHUNK_SIZE = 64;
+
+// Strings shorter than this are encoded in JavaScript. For short strings the
+// per-call overhead of the native encoder dominates the actual encoding.
+const INLINE_UCS2_LENGTH = 64;
 
 export type Encoding = 'utf8' | 'ucs2' | 'ascii';
 
 /**
-  A Buffer-like class that tracks position.
-
-  As values are written, the position advances by the size of the written data.
-  When writing, automatically allocates new buffers if there's not enough space.
+ * A write-side buffer list.
+ *
+ * Bytes are appended through `append` and the `write*` methods, and taken
+ * out again either as a single buffer (`data`, `slice`) or as a list of
+ * chunks (`getBuffers`, `consume`). Small pieces are coalesced into chunks
+ * of at most `CHUNK_SIZE` bytes. Buffers of at least `CHUNK_SIZE` bytes are
+ * referenced rather than copied, so that large values cost no extra memory.
+ * (The caller must therefore not modify such buffers until they have been
+ * consumed.)
+ *
+ * The list API mirrors that of `bl`'s `BufferList`, with `write*` methods in
+ * place of its `read*` methods.
  */
 class WritableTrackingBuffer {
-  declare initialSize: number;
-  declare encoding: Encoding;
-  declare doubleSizeGrowth: boolean;
+  /**
+   * The number of bytes appended and not yet consumed.
+   */
+  declare length: number;
 
-  declare buffer: Buffer;
-  declare compositeBuffer: Buffer;
+  declare private _bufs: Buffer[];
+  declare private _open: Buffer;
+  declare private _pos: number;
 
-  declare position: number;
-
-  constructor(initialSize: number, encoding?: Encoding | null, doubleSizeGrowth?: boolean) {
-    this.initialSize = initialSize;
-    this.encoding = encoding || 'ucs2';
-    this.doubleSizeGrowth = doubleSizeGrowth || false;
-    this.buffer = Buffer.alloc(this.initialSize, 0);
-    this.compositeBuffer = ZERO_LENGTH_BUFFER;
-    this.position = 0;
+  constructor() {
+    this.length = 0;
+    this._bufs = [];
+    this._open = Buffer.allocUnsafe(MIN_CHUNK_SIZE);
+    this._pos = 0;
   }
 
-  get data() {
-    this.newBuffer(0);
-    return this.compositeBuffer;
+  /**
+   * All appended and not yet consumed bytes as a single buffer.
+   *
+   * When everything fits into a single chunk this is a view of that chunk
+   * rather than a copy. The returned buffer must not be modified.
+   */
+  get data(): Buffer {
+    if (this._bufs.length === 0) {
+      return this._open.subarray(0, this._pos);
+    }
+
+    return this.slice();
   }
 
-  copyFrom(buffer: Buffer) {
-    const length = buffer.length;
-    this.makeRoomFor(length);
-    buffer.copy(this.buffer, this.position);
-    this.position += length;
+  private _seal() {
+    if (this._pos > 0) {
+      this._bufs.push(this._open.subarray(0, this._pos));
+      this._open = Buffer.allocUnsafe(Math.min(this._open.length * 2, CHUNK_SIZE));
+      this._pos = 0;
+    }
   }
 
-  makeRoomFor(requiredLength: number) {
-    if (this.buffer.length - this.position < requiredLength) {
-      if (this.doubleSizeGrowth) {
-        let size = Math.max(128, this.buffer.length * 2);
-        while (size < requiredLength) {
-          size *= 2;
-        }
-        this.newBuffer(size);
-      } else {
-        this.newBuffer(requiredLength);
+  private _ensure(size: number) {
+    if (this._open.length - this._pos < size) {
+      this._seal();
+
+      if (this._open.length < size) {
+        this._open = Buffer.allocUnsafe(size);
       }
     }
   }
 
-  newBuffer(size: number) {
-    const buffer = this.buffer.slice(0, this.position);
-    this.compositeBuffer = Buffer.concat([this.compositeBuffer, buffer]);
-    this.buffer = (size === 0) ? ZERO_LENGTH_BUFFER : Buffer.alloc(size, 0);
-    this.position = 0;
+  /**
+   * Appends a buffer, a string or a list of buffers.
+   */
+  append(value: Buffer | Buffer[] | string, encoding?: Encoding): this {
+    if (typeof value === 'string') {
+      return this._appendString(value, encoding ?? 'utf8');
+    }
+
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        this.append(value[i]);
+      }
+      return this;
+    }
+
+    const length = value.length;
+    if (length >= CHUNK_SIZE) {
+      this._seal();
+      this._bufs.push(value);
+    } else {
+      this._ensure(length);
+      value.copy(this._open, this._pos);
+      this._pos += length;
+    }
+
+    this.length += length;
+    return this;
+  }
+
+  private _appendString(value: string, encoding: Encoding): this {
+    if (encoding === 'ucs2' && value.length < INLINE_UCS2_LENGTH) {
+      const length = value.length * 2;
+      this._ensure(length);
+
+      const open = this._open;
+      let pos = this._pos;
+      for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+        open[pos++] = code & 0xFF;
+        open[pos++] = code >>> 8;
+      }
+
+      this._pos = pos;
+      this.length += length;
+      return this;
+    }
+
+    return this.append(Buffer.from(value, encoding));
+  }
+
+  /**
+   * The chunks holding all appended and not yet consumed bytes. The returned
+   * array is not modified by later appends or `consume` calls.
+   */
+  getBuffers(): Buffer[] {
+    this._seal();
+    return this._bufs;
+  }
+
+  /**
+   * Discards the given number of bytes from the front of the list.
+   */
+  consume(bytes: number): this {
+    this._seal();
+
+    const bufs = this._bufs;
+    let i = 0;
+    while (i < bufs.length && bytes >= bufs[i].length) {
+      bytes -= bufs[i].length;
+      this.length -= bufs[i].length;
+      i++;
+    }
+
+    // A fresh array, so that a previously returned `getBuffers()` result
+    // stays intact.
+    this._bufs = bufs.slice(i);
+
+    if (bytes > 0 && this._bufs.length) {
+      this._bufs[0] = this._bufs[0].subarray(bytes);
+      this.length -= bytes;
+    }
+
+    return this;
+  }
+
+  /**
+   * Copies the given byte range into a new buffer.
+   */
+  slice(start = 0, end = this.length): Buffer {
+    this._seal();
+
+    const result = Buffer.allocUnsafe(Math.max(end - start, 0));
+    let position = 0;
+    let offset = 0;
+
+    for (const buffer of this._bufs) {
+      if (offset >= end) {
+        break;
+      }
+
+      const from = Math.max(start - offset, 0);
+      const to = Math.min(end - offset, buffer.length);
+      if (to > from) {
+        position += buffer.copy(result, position, from, to);
+      }
+
+      offset += buffer.length;
+    }
+
+    return result;
   }
 
   writeUInt8(value: number) {
-    const length = 1;
-    this.makeRoomFor(length);
-    this.buffer.writeUInt8(value, this.position);
-    this.position += length;
+    this._ensure(1);
+    this._open.writeUInt8(value, this._pos);
+    this._pos += 1;
+    this.length += 1;
   }
 
   writeUInt16LE(value: number) {
-    const length = 2;
-    this.makeRoomFor(length);
-    this.buffer.writeUInt16LE(value, this.position);
-    this.position += length;
+    this._ensure(2);
+    this._open.writeUInt16LE(value, this._pos);
+    this._pos += 2;
+    this.length += 2;
   }
 
   writeUShort(value: number) {
@@ -82,33 +212,33 @@ class WritableTrackingBuffer {
   }
 
   writeUInt16BE(value: number) {
-    const length = 2;
-    this.makeRoomFor(length);
-    this.buffer.writeUInt16BE(value, this.position);
-    this.position += length;
+    this._ensure(2);
+    this._open.writeUInt16BE(value, this._pos);
+    this._pos += 2;
+    this.length += 2;
   }
 
   writeUInt24LE(value: number) {
-    const length = 3;
-    this.makeRoomFor(length);
-    this.buffer[this.position + 2] = (value >>> 16) & 0xff;
-    this.buffer[this.position + 1] = (value >>> 8) & 0xff;
-    this.buffer[this.position] = value & 0xff;
-    this.position += length;
+    this._ensure(3);
+    this._open[this._pos + 2] = (value >>> 16) & 0xff;
+    this._open[this._pos + 1] = (value >>> 8) & 0xff;
+    this._open[this._pos] = value & 0xff;
+    this._pos += 3;
+    this.length += 3;
   }
 
   writeUInt32LE(value: number) {
-    const length = 4;
-    this.makeRoomFor(length);
-    this.buffer.writeUInt32LE(value, this.position);
-    this.position += length;
+    this._ensure(4);
+    this._open.writeUInt32LE(value, this._pos);
+    this._pos += 4;
+    this.length += 4;
   }
 
   writeBigInt64LE(value: bigint) {
-    const length = 8;
-    this.makeRoomFor(length);
-    this.buffer.writeBigInt64LE(value, this.position);
-    this.position += length;
+    this._ensure(8);
+    this._open.writeBigInt64LE(value, this._pos);
+    this._pos += 8;
+    this.length += 8;
   }
 
   writeInt64LE(value: number) {
@@ -120,17 +250,17 @@ class WritableTrackingBuffer {
   }
 
   writeBigUInt64LE(value: bigint) {
-    const length = 8;
-    this.makeRoomFor(length);
-    this.buffer.writeBigUInt64LE(value, this.position);
-    this.position += length;
+    this._ensure(8);
+    this._open.writeBigUInt64LE(value, this._pos);
+    this._pos += 8;
+    this.length += 8;
   }
 
   writeUInt32BE(value: number) {
-    const length = 4;
-    this.makeRoomFor(length);
-    this.buffer.writeUInt32BE(value, this.position);
-    this.position += length;
+    this._ensure(4);
+    this._open.writeUInt32BE(value, this._pos);
+    this._pos += 4;
+    this.length += 4;
   }
 
   writeUInt40LE(value: number) {
@@ -140,131 +270,91 @@ class WritableTrackingBuffer {
   }
 
   writeInt8(value: number) {
-    const length = 1;
-    this.makeRoomFor(length);
-    this.buffer.writeInt8(value, this.position);
-    this.position += length;
+    this._ensure(1);
+    this._open.writeInt8(value, this._pos);
+    this._pos += 1;
+    this.length += 1;
   }
 
   writeInt16LE(value: number) {
-    const length = 2;
-    this.makeRoomFor(length);
-    this.buffer.writeInt16LE(value, this.position);
-    this.position += length;
+    this._ensure(2);
+    this._open.writeInt16LE(value, this._pos);
+    this._pos += 2;
+    this.length += 2;
   }
 
   writeInt16BE(value: number) {
-    const length = 2;
-    this.makeRoomFor(length);
-    this.buffer.writeInt16BE(value, this.position);
-    this.position += length;
+    this._ensure(2);
+    this._open.writeInt16BE(value, this._pos);
+    this._pos += 2;
+    this.length += 2;
   }
 
   writeInt32LE(value: number) {
-    const length = 4;
-    this.makeRoomFor(length);
-    this.buffer.writeInt32LE(value, this.position);
-    this.position += length;
+    this._ensure(4);
+    this._open.writeInt32LE(value, this._pos);
+    this._pos += 4;
+    this.length += 4;
   }
 
   writeInt32BE(value: number) {
-    const length = 4;
-    this.makeRoomFor(length);
-    this.buffer.writeInt32BE(value, this.position);
-    this.position += length;
+    this._ensure(4);
+    this._open.writeInt32BE(value, this._pos);
+    this._pos += 4;
+    this.length += 4;
   }
 
   writeFloatLE(value: number) {
-    const length = 4;
-    this.makeRoomFor(length);
-    this.buffer.writeFloatLE(value, this.position);
-    this.position += length;
+    this._ensure(4);
+    this._open.writeFloatLE(value, this._pos);
+    this._pos += 4;
+    this.length += 4;
   }
 
   writeDoubleLE(value: number) {
-    const length = 8;
-    this.makeRoomFor(length);
-    this.buffer.writeDoubleLE(value, this.position);
-    this.position += length;
+    this._ensure(8);
+    this._open.writeDoubleLE(value, this._pos);
+    this._pos += 8;
+    this.length += 8;
   }
 
-  writeString(value: string, encoding?: Encoding | null) {
-    if (encoding == null) {
-      encoding = this.encoding;
-    }
-
-    const length = Buffer.byteLength(value, encoding);
-    this.makeRoomFor(length);
-
-    // $FlowFixMe https://github.com/facebook/flow/pull/5398
-    this.buffer.write(value, this.position, encoding);
-    this.position += length;
+  writeString(value: string, encoding: Encoding) {
+    this.append(value, encoding);
   }
 
-  writeBVarchar(value: string, encoding?: Encoding | null) {
+  writeBVarchar(value: string, encoding: Encoding) {
     this.writeUInt8(value.length);
-    this.writeString(value, encoding);
+    this.append(value, encoding);
   }
 
-  writeUsVarchar(value: string, encoding?: Encoding | null) {
+  writeUsVarchar(value: string, encoding: Encoding) {
     this.writeUInt16LE(value.length);
-    this.writeString(value, encoding);
+    this.append(value, encoding);
   }
 
-  // TODO: Figure out what types are passed in other than `Buffer`
-  writeUsVarbyte(value: any, encoding?: Encoding | null) {
-    if (encoding == null) {
-      encoding = this.encoding;
-    }
-
-    let length;
-    if (value instanceof Buffer) {
-      length = value.length;
+  writeUsVarbyte(value: Buffer | string, encoding: Encoding) {
+    if (Buffer.isBuffer(value)) {
+      this.writeUInt16LE(value.length);
+      this.append(value);
     } else {
-      value = value.toString();
-      length = Buffer.byteLength(value, encoding);
-    }
-    this.writeUInt16LE(length);
-
-    if (value instanceof Buffer) {
-      this.writeBuffer(value);
-    } else {
-      this.makeRoomFor(length);
-      // $FlowFixMe https://github.com/facebook/flow/pull/5398
-      this.buffer.write(value, this.position, encoding);
-      this.position += length;
+      this.writeUInt16LE(Buffer.byteLength(value, encoding));
+      this.append(value, encoding);
     }
   }
 
-  writePLPBody(value: any, encoding?: Encoding | null) {
-    if (encoding == null) {
-      encoding = this.encoding;
-    }
-
-    let length;
-    if (value instanceof Buffer) {
-      length = value.length;
-    } else {
-      value = value.toString();
-      length = Buffer.byteLength(value, encoding);
-    }
+  writePLPBody(value: Buffer | string, encoding: Encoding) {
+    const length = Buffer.isBuffer(value) ? value.length : Buffer.byteLength(value, encoding);
 
     // Length of all chunks.
     // this.writeUInt64LE(length);
     // unknown seems to work better here - might revisit later.
-    this.writeBuffer(UNKNOWN_PLP_LEN);
+    this.append(UNKNOWN_PLP_LEN);
 
     // In the UNKNOWN_PLP_LEN case, the data is represented as a series of zero or more chunks.
     if (length > 0) {
       // One chunk.
       this.writeUInt32LE(length);
-      if (value instanceof Buffer) {
-        this.writeBuffer(value);
-      } else {
-        this.makeRoomFor(length);
-        this.buffer.write(value, this.position, encoding);
-        this.position += length;
-      }
+      this.append(value, encoding);
     }
 
     // PLP_TERMINATOR (no more chunks).
@@ -272,10 +362,7 @@ class WritableTrackingBuffer {
   }
 
   writeBuffer(value: Buffer) {
-    const length = value.length;
-    this.makeRoomFor(length);
-    value.copy(this.buffer, this.position);
-    this.position += length;
+    this.append(value);
   }
 
   writeMoney(value: number) {
@@ -286,3 +373,4 @@ class WritableTrackingBuffer {
 
 export default WritableTrackingBuffer;
 module.exports = WritableTrackingBuffer;
+module.exports.CHUNK_SIZE = CHUNK_SIZE;

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -1,6 +1,5 @@
 const SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
 const SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;
-const UNKNOWN_PLP_LEN = Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
 /**
  * The size of the chunks a `WritableTrackingBuffer` produces, and the size
@@ -335,42 +334,13 @@ class WritableTrackingBuffer {
     this.append(value, encoding);
   }
 
-  writeUsVarbyte(value: Buffer | string, encoding: Encoding) {
-    if (Buffer.isBuffer(value)) {
-      this.writeUInt16LE(value.length);
-      this.append(value);
-    } else {
-      this.writeUInt16LE(Buffer.byteLength(value, encoding));
-      this.append(value, encoding);
-    }
-  }
-
-  writePLPBody(value: Buffer | string, encoding: Encoding) {
-    const length = Buffer.isBuffer(value) ? value.length : Buffer.byteLength(value, encoding);
-
-    // Length of all chunks.
-    // this.writeUInt64LE(length);
-    // unknown seems to work better here - might revisit later.
-    this.append(UNKNOWN_PLP_LEN);
-
-    // In the UNKNOWN_PLP_LEN case, the data is represented as a series of zero or more chunks.
-    if (length > 0) {
-      // One chunk.
-      this.writeUInt32LE(length);
-      this.append(value, encoding);
-    }
-
-    // PLP_TERMINATOR (no more chunks).
-    this.writeUInt32LE(0);
+  writeUsVarbyte(value: Buffer) {
+    this.writeUInt16LE(value.length);
+    this.append(value);
   }
 
   writeBuffer(value: Buffer) {
     this.append(value);
-  }
-
-  writeMoney(value: number) {
-    this.writeInt32LE(Math.floor(value * SHIFT_RIGHT_32));
-    this.writeInt32LE(value & -1);
   }
 }
 

--- a/src/tracking-buffer/writable-tracking-buffer.ts
+++ b/src/tracking-buffer/writable-tracking-buffer.ts
@@ -20,16 +20,16 @@ export type Encoding = 'utf8' | 'ucs2' | 'ascii';
 /**
  * A write-side buffer list.
  *
- * Bytes are appended through `append` and the `write*` methods, and taken
- * out again either as a single buffer (`data`, `slice`) or as a list of
- * chunks (`getBuffers`, `consume`). Small pieces are coalesced into chunks
- * of at most `CHUNK_SIZE` bytes. Buffers of at least `CHUNK_SIZE` bytes are
- * referenced rather than copied, so that large values cost no extra memory.
- * (The caller must therefore not modify such buffers until they have been
- * consumed.)
+ * Bytes are appended through the `write*` methods, and taken out again
+ * either as a single buffer (`data`, `slice`) or as a list of chunks
+ * (`getBuffers`, `consume`). Small pieces are coalesced into chunks of at
+ * most `CHUNK_SIZE` bytes. Buffers of at least `CHUNK_SIZE` bytes written
+ * through `writeBuffer` are referenced rather than copied, so that large
+ * values cost no extra memory. (The caller must therefore not modify such
+ * buffers until they have been consumed.)
  *
- * The list API mirrors that of `bl`'s `BufferList`, with `write*` methods in
- * place of its `read*` methods.
+ * The consumer side (`length`, `getBuffers`, `consume`, `slice`) mirrors
+ * that of `bl`'s `BufferList`.
  */
 class WritableTrackingBuffer {
   /**
@@ -78,56 +78,6 @@ class WritableTrackingBuffer {
         this._open = Buffer.allocUnsafe(size);
       }
     }
-  }
-
-  /**
-   * Appends a buffer, a string or a list of buffers.
-   */
-  append(value: Buffer | Buffer[] | string, encoding?: Encoding): this {
-    if (typeof value === 'string') {
-      return this._appendString(value, encoding ?? 'utf8');
-    }
-
-    if (Array.isArray(value)) {
-      for (let i = 0; i < value.length; i++) {
-        this.append(value[i]);
-      }
-      return this;
-    }
-
-    const length = value.length;
-    if (length >= CHUNK_SIZE) {
-      this._seal();
-      this._bufs.push(value);
-    } else {
-      this._ensure(length);
-      value.copy(this._open, this._pos);
-      this._pos += length;
-    }
-
-    this.length += length;
-    return this;
-  }
-
-  private _appendString(value: string, encoding: Encoding): this {
-    if (encoding === 'ucs2' && value.length < INLINE_UCS2_LENGTH) {
-      const length = value.length * 2;
-      this._ensure(length);
-
-      const open = this._open;
-      let pos = this._pos;
-      for (let i = 0; i < value.length; i++) {
-        const code = value.charCodeAt(i);
-        open[pos++] = code & 0xFF;
-        open[pos++] = code >>> 8;
-      }
-
-      this._pos = pos;
-      this.length += length;
-      return this;
-    }
-
-    return this.append(Buffer.from(value, encoding));
   }
 
   /**
@@ -309,26 +259,57 @@ class WritableTrackingBuffer {
   }
 
   writeString(value: string, encoding: Encoding) {
-    this.append(value, encoding);
+    if (encoding === 'ucs2' && value.length < INLINE_UCS2_LENGTH) {
+      const length = value.length * 2;
+      this._ensure(length);
+
+      const open = this._open;
+      let pos = this._pos;
+      for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+        open[pos++] = code & 0xFF;
+        open[pos++] = code >>> 8;
+      }
+
+      this._pos = pos;
+      this.length += length;
+      return;
+    }
+
+    this.writeBuffer(Buffer.from(value, encoding));
   }
 
   writeBVarchar(value: string, encoding: Encoding) {
     this.writeUInt8(value.length);
-    this.append(value, encoding);
+    this.writeString(value, encoding);
   }
 
   writeUsVarchar(value: string, encoding: Encoding) {
     this.writeUInt16LE(value.length);
-    this.append(value, encoding);
+    this.writeString(value, encoding);
   }
 
   writeUsVarbyte(value: Buffer) {
     this.writeUInt16LE(value.length);
-    this.append(value);
+    this.writeBuffer(value);
   }
 
+  /**
+   * Appends a buffer. Buffers of at least `CHUNK_SIZE` bytes are referenced
+   * rather than copied, and must not be modified until consumed.
+   */
   writeBuffer(value: Buffer) {
-    this.append(value);
+    const length = value.length;
+    if (length >= CHUNK_SIZE) {
+      this._seal();
+      this._bufs.push(value);
+    } else {
+      this._ensure(length);
+      value.copy(this._open, this._pos);
+      this._pos += length;
+    }
+
+    this.length += length;
   }
 }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -56,7 +56,7 @@ export class Transaction {
   }
 
   beginPayload(txnDescriptor: Buffer) {
-    const buffer = new WritableTrackingBuffer(100, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     writeToTrackingBuffer(buffer, txnDescriptor, this.outstandingRequestCount);
     buffer.writeUShort(OPERATION_TYPE.TM_BEGIN_XACT);
     buffer.writeUInt8(this.isolationLevel);
@@ -74,7 +74,7 @@ export class Transaction {
   }
 
   commitPayload(txnDescriptor: Buffer) {
-    const buffer = new WritableTrackingBuffer(100, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     writeToTrackingBuffer(buffer, txnDescriptor, this.outstandingRequestCount);
     buffer.writeUShort(OPERATION_TYPE.TM_COMMIT_XACT);
     buffer.writeUInt8(this.name.length * 2);
@@ -93,7 +93,7 @@ export class Transaction {
   }
 
   rollbackPayload(txnDescriptor: Buffer) {
-    const buffer = new WritableTrackingBuffer(100, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     writeToTrackingBuffer(buffer, txnDescriptor, this.outstandingRequestCount);
     buffer.writeUShort(OPERATION_TYPE.TM_ROLLBACK_XACT);
     buffer.writeUInt8(this.name.length * 2);
@@ -112,7 +112,7 @@ export class Transaction {
   }
 
   savePayload(txnDescriptor: Buffer) {
-    const buffer = new WritableTrackingBuffer(100, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     writeToTrackingBuffer(buffer, txnDescriptor, this.outstandingRequestCount);
     buffer.writeUShort(OPERATION_TYPE.TM_SAVE_XACT);
     buffer.writeUInt8(this.name.length * 2);

--- a/test/unit/all-headers-test.ts
+++ b/test/unit/all-headers-test.ts
@@ -29,7 +29,7 @@ describe('All Headers', function() {
       0x00
     ]);
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     const transactionDescriptor = Buffer.from([
       0x01,
       0x02,

--- a/test/unit/rerouting-test.ts
+++ b/test/unit/rerouting-test.ts
@@ -16,12 +16,12 @@ function buildRoutingEnvChangeToken(hostname: string, port: number): Buffer {
 
   const envValueDataBuffer = new WritableTrackingBuffer();
   envValueDataBuffer.writeUInt8(20); // Type
-  envValueDataBuffer.writeUsVarbyte(valueBuffer.data, 'ucs2');
-  envValueDataBuffer.writeUsVarbyte(Buffer.alloc(0), 'ucs2');
+  envValueDataBuffer.writeUsVarbyte(valueBuffer.data);
+  envValueDataBuffer.writeUsVarbyte(Buffer.alloc(0));
 
   const envChangeBuffer = new WritableTrackingBuffer();
   envChangeBuffer.writeUInt8(0xE3); // TokenType
-  envChangeBuffer.writeUsVarbyte(envValueDataBuffer.data, 'ucs2'); // Length + EnvValueData
+  envChangeBuffer.writeUsVarbyte(envValueDataBuffer.data); // Length + EnvValueData
 
   return envChangeBuffer.data;
 }

--- a/test/unit/rerouting-test.ts
+++ b/test/unit/rerouting-test.ts
@@ -9,19 +9,19 @@ import Message from '../../src/message';
 import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
 
 function buildRoutingEnvChangeToken(hostname: string, port: number): Buffer {
-  const valueBuffer = new WritableTrackingBuffer(0);
+  const valueBuffer = new WritableTrackingBuffer();
   valueBuffer.writeUInt8(0); // Protocol
   valueBuffer.writeUInt16LE(port); // Port
   valueBuffer.writeUsVarchar(hostname, 'ucs2');
 
-  const envValueDataBuffer = new WritableTrackingBuffer(0);
+  const envValueDataBuffer = new WritableTrackingBuffer();
   envValueDataBuffer.writeUInt8(20); // Type
-  envValueDataBuffer.writeUsVarbyte(valueBuffer.data);
-  envValueDataBuffer.writeUsVarbyte(Buffer.alloc(0));
+  envValueDataBuffer.writeUsVarbyte(valueBuffer.data, 'ucs2');
+  envValueDataBuffer.writeUsVarbyte(Buffer.alloc(0), 'ucs2');
 
-  const envChangeBuffer = new WritableTrackingBuffer(0);
+  const envChangeBuffer = new WritableTrackingBuffer();
   envChangeBuffer.writeUInt8(0xE3); // TokenType
-  envChangeBuffer.writeUsVarbyte(envValueDataBuffer.data); // Length + EnvValueData
+  envChangeBuffer.writeUsVarbyte(envValueDataBuffer.data, 'ucs2'); // Length + EnvValueData
 
   return envChangeBuffer.data;
 }

--- a/test/unit/token/colinfo-token-parser-test.ts
+++ b/test/unit/token/colinfo-token-parser-test.ts
@@ -8,7 +8,7 @@ describe('ColInfo Token Parser', function() {
   const options = { tdsVersion: '7_4' } as ParserOptions;
 
   it('should parse a single column', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa5);
     buffer.writeUInt16LE(3);
@@ -30,7 +30,7 @@ describe('ColInfo Token Parser', function() {
   });
 
   it('should parse the column status flags', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa5);
     buffer.writeUInt16LE(3 * 3);
@@ -60,14 +60,14 @@ describe('ColInfo Token Parser', function() {
   });
 
   it('should parse the base column name for aliased columns', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa5);
     buffer.writeUInt16LE(3 + 1 + ('name'.length * 2) + 3);
     buffer.writeUInt8(1);
     buffer.writeUInt8(1);
     buffer.writeUInt8(0x20); // DIFFERENT_NAME
-    buffer.writeBVarchar('name');
+    buffer.writeBVarchar('name', 'ucs2');
     buffer.writeUInt8(2);
     buffer.writeUInt8(1);
     buffer.writeUInt8(0x00);
@@ -87,14 +87,14 @@ describe('ColInfo Token Parser', function() {
   });
 
   it('should reject a token whose contents overrun its declared length', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa5);
     buffer.writeUInt16LE(3); // declared length only covers the fixed fields
     buffer.writeUInt8(1);
     buffer.writeUInt8(1);
     buffer.writeUInt8(0x20); // DIFFERENT_NAME
-    buffer.writeBVarchar('name');
+    buffer.writeBVarchar('name', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
 
@@ -110,14 +110,14 @@ describe('ColInfo Token Parser', function() {
   });
 
   it('should parse a token that arrives in single byte chunks', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa5);
     buffer.writeUInt16LE(3 + 1 + ('name'.length * 2));
     buffer.writeUInt8(1);
     buffer.writeUInt8(1);
     buffer.writeUInt8(0x20); // DIFFERENT_NAME
-    buffer.writeBVarchar('name');
+    buffer.writeBVarchar('name', 'ucs2');
 
     const chunks = Array.from(buffer.data, (byte) => Buffer.from([byte]));
 

--- a/test/unit/token/colmetadata-token-parser-test.ts
+++ b/test/unit/token/colmetadata-token-parser-test.ts
@@ -15,7 +15,7 @@ describe('Colmetadata Token Parser', function() {
       const flags = 3;
       const columnName = 'name';
 
-      const buffer = new WritableTrackingBuffer(50, 'ucs2');
+      const buffer = new WritableTrackingBuffer();
 
       buffer.writeUInt8(0x81);
       // Column Count
@@ -25,7 +25,7 @@ describe('Colmetadata Token Parser', function() {
         buffer.writeUInt32LE(userType);
         buffer.writeUInt16LE(flags);
         buffer.writeUInt8(typeByName.Int.id);
-        buffer.writeBVarchar(columnName);
+        buffer.writeBVarchar(columnName, 'ucs2');
       }
 
       const parser = StreamParser.parseTokens([buffer.data], debug, options);
@@ -55,14 +55,14 @@ describe('Colmetadata Token Parser', function() {
     const flags = 3;
     const columnName = 'name';
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0x81);
     buffer.writeUInt16LE(numberOfColumns);
     buffer.writeUInt32LE(userType);
     buffer.writeUInt16LE(flags);
     buffer.writeUInt8(typeByName.Int.id);
-    buffer.writeBVarchar(columnName);
+    buffer.writeBVarchar(columnName, 'ucs2');
     // console.log(buffer.data)
 
     const parser = StreamParser.parseTokens([buffer.data], debug, options);
@@ -90,7 +90,7 @@ describe('Colmetadata Token Parser', function() {
     const collation = Buffer.from([0x09, 0x04, 0x50, 0x78, 0x9a]);
     const columnName = 'name';
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0x81);
     buffer.writeUInt16LE(numberOfColumns);
@@ -99,7 +99,7 @@ describe('Colmetadata Token Parser', function() {
     buffer.writeUInt8(typeByName.VarChar.id);
     buffer.writeUInt16LE(length);
     buffer.writeBuffer(collation);
-    buffer.writeBVarchar(columnName);
+    buffer.writeBVarchar(columnName, 'ucs2');
     // console.log(buffer)
 
 

--- a/test/unit/token/done-token-parser-test.ts
+++ b/test/unit/token/done-token-parser-test.ts
@@ -10,7 +10,7 @@ function parse(status: number, curCmd: number, doneRowCount: number) {
   const doneRowCountLow = doneRowCount % 0x100000000;
   const doneRowCountHi = ~~(doneRowCount / 0x100000000);
 
-  const buffer = new WritableTrackingBuffer(50, 'ucs2');
+  const buffer = new WritableTrackingBuffer();
 
   buffer.writeUInt8(0xfd);
   buffer.writeUInt16LE(status);

--- a/test/unit/token/env-change-token-parser-test.ts
+++ b/test/unit/token/env-change-token-parser-test.ts
@@ -12,13 +12,13 @@ describe('Env Change Token Parser', () => {
     const oldDb = 'old';
     const newDb = 'new';
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xe3);
     buffer.writeUInt16LE(0); // Length written later
     buffer.writeUInt8(0x01); // Database
-    buffer.writeBVarchar(newDb);
-    buffer.writeBVarchar(oldDb);
+    buffer.writeBVarchar(newDb, 'ucs2');
+    buffer.writeBVarchar(oldDb, 'ucs2');
 
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
@@ -39,13 +39,13 @@ describe('Env Change Token Parser', () => {
     const oldSize = '1024';
     const newSize = '2048';
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xe3);
     buffer.writeUInt16LE(0); // Length written later
     buffer.writeUInt8(0x04); // Packet size
-    buffer.writeBVarchar(newSize);
-    buffer.writeBVarchar(oldSize);
+    buffer.writeBVarchar(newSize, 'ucs2');
+    buffer.writeBVarchar(oldSize, 'ucs2');
 
     const data = buffer.data;
     data.writeUInt16LE(data.length - 3, 1);
@@ -63,7 +63,7 @@ describe('Env Change Token Parser', () => {
 
   it('should skip unknown env change types', async function() {
     const debug = new Debug();
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xe3);
     buffer.writeUInt16LE(0); // Length written later

--- a/test/unit/token/feature-ext-parser-test.ts
+++ b/test/unit/token/feature-ext-parser-test.ts
@@ -9,7 +9,7 @@ const options = { tdsVersion: '7_2', useUTC: false } as ParserOptions;
 describe('Feature Ext Parser', () => {
   it('should parse federated authentication token', async function() {
     const debug = new Debug();
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xAE); // FEATUREEXTACK token header
 
@@ -41,7 +41,7 @@ describe('Feature Ext Parser', () => {
 
   it('should parse UTF-8 support token', async function() {
     const debug = new Debug();
-    const buffer = new WritableTrackingBuffer(8);
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xAE); // FEATUREEXTACK token header
     buffer.writeUInt8(0x0A); // UTF8_SUPPORT feature id

--- a/test/unit/token/fedauth-info-parser-test.ts
+++ b/test/unit/token/fedauth-info-parser-test.ts
@@ -9,7 +9,7 @@ const options = { tdsVersion: '7_2', useUTC: false } as ParserOptions;
 describe('Fedauth Info Parser', function() {
   it('should contain fed auth info', async function() {
     const debug = new Debug();
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xEE);
     buffer.writeUInt32LE(40);
     buffer.writeUInt32LE(2);
@@ -19,8 +19,8 @@ describe('Fedauth Info Parser', function() {
     buffer.writeUInt8(1);
     buffer.writeUInt32LE(12);
     buffer.writeUInt32LE(28);
-    buffer.writeString('spn');
-    buffer.writeString('stsurl');
+    buffer.writeString('spn', 'ucs2');
+    buffer.writeString('stsurl', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], debug, options);
     const result = await parser.next();

--- a/test/unit/token/infoerror-token-parser-test.ts
+++ b/test/unit/token/infoerror-token-parser-test.ts
@@ -17,16 +17,16 @@ describe('Infoerror token parser', function() {
     const procName = 'proc';
     const lineNumber = 6;
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xab);
     buffer.writeUInt16LE(0); // Length written later
     buffer.writeUInt32LE(number);
     buffer.writeUInt8(state);
     buffer.writeUInt8(class_);
-    buffer.writeUsVarchar(message);
-    buffer.writeBVarchar(serverName);
-    buffer.writeBVarchar(procName);
+    buffer.writeUsVarchar(message, 'ucs2');
+    buffer.writeBVarchar(serverName, 'ucs2');
+    buffer.writeBVarchar(procName, 'ucs2');
     buffer.writeUInt32LE(lineNumber);
 
     const data = buffer.data;

--- a/test/unit/token/loginack-token-parser-test.ts
+++ b/test/unit/token/loginack-token-parser-test.ts
@@ -19,13 +19,13 @@ describe('Loginack Token Parser', function() {
       buildNumLow: 4
     };
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xad);
     buffer.writeUInt16LE(0); // Length written later
     buffer.writeUInt8(interfaceType);
     buffer.writeUInt32BE(version);
-    buffer.writeBVarchar(progName);
+    buffer.writeBVarchar(progName, 'ucs2');
     buffer.writeUInt8(progVersion.major);
     buffer.writeUInt8(progVersion.minor);
     buffer.writeUInt8(progVersion.buildNumHi);

--- a/test/unit/token/nbcrow-token-parser-test.ts
+++ b/test/unit/token/nbcrow-token-parser-test.ts
@@ -17,7 +17,7 @@ describe('NBCRow Token Parser', function() {
   describe('parsing a row with many columns', function() {
     it('should parse them correctly', async function() {
       const debug = new Debug();
-      const buffer = new WritableTrackingBuffer(0, 'ascii');
+      const buffer = new WritableTrackingBuffer();
       buffer.writeUInt8(0xd2);
 
       // Write the null bitmap
@@ -37,7 +37,7 @@ describe('NBCRow Token Parser', function() {
           type: dataTypeByName.VarChar,
           collation: new Collation(1033, 0, 0, 52)
         });
-        buffer.writeUsVarchar(i.toString());
+        buffer.writeUsVarchar(i.toString(), 'ascii');
       }
 
       const parser = Parser.parseTokens([buffer.data], debug, options, colMetadata);

--- a/test/unit/token/order-token-parser-test.ts
+++ b/test/unit/token/order-token-parser-test.ts
@@ -13,7 +13,7 @@ describe('Order Token Parser', function() {
     const length = numberOfColumns * 2;
     const column = 3;
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa9);
     buffer.writeUInt16LE(length);
@@ -37,7 +37,7 @@ describe('Order Token Parser', function() {
     const column1 = 3;
     const column2 = 4;
 
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa9);
     buffer.writeUInt16LE(length);

--- a/test/unit/token/row-token-parser-test.ts
+++ b/test/unit/token/row-token-parser-test.ts
@@ -24,7 +24,7 @@ describe('Row Token Parser', function() {
   describe('parsing a row with many columns', function() {
     it('should parse them correctly', async function() {
       const debug = new Debug();
-      const buffer = new WritableTrackingBuffer(0, 'ascii');
+      const buffer = new WritableTrackingBuffer();
       buffer.writeUInt8(0xd1);
 
       const colMetadata: ColumnMetadata[] = [];
@@ -41,7 +41,7 @@ describe('Row Token Parser', function() {
           type: dataTypeByName.VarChar,
           collation: new Collation(1033, 0, 0, 52)
         });
-        buffer.writeUsVarchar(i.toString());
+        buffer.writeUsVarchar(i.toString(), 'ascii');
       }
 
       const parser = Parser.parseTokens([buffer.data], debug, options, colMetadata);
@@ -91,9 +91,9 @@ describe('Row Token Parser', function() {
         }
       ];
 
-      const buffer = new WritableTrackingBuffer(0, 'ascii');
+      const buffer = new WritableTrackingBuffer();
       buffer.writeUInt8(0xd1);
-      buffer.writeUsVarchar('hello world');
+      buffer.writeUsVarchar('hello world', 'ascii');
       buffer.writeUInt32LE(1234);
 
       const chunks = Array.from(buffer.data, (byte) => Buffer.from([byte]));
@@ -128,7 +128,7 @@ describe('Row Token Parser', function() {
     }];
     const value = 3;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt32LE(value);
 
@@ -173,7 +173,7 @@ describe('Row Token Parser', function() {
       }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 127])
@@ -207,7 +207,7 @@ describe('Row Token Parser', function() {
     }];
     const value = 9.5;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(Buffer.from([0x00, 0x00, 0x18, 0x41]));
 
@@ -240,7 +240,7 @@ describe('Row Token Parser', function() {
     }];
     const value = 9.5;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x23, 0x40])
@@ -281,7 +281,7 @@ describe('Row Token Parser', function() {
     const value = 123.456;
     const valueLarge = 123456789012345.11;
 
-    const buffer = new WritableTrackingBuffer(0);
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(Buffer.from([0x80, 0xd6, 0x12, 0x00]));
     buffer.writeBuffer(
@@ -330,9 +330,9 @@ describe('Row Token Parser', function() {
     ];
     const value = 'abcde';
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
-    buffer.writeUsVarchar(value);
+    buffer.writeUsVarchar(value, 'ascii');
     // console.log(buffer.data)
 
 
@@ -366,9 +366,9 @@ describe('Row Token Parser', function() {
     ];
     const value = 'abcdé';
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
-    buffer.writeUsVarchar(value);
+    buffer.writeUsVarchar(value, 'ascii');
     // console.log(buffer.data)
 
 
@@ -400,10 +400,10 @@ describe('Row Token Parser', function() {
     }];
     const value = 'abc';
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt16LE(value.length * 2);
-    buffer.writeString(value);
+    buffer.writeString(value, 'ucs2');
     // console.log(buffer.data)
 
     const parser = Parser.parseTokens([buffer.data], debug, options, colMetadata);
@@ -434,7 +434,7 @@ describe('Row Token Parser', function() {
     }];
     const value = Buffer.from([0x12, 0x34]);
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt16LE(value.length);
     buffer.writeBuffer(Buffer.from(value));
@@ -468,7 +468,7 @@ describe('Row Token Parser', function() {
     }];
     const value = Buffer.from([0x12, 0x34]);
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt16LE(value.length);
     buffer.writeBuffer(Buffer.from(value));
@@ -503,7 +503,7 @@ describe('Row Token Parser', function() {
       }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
@@ -540,15 +540,15 @@ describe('Row Token Parser', function() {
     ];
     const value = 'abcdef';
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
     );
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(0, 3));
+    buffer.writeString(value.slice(0, 3), 'ascii');
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(3, 6));
+    buffer.writeString(value.slice(3, 6), 'ascii');
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
@@ -582,13 +582,13 @@ describe('Row Token Parser', function() {
     ];
     const value = 'abcdef';
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt64LE(value.length);
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(0, 3));
+    buffer.writeString(value.slice(0, 3), 'ascii');
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(3, 6));
+    buffer.writeString(value.slice(3, 6), 'ascii');
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
@@ -623,13 +623,13 @@ describe('Row Token Parser', function() {
     ];
     const value = 'abcdéf';
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt64LE(value.length);
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(0, 3));
+    buffer.writeString(value.slice(0, 3), 'ascii');
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(3, 6));
+    buffer.writeString(value.slice(3, 6), 'ascii');
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
@@ -663,13 +663,13 @@ describe('Row Token Parser', function() {
     ];
     const value = 'abcdef';
 
-    const buffer = new WritableTrackingBuffer(0, 'ascii');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt64LE(value.length + 1);
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(0, 3));
+    buffer.writeString(value.slice(0, 3), 'ascii');
     buffer.writeUInt32LE(3);
-    buffer.writeString(value.slice(3, 6));
+    buffer.writeString(value.slice(3, 6), 'ascii');
     buffer.writeUInt32LE(0);
     // console.log(buffer.data)
 
@@ -704,7 +704,7 @@ describe('Row Token Parser', function() {
       }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
@@ -741,7 +741,7 @@ describe('Row Token Parser', function() {
     ];
     const value = Buffer.from([0x12, 0x34, 0x56, 0x78]);
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
@@ -791,7 +791,7 @@ describe('Row Token Parser', function() {
       { ...baseMetadata, colName: 'col11', type: IntN }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([
@@ -938,7 +938,7 @@ describe('Row Token Parser', function() {
       { ...baseMetadata, colName: 'col1', type: dataTypeByName.UniqueIdentifier }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([
@@ -998,7 +998,7 @@ describe('Row Token Parser', function() {
       { ...baseMetadata, colName: 'col1', type: dataTypeByName.UniqueIdentifier }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([
@@ -1056,7 +1056,7 @@ describe('Row Token Parser', function() {
       { ...baseMetadata, colName: 'col2', type: FloatN }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeBuffer(
       Buffer.from([
@@ -1110,7 +1110,7 @@ describe('Row Token Parser', function() {
     const days = 2; // 3rd January 1900
     const threeHundredthsOfSecond = 45 * 300; // 45 seconds
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeInt32LE(days);
@@ -1171,7 +1171,7 @@ describe('Row Token Parser', function() {
       collation: undefined
     }];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeUInt8(0);
@@ -1208,7 +1208,7 @@ describe('Row Token Parser', function() {
 
     const value = 9.3;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeUInt8(1 + 4);
@@ -1247,7 +1247,7 @@ describe('Row Token Parser', function() {
 
     const value = -9.3;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeUInt8(1 + 4);
@@ -1285,7 +1285,7 @@ describe('Row Token Parser', function() {
 
     const value = (0x100000000 + 93) / 10;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeUInt8(1 + 8);
@@ -1325,7 +1325,7 @@ describe('Row Token Parser', function() {
 
     const value = (0x100000000 * 0x100000000 + 0x200000000 + 93) / 10;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeUInt8(1 + 12);
@@ -1371,7 +1371,7 @@ describe('Row Token Parser', function() {
         93) /
       10;
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
 
     buffer.writeUInt8(1 + 16);
@@ -1411,7 +1411,7 @@ describe('Row Token Parser', function() {
       }
     ];
 
-    const buffer = new WritableTrackingBuffer(0, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(0xd1);
     buffer.writeUInt8(0);
     // console.log(buffer)

--- a/test/unit/token/sspi-token-parser-test.ts
+++ b/test/unit/token/sspi-token-parser-test.ts
@@ -9,7 +9,7 @@ const options = { tdsVersion: '7_2', useUTC: false } as ParserOptions;
 describe('sspi token parser', function() {
   it('should parse challenge', async function() {
     const debug = new Debug();
-    const source = new WriteBuffer(68);
+    const source = new WriteBuffer();
     source.writeUInt8(0xed);
     source.writeUInt16LE(0);
     source.writeString('NTLMSSP\0', 'utf8');
@@ -18,12 +18,12 @@ describe('sspi token parser', function() {
     source.writeInt16LE(12); // domain max
     source.writeInt32LE(111); // domain offset
     source.writeInt32LE(11256099); // flags == 'abc123'
-    source.copyFrom(Buffer.from([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0xa7, 0xb8])); // nonce
-    source.copyFrom(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])); // empty
+    source.writeBuffer(Buffer.from([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0xa7, 0xb8])); // nonce
+    source.writeBuffer(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])); // empty
     source.writeInt16LE(4); // target len
     source.writeInt16LE(4); // target max
     source.writeInt32LE(222); // target offset
-    source.copyFrom(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])); // odd data
+    source.writeBuffer(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])); // odd data
     source.writeString('domain', 'ucs2'); // domain
     source.writeInt32BE(11259375); // target == 'abcdef'
 

--- a/test/unit/token/tabname-token-parser-test.ts
+++ b/test/unit/token/tabname-token-parser-test.ts
@@ -8,12 +8,12 @@ describe('TabName Token Parser', function() {
   const options = { tdsVersion: '7_4' } as ParserOptions;
 
   it('should parse a single one-part table name', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa4);
     buffer.writeUInt16LE(1 + 2 + ('employees'.length * 2));
     buffer.writeUInt8(1);
-    buffer.writeUsVarchar('employees');
+    buffer.writeUsVarchar('employees', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
     const result = await parser.next();
@@ -27,13 +27,13 @@ describe('TabName Token Parser', function() {
   });
 
   it('should parse a multi-part table name', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa4);
     buffer.writeUInt16LE(1 + 2 + ('dbo'.length * 2) + 2 + ('employees'.length * 2));
     buffer.writeUInt8(2);
-    buffer.writeUsVarchar('dbo');
-    buffer.writeUsVarchar('employees');
+    buffer.writeUsVarchar('dbo', 'ucs2');
+    buffer.writeUsVarchar('employees', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
     const result = await parser.next();
@@ -47,14 +47,14 @@ describe('TabName Token Parser', function() {
   });
 
   it('should parse multiple table names', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa4);
     buffer.writeUInt16LE((1 + 2 + ('employees'.length * 2)) + (1 + 2 + ('teams'.length * 2)));
     buffer.writeUInt8(1);
-    buffer.writeUsVarchar('employees');
+    buffer.writeUsVarchar('employees', 'ucs2');
     buffer.writeUInt8(1);
-    buffer.writeUsVarchar('teams');
+    buffer.writeUsVarchar('teams', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
     const result = await parser.next();
@@ -70,12 +70,12 @@ describe('TabName Token Parser', function() {
   it('should parse the multi-part table name format on TDS 7.1', async function() {
     // Servers speaking TDS 7.1 already use the multi-part format, which was
     // introduced in TDS 7.1 Revision 1.
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa4);
     buffer.writeUInt16LE(1 + 2 + ('employees'.length * 2));
     buffer.writeUInt8(1);
-    buffer.writeUsVarchar('employees');
+    buffer.writeUsVarchar('employees', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), { tdsVersion: '7_1' } as ParserOptions);
     const result = await parser.next();
@@ -89,12 +89,12 @@ describe('TabName Token Parser', function() {
   });
 
   it('should reject a token whose contents overrun its declared length', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa4);
     buffer.writeUInt16LE(1); // declared length only covers the part count
     buffer.writeUInt8(1);
-    buffer.writeUsVarchar('employees');
+    buffer.writeUsVarchar('employees', 'ucs2');
 
     const parser = StreamParser.parseTokens([buffer.data], new Debug(), options);
 
@@ -110,13 +110,13 @@ describe('TabName Token Parser', function() {
   });
 
   it('should parse a token that arrives in single byte chunks', async function() {
-    const buffer = new WritableTrackingBuffer(50, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(0xa4);
     buffer.writeUInt16LE(1 + 2 + ('dbo'.length * 2) + 2 + ('employees'.length * 2));
     buffer.writeUInt8(2);
-    buffer.writeUsVarchar('dbo');
-    buffer.writeUsVarchar('employees');
+    buffer.writeUsVarchar('dbo', 'ucs2');
+    buffer.writeUsVarchar('employees', 'ucs2');
 
     const chunks = Array.from(buffer.data, (byte) => Buffer.from([byte]));
 

--- a/test/unit/token/token-stream-parser-test.ts
+++ b/test/unit/token/token-stream-parser-test.ts
@@ -22,10 +22,10 @@ function createDbChangeBuffer() {
   buffer.writeUInt8(oldDb.length);
   buffer.writeString(oldDb, 'ucs2');
 
-  buffer.data.writeUInt16LE(buffer.data.length - (1 + 2), 1);
-  // console.log(buffer)
+  const data = buffer.data;
+  data.writeUInt16LE(data.length - (1 + 2), 1);
 
-  return buffer.data;
+  return data;
 }
 
 // Test handler that only handles database change events

--- a/test/unit/token/token-stream-parser-test.ts
+++ b/test/unit/token/token-stream-parser-test.ts
@@ -12,15 +12,15 @@ const options = { tdsVersion: '7_2', useUTC: false } as ParserOptions;
 function createDbChangeBuffer() {
   const oldDb = 'old';
   const newDb = 'new';
-  const buffer = new WritableTrackingBuffer(50, 'ucs2');
+  const buffer = new WritableTrackingBuffer();
 
   buffer.writeUInt8(TYPE.ENVCHANGE);
   buffer.writeUInt16LE(0); // Length written later
   buffer.writeUInt8(0x01); // Database
   buffer.writeUInt8(newDb.length);
-  buffer.writeString(newDb);
+  buffer.writeString(newDb, 'ucs2');
   buffer.writeUInt8(oldDb.length);
-  buffer.writeString(oldDb);
+  buffer.writeString(oldDb, 'ucs2');
 
   buffer.data.writeUInt16LE(buffer.data.length - (1 + 2), 1);
   // console.log(buffer)

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -140,101 +140,99 @@ describe('Writable Tracking Buffer', () => {
 
     assertBuffer(buffer, [0x01, 0x02, 0x03, 0x04, 0x05]);
   });
-});
 
-describe('Writable Tracking Buffer list API', function() {
-  it('starts out empty', function() {
-    const list = new WritableTrackingBuffer();
-    assert.strictEqual(list.length, 0);
-    assert.deepEqual(list.getBuffers(), []);
-    assert.deepEqual(list.slice(), Buffer.alloc(0));
+  it('starts out empty', () => {
+    const buffer = new WritableTrackingBuffer();
+    assert.strictEqual(buffer.length, 0);
+    assert.deepEqual(buffer.getBuffers(), []);
+    assert.deepEqual(buffer.slice(), Buffer.alloc(0));
   });
 
-  it('returns stable data across later writes', function() {
-    const list = new WritableTrackingBuffer();
-    list.writeUInt8(1);
-    list.writeUInt8(2);
+  it('returns stable data across later writes', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.writeUInt8(1);
+    buffer.writeUInt8(2);
 
-    const first = list.data;
-    list.writeUInt8(3);
-    list.append(Buffer.alloc(CHUNK_SIZE, 4));
-    list.writeUInt8(5);
+    const first = buffer.data;
+    buffer.writeUInt8(3);
+    buffer.append(Buffer.alloc(CHUNK_SIZE, 4));
+    buffer.writeUInt8(5);
 
     assert.deepEqual(first, Buffer.from([1, 2]));
-    assert.strictEqual(list.data.length, 3 + CHUNK_SIZE + 1);
-    assert.deepEqual(list.data.subarray(0, 3), Buffer.from([1, 2, 3]));
-    assert.strictEqual(list.data[3 + CHUNK_SIZE], 5);
+    assert.strictEqual(buffer.data.length, 3 + CHUNK_SIZE + 1);
+    assert.deepEqual(buffer.data.subarray(0, 3), Buffer.from([1, 2, 3]));
+    assert.strictEqual(buffer.data[3 + CHUNK_SIZE], 5);
   });
 
-  it('coalesces small appended buffers into a single chunk', function() {
-    const list = new WritableTrackingBuffer();
-    list.append(Buffer.from([1, 2]));
-    list.append(Buffer.from([3]));
-    list.append([Buffer.from([4]), Buffer.from([5, 6])]);
+  it('coalesces small appended buffers into a single chunk', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.append(Buffer.from([1, 2]));
+    buffer.append(Buffer.from([3]));
+    buffer.append([Buffer.from([4]), Buffer.from([5, 6])]);
 
-    assert.strictEqual(list.length, 6);
-    const buffers = list.getBuffers();
+    assert.strictEqual(buffer.length, 6);
+    const buffers = buffer.getBuffers();
     assert.lengthOf(buffers, 1);
     assert.deepEqual(buffers[0], Buffer.from([1, 2, 3, 4, 5, 6]));
   });
 
-  it('references large buffers instead of copying them', function() {
-    const list = new WritableTrackingBuffer();
+  it('references large buffers instead of copying them', () => {
+    const buffer = new WritableTrackingBuffer();
     const large = Buffer.alloc(CHUNK_SIZE, 0x42);
-    list.append(Buffer.from([1]));
-    list.append(large);
-    list.append(Buffer.from([2]));
+    buffer.append(Buffer.from([1]));
+    buffer.append(large);
+    buffer.append(Buffer.from([2]));
 
-    const buffers = list.getBuffers();
+    const buffers = buffer.getBuffers();
     assert.lengthOf(buffers, 3);
     assert.deepEqual(buffers[0], Buffer.from([1]));
     assert.strictEqual(buffers[1], large);
     assert.deepEqual(buffers[2], Buffer.from([2]));
-    assert.strictEqual(list.length, CHUNK_SIZE + 2);
+    assert.strictEqual(buffer.length, CHUNK_SIZE + 2);
   });
 
-  it('never produces coalesced chunks larger than the chunk size', function() {
-    const list = new WritableTrackingBuffer();
+  it('never produces coalesced chunks larger than the chunk size', () => {
+    const buffer = new WritableTrackingBuffer();
     const piece = Buffer.alloc(1000, 0x01);
     for (let i = 0; i < 100; i++) {
-      list.append(piece);
+      buffer.append(piece);
     }
 
-    const buffers = list.getBuffers();
+    const buffers = buffer.getBuffers();
     assert.isAbove(buffers.length, 1);
-    for (const buffer of buffers) {
-      assert.isAtMost(buffer.length, CHUNK_SIZE);
+    for (const chunk of buffers) {
+      assert.isAtMost(chunk.length, CHUNK_SIZE);
     }
-    assert.deepEqual(list.slice(), Buffer.alloc(100 * 1000, 0x01));
+    assert.deepEqual(buffer.slice(), Buffer.alloc(100 * 1000, 0x01));
   });
 
-  it('encodes strings', function() {
-    const list = new WritableTrackingBuffer();
-    list.append('héllo 🎉', 'ucs2');
-    list.append('héllo 🎉', 'utf8');
-    list.append('x'.repeat(100), 'ucs2');
+  it('encodes strings', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.append('héllo 🎉', 'ucs2');
+    buffer.append('héllo 🎉', 'utf8');
+    buffer.append('x'.repeat(100), 'ucs2');
 
     const expected = Buffer.concat([
       Buffer.from('héllo 🎉', 'ucs2'),
       Buffer.from('héllo 🎉', 'utf8'),
       Buffer.from('x'.repeat(100), 'ucs2')
     ]);
-    assert.deepEqual(list.slice(), expected);
-    assert.strictEqual(list.length, expected.length);
+    assert.deepEqual(buffer.slice(), expected);
+    assert.strictEqual(buffer.length, expected.length);
   });
 
-  it('writes fixed-width values', function() {
-    const list = new WritableTrackingBuffer();
-    list.writeUInt8(0xFF);
-    list.writeInt8(-1);
-    list.writeUInt16LE(0x1234);
-    list.writeInt16LE(-2);
-    list.writeUInt32LE(0xDEADBEEF);
-    list.writeInt32LE(-3);
-    list.writeBigUInt64LE(0xFFFFFFFFFFFFFFFFn);
-    list.writeBigInt64LE(-4n);
-    list.writeFloatLE(1.5);
-    list.writeDoubleLE(-2.25);
+  it('writes fixed-width values', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.writeUInt8(0xFF);
+    buffer.writeInt8(-1);
+    buffer.writeUInt16LE(0x1234);
+    buffer.writeInt16LE(-2);
+    buffer.writeUInt32LE(0xDEADBEEF);
+    buffer.writeInt32LE(-3);
+    buffer.writeBigUInt64LE(0xFFFFFFFFFFFFFFFFn);
+    buffer.writeBigInt64LE(-4n);
+    buffer.writeFloatLE(1.5);
+    buffer.writeDoubleLE(-2.25);
 
     const expected = Buffer.alloc(1 + 1 + 2 + 2 + 4 + 4 + 8 + 8 + 4 + 8);
     let offset = 0;
@@ -249,64 +247,64 @@ describe('Writable Tracking Buffer list API', function() {
     offset = expected.writeFloatLE(1.5, offset);
     expected.writeDoubleLE(-2.25, offset);
 
-    assert.deepEqual(list.slice(), expected);
-    assert.strictEqual(list.length, expected.length);
+    assert.deepEqual(buffer.slice(), expected);
+    assert.strictEqual(buffer.length, expected.length);
   });
 
-  it('keeps writes contiguous across chunk boundaries', function() {
-    const list = new WritableTrackingBuffer();
+  it('keeps writes contiguous across chunk boundaries', () => {
+    const buffer = new WritableTrackingBuffer();
     // Fill up to just below the first chunk boundary, then write a value
     // that does not fit into the remaining space.
-    list.append(Buffer.alloc(1023, 0x00));
-    list.writeUInt32LE(0x01020304);
+    buffer.append(Buffer.alloc(1023, 0x00));
+    buffer.writeUInt32LE(0x01020304);
 
-    const data = list.slice();
+    const data = buffer.slice();
     assert.strictEqual(data.readUInt32LE(1023), 0x01020304);
-    for (const buffer of list.getBuffers()) {
-      assert.isAtMost(buffer.length, CHUNK_SIZE);
+    for (const chunk of buffer.getBuffers()) {
+      assert.isAtMost(chunk.length, CHUNK_SIZE);
     }
   });
 
-  it('consumes bytes from the front', function() {
-    const list = new WritableTrackingBuffer();
-    list.append(Buffer.from([1, 2, 3, 4, 5]));
+  it('consumes bytes from the front', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.append(Buffer.from([1, 2, 3, 4, 5]));
 
-    const before = list.getBuffers();
-    list.consume(2);
-    assert.strictEqual(list.length, 3);
-    assert.deepEqual(list.slice(), Buffer.from([3, 4, 5]));
+    const before = buffer.getBuffers();
+    buffer.consume(2);
+    assert.strictEqual(buffer.length, 3);
+    assert.deepEqual(buffer.slice(), Buffer.from([3, 4, 5]));
 
     // a previously returned list of buffers is unaffected
     assert.deepEqual(before, [Buffer.from([1, 2, 3, 4, 5])]);
 
-    list.consume(3);
-    assert.strictEqual(list.length, 0);
-    assert.deepEqual(list.getBuffers(), []);
+    buffer.consume(3);
+    assert.strictEqual(buffer.length, 0);
+    assert.deepEqual(buffer.getBuffers(), []);
 
-    list.append(Buffer.from([6]));
-    assert.deepEqual(list.slice(), Buffer.from([6]));
+    buffer.append(Buffer.from([6]));
+    assert.deepEqual(buffer.slice(), Buffer.from([6]));
   });
 
-  it('consumes across chunks', function() {
-    const list = new WritableTrackingBuffer();
+  it('consumes across chunks', () => {
+    const buffer = new WritableTrackingBuffer();
     const large = Buffer.alloc(CHUNK_SIZE, 0x42);
-    list.append(Buffer.from([1, 2]));
-    list.append(large);
-    list.append(Buffer.from([3]));
+    buffer.append(Buffer.from([1, 2]));
+    buffer.append(large);
+    buffer.append(Buffer.from([3]));
 
-    list.consume(2 + CHUNK_SIZE - 1);
-    assert.strictEqual(list.length, 2);
-    assert.deepEqual(list.slice(), Buffer.from([0x42, 3]));
+    buffer.consume(2 + CHUNK_SIZE - 1);
+    assert.strictEqual(buffer.length, 2);
+    assert.deepEqual(buffer.slice(), Buffer.from([0x42, 3]));
   });
 
-  it('slices ranges', function() {
-    const list = new WritableTrackingBuffer();
-    list.append(Buffer.from([1, 2, 3]));
-    list.append(Buffer.alloc(CHUNK_SIZE, 4));
-    list.append(Buffer.from([5, 6]));
+  it('slices ranges', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.append(Buffer.from([1, 2, 3]));
+    buffer.append(Buffer.alloc(CHUNK_SIZE, 4));
+    buffer.append(Buffer.from([5, 6]));
 
-    assert.deepEqual(list.slice(1, 3), Buffer.from([2, 3]));
-    assert.deepEqual(list.slice(2, 5), Buffer.from([3, 4, 4]));
-    assert.deepEqual(list.slice(CHUNK_SIZE + 2), Buffer.from([4, 5, 6]));
+    assert.deepEqual(buffer.slice(1, 3), Buffer.from([2, 3]));
+    assert.deepEqual(buffer.slice(2, 5), Buffer.from([3, 4, 4]));
+    assert.deepEqual(buffer.slice(CHUNK_SIZE + 2), Buffer.from([4, 5, 6]));
   });
 });

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -296,15 +296,4 @@ describe('Writable Tracking Buffer', () => {
     assert.strictEqual(buffer.length, 2);
     assert.deepEqual(buffer.slice(), Buffer.from([0x42, 3]));
   });
-
-  it('slices ranges', () => {
-    const buffer = new WritableTrackingBuffer();
-    buffer.append(Buffer.from([1, 2, 3]));
-    buffer.append(Buffer.alloc(CHUNK_SIZE, 4));
-    buffer.append(Buffer.from([5, 6]));
-
-    assert.deepEqual(buffer.slice(1, 3), Buffer.from([2, 3]));
-    assert.deepEqual(buffer.slice(2, 5), Buffer.from([3, 4, 4]));
-    assert.deepEqual(buffer.slice(CHUNK_SIZE + 2), Buffer.from([4, 5, 6]));
-  });
 });

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -1,7 +1,7 @@
 import WritableTrackingBuffer, { type Encoding } from '../../../src/tracking-buffer/writable-tracking-buffer';
+import { assert } from 'chai';
 
 const { CHUNK_SIZE } = WritableTrackingBuffer;
-import { assert } from 'chai';
 
 function assertBuffer(actual: WritableTrackingBuffer, expected: number[]): void {
   const actualData = actual.data;

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -237,9 +237,9 @@ describe('Writable Tracking Buffer', () => {
 
   it('encodes strings', () => {
     const buffer = new WritableTrackingBuffer();
-    // Strings under 64 characters are encoded inline, longer ones natively;
-    // both must produce exactly what `Buffer.from` produces, including for
-    // surrogate pairs and lone surrogates.
+    // Strings are encoded in place; the result must be exactly what
+    // `Buffer.from` produces, including for surrogate pairs, lone
+    // surrogates, and strings that do not fit the open chunk.
     const strings: [string, Encoding][] = [
       ['héllo 🎉', 'ucs2'],
       ['héllo 🎉', 'utf8'],

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -1,4 +1,4 @@
-import WritableTrackingBuffer, { CHUNK_SIZE } from '../../../src/tracking-buffer/writable-tracking-buffer';
+import WritableTrackingBuffer, { CHUNK_SIZE, type Encoding } from '../../../src/tracking-buffer/writable-tracking-buffer';
 import { assert } from 'chai';
 
 function assertBuffer(actual: WritableTrackingBuffer, expected: number[]): void {
@@ -148,6 +148,20 @@ describe('Writable Tracking Buffer', () => {
     assert.deepEqual(buffer.slice(), Buffer.alloc(0));
   });
 
+  it('returns a view of a single chunk and a copy of several', () => {
+    const buffer = new WritableTrackingBuffer();
+    buffer.writeUInt8(1);
+
+    const view = buffer.data;
+    const [chunk] = buffer.getBuffers();
+    assert.strictEqual(view.buffer, chunk.buffer);
+    assert.strictEqual(view.byteOffset, chunk.byteOffset);
+
+    buffer.writeBuffer(Buffer.alloc(CHUNK_SIZE, 2));
+    assert.notStrictEqual(buffer.data, buffer.data);
+    assert.notStrictEqual(buffer.data.buffer, chunk.buffer);
+  });
+
   it('returns stable data across later writes', () => {
     const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(1);
@@ -177,6 +191,17 @@ describe('Writable Tracking Buffer', () => {
     assert.deepEqual(buffers[0], Buffer.from([1, 2, 3, 4, 5, 6]));
   });
 
+  it('copies buffers below the chunk size', () => {
+    const buffer = new WritableTrackingBuffer();
+    const almost = Buffer.alloc(CHUNK_SIZE - 1, 0x42);
+    buffer.writeBuffer(almost);
+
+    const [chunk] = buffer.getBuffers();
+    assert.notStrictEqual(chunk, almost);
+    assert.notStrictEqual(chunk.buffer, almost.buffer);
+    assert.deepEqual(chunk, almost);
+  });
+
   it('references large buffers instead of copying them', () => {
     const buffer = new WritableTrackingBuffer();
     const large = Buffer.alloc(CHUNK_SIZE, 0x42);
@@ -199,8 +224,11 @@ describe('Writable Tracking Buffer', () => {
       buffer.writeBuffer(piece);
     }
 
+    // 100 KB coalesced into chunks of at most 8 KB: at least 13 chunks, and
+    // not one per write.
     const buffers = buffer.getBuffers();
-    assert.isAbove(buffers.length, 1);
+    assert.isAtLeast(buffers.length, 13);
+    assert.isAtMost(buffers.length, 16);
     for (const chunk of buffers) {
       assert.isAtMost(chunk.length, CHUNK_SIZE);
     }
@@ -209,15 +237,23 @@ describe('Writable Tracking Buffer', () => {
 
   it('encodes strings', () => {
     const buffer = new WritableTrackingBuffer();
-    buffer.writeString('héllo 🎉', 'ucs2');
-    buffer.writeString('héllo 🎉', 'utf8');
-    buffer.writeString('x'.repeat(100), 'ucs2');
+    // Strings under 64 characters are encoded inline, longer ones natively;
+    // both must produce exactly what `Buffer.from` produces, including for
+    // surrogate pairs and lone surrogates.
+    const strings: [string, Encoding][] = [
+      ['héllo 🎉', 'ucs2'],
+      ['héllo 🎉', 'utf8'],
+      ['\ud83c', 'ucs2'],
+      ['x'.repeat(63), 'ucs2'],
+      ['x'.repeat(64), 'ucs2'],
+      ['x'.repeat(100), 'ucs2'],
+      ['abc', 'ascii']
+    ];
+    for (const [value, encoding] of strings) {
+      buffer.writeString(value, encoding);
+    }
 
-    const expected = Buffer.concat([
-      Buffer.from('héllo 🎉', 'ucs2'),
-      Buffer.from('héllo 🎉', 'utf8'),
-      Buffer.from('x'.repeat(100), 'ucs2')
-    ]);
+    const expected = Buffer.concat(strings.map(([value, encoding]) => Buffer.from(value, encoding)));
     assert.deepEqual(buffer.slice(), expected);
     assert.strictEqual(buffer.length, expected.length);
   });
@@ -254,16 +290,14 @@ describe('Writable Tracking Buffer', () => {
 
   it('keeps writes contiguous across chunk boundaries', () => {
     const buffer = new WritableTrackingBuffer();
-    // Fill up to just below the first chunk boundary, then write a value
-    // that does not fit into the remaining space.
-    buffer.writeBuffer(Buffer.alloc(1023, 0x00));
+    // The first chunk holds 64 bytes. Leave two of them free, then write a
+    // value that does not fit: it must land whole in the next chunk.
+    buffer.writeBuffer(Buffer.alloc(62, 0x00));
     buffer.writeUInt32LE(0x01020304);
 
     const data = buffer.slice();
-    assert.strictEqual(data.readUInt32LE(1023), 0x01020304);
-    for (const chunk of buffer.getBuffers()) {
-      assert.isAtMost(chunk.length, CHUNK_SIZE);
-    }
+    assert.strictEqual(data.readUInt32LE(62), 0x01020304);
+    assert.deepEqual(buffer.getBuffers().map((chunk) => chunk.length), [62, 4]);
   });
 
   it('consumes bytes from the front', () => {

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -1,4 +1,4 @@
-import WritableTrackingBuffer from '../../../src/tracking-buffer/writable-tracking-buffer';
+import WritableTrackingBuffer, { CHUNK_SIZE } from '../../../src/tracking-buffer/writable-tracking-buffer';
 import { assert } from 'chai';
 
 function assertBuffer(actual: WritableTrackingBuffer, expected: number[]): void {
@@ -15,14 +15,14 @@ function assertBuffer(actual: WritableTrackingBuffer, expected: number[]): void 
 
 describe('Writable Tracking Buffer', () => {
   it('should create', function() {
-    const buffer = new WritableTrackingBuffer(2);
+    const buffer = new WritableTrackingBuffer();
 
     assert.isDefined(buffer);
     assert.strictEqual(0, buffer.data.length);
   });
 
   it('should write unsigned int', function() {
-    const buffer = new WritableTrackingBuffer(20);
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeUInt8(1);
     buffer.writeUInt16LE(2);
@@ -57,7 +57,7 @@ describe('Writable Tracking Buffer', () => {
   });
 
   it('should write signed int', function() {
-    const buffer = new WritableTrackingBuffer(2);
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeInt8(-1);
     buffer.writeInt16LE(-2);
@@ -92,31 +92,31 @@ describe('Writable Tracking Buffer', () => {
   });
 
   it('should write string', function() {
-    const buffer = new WritableTrackingBuffer(2, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
-    buffer.writeString('abc');
+    buffer.writeString('abc', 'ucs2');
 
     assertBuffer(buffer, [0x61, 0x00, 0x62, 0x00, 0x63, 0x00]);
   });
 
   it('should write BVarChar', function() {
-    const buffer = new WritableTrackingBuffer(2, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
-    buffer.writeBVarchar('abc');
+    buffer.writeBVarchar('abc', 'ucs2');
 
     assertBuffer(buffer, [0x03, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00]);
   });
 
   it('should write UsVarChar', function() {
-    const buffer = new WritableTrackingBuffer(2, 'ucs2');
+    const buffer = new WritableTrackingBuffer();
 
-    buffer.writeUsVarchar('abc');
+    buffer.writeUsVarchar('abc', 'ucs2');
 
     assertBuffer(buffer, [0x03, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00]);
   });
 
   it('should write 64-bit signed `BigInt`s', function() {
-    const buffer = new WritableTrackingBuffer(8);
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeBigInt64LE(BigInt('0x0807060504030201'));
 
@@ -124,20 +124,189 @@ describe('Writable Tracking Buffer', () => {
   });
 
   it('should write 64-bit unsigned `BigInt`s', function() {
-    const buffer = new WritableTrackingBuffer(8);
+    const buffer = new WritableTrackingBuffer();
 
     buffer.writeBigUInt64LE(BigInt('0xdecafafecacefade'));
 
     assertBuffer(buffer, [0xde, 0xfa, 0xce, 0xca, 0xfe, 0xfa, 0xca, 0xde]);
   });
 
-  it('should copyFrom', function() {
-    const buffer = new WritableTrackingBuffer(10);
+  it('should write buffers', function() {
+    const buffer = new WritableTrackingBuffer();
     const source = Buffer.from([0x01, 0x02, 0x03, 0x04]);
 
-    buffer.copyFrom(source);
+    buffer.writeBuffer(source);
     buffer.writeUInt8(5);
 
     assertBuffer(buffer, [0x01, 0x02, 0x03, 0x04, 0x05]);
+  });
+});
+
+describe('Writable Tracking Buffer list API', function() {
+  it('starts out empty', function() {
+    const list = new WritableTrackingBuffer();
+    assert.strictEqual(list.length, 0);
+    assert.deepEqual(list.getBuffers(), []);
+    assert.deepEqual(list.slice(), Buffer.alloc(0));
+  });
+
+  it('returns stable data across later writes', function() {
+    const list = new WritableTrackingBuffer();
+    list.writeUInt8(1);
+    list.writeUInt8(2);
+
+    const first = list.data;
+    list.writeUInt8(3);
+    list.append(Buffer.alloc(CHUNK_SIZE, 4));
+    list.writeUInt8(5);
+
+    assert.deepEqual(first, Buffer.from([1, 2]));
+    assert.strictEqual(list.data.length, 3 + CHUNK_SIZE + 1);
+    assert.deepEqual(list.data.subarray(0, 3), Buffer.from([1, 2, 3]));
+    assert.strictEqual(list.data[3 + CHUNK_SIZE], 5);
+  });
+
+  it('coalesces small appended buffers into a single chunk', function() {
+    const list = new WritableTrackingBuffer();
+    list.append(Buffer.from([1, 2]));
+    list.append(Buffer.from([3]));
+    list.append([Buffer.from([4]), Buffer.from([5, 6])]);
+
+    assert.strictEqual(list.length, 6);
+    const buffers = list.getBuffers();
+    assert.lengthOf(buffers, 1);
+    assert.deepEqual(buffers[0], Buffer.from([1, 2, 3, 4, 5, 6]));
+  });
+
+  it('references large buffers instead of copying them', function() {
+    const list = new WritableTrackingBuffer();
+    const large = Buffer.alloc(CHUNK_SIZE, 0x42);
+    list.append(Buffer.from([1]));
+    list.append(large);
+    list.append(Buffer.from([2]));
+
+    const buffers = list.getBuffers();
+    assert.lengthOf(buffers, 3);
+    assert.deepEqual(buffers[0], Buffer.from([1]));
+    assert.strictEqual(buffers[1], large);
+    assert.deepEqual(buffers[2], Buffer.from([2]));
+    assert.strictEqual(list.length, CHUNK_SIZE + 2);
+  });
+
+  it('never produces coalesced chunks larger than the chunk size', function() {
+    const list = new WritableTrackingBuffer();
+    const piece = Buffer.alloc(1000, 0x01);
+    for (let i = 0; i < 100; i++) {
+      list.append(piece);
+    }
+
+    const buffers = list.getBuffers();
+    assert.isAbove(buffers.length, 1);
+    for (const buffer of buffers) {
+      assert.isAtMost(buffer.length, CHUNK_SIZE);
+    }
+    assert.deepEqual(list.slice(), Buffer.alloc(100 * 1000, 0x01));
+  });
+
+  it('encodes strings', function() {
+    const list = new WritableTrackingBuffer();
+    list.append('héllo 🎉', 'ucs2');
+    list.append('héllo 🎉', 'utf8');
+    list.append('x'.repeat(100), 'ucs2');
+
+    const expected = Buffer.concat([
+      Buffer.from('héllo 🎉', 'ucs2'),
+      Buffer.from('héllo 🎉', 'utf8'),
+      Buffer.from('x'.repeat(100), 'ucs2')
+    ]);
+    assert.deepEqual(list.slice(), expected);
+    assert.strictEqual(list.length, expected.length);
+  });
+
+  it('writes fixed-width values', function() {
+    const list = new WritableTrackingBuffer();
+    list.writeUInt8(0xFF);
+    list.writeInt8(-1);
+    list.writeUInt16LE(0x1234);
+    list.writeInt16LE(-2);
+    list.writeUInt32LE(0xDEADBEEF);
+    list.writeInt32LE(-3);
+    list.writeBigUInt64LE(0xFFFFFFFFFFFFFFFFn);
+    list.writeBigInt64LE(-4n);
+    list.writeFloatLE(1.5);
+    list.writeDoubleLE(-2.25);
+
+    const expected = Buffer.alloc(1 + 1 + 2 + 2 + 4 + 4 + 8 + 8 + 4 + 8);
+    let offset = 0;
+    offset = expected.writeUInt8(0xFF, offset);
+    offset = expected.writeInt8(-1, offset);
+    offset = expected.writeUInt16LE(0x1234, offset);
+    offset = expected.writeInt16LE(-2, offset);
+    offset = expected.writeUInt32LE(0xDEADBEEF, offset);
+    offset = expected.writeInt32LE(-3, offset);
+    offset = expected.writeBigUInt64LE(0xFFFFFFFFFFFFFFFFn, offset);
+    offset = expected.writeBigInt64LE(-4n, offset);
+    offset = expected.writeFloatLE(1.5, offset);
+    expected.writeDoubleLE(-2.25, offset);
+
+    assert.deepEqual(list.slice(), expected);
+    assert.strictEqual(list.length, expected.length);
+  });
+
+  it('keeps writes contiguous across chunk boundaries', function() {
+    const list = new WritableTrackingBuffer();
+    // Fill up to just below the first chunk boundary, then write a value
+    // that does not fit into the remaining space.
+    list.append(Buffer.alloc(1023, 0x00));
+    list.writeUInt32LE(0x01020304);
+
+    const data = list.slice();
+    assert.strictEqual(data.readUInt32LE(1023), 0x01020304);
+    for (const buffer of list.getBuffers()) {
+      assert.isAtMost(buffer.length, CHUNK_SIZE);
+    }
+  });
+
+  it('consumes bytes from the front', function() {
+    const list = new WritableTrackingBuffer();
+    list.append(Buffer.from([1, 2, 3, 4, 5]));
+
+    const before = list.getBuffers();
+    list.consume(2);
+    assert.strictEqual(list.length, 3);
+    assert.deepEqual(list.slice(), Buffer.from([3, 4, 5]));
+
+    // a previously returned list of buffers is unaffected
+    assert.deepEqual(before, [Buffer.from([1, 2, 3, 4, 5])]);
+
+    list.consume(3);
+    assert.strictEqual(list.length, 0);
+    assert.deepEqual(list.getBuffers(), []);
+
+    list.append(Buffer.from([6]));
+    assert.deepEqual(list.slice(), Buffer.from([6]));
+  });
+
+  it('consumes across chunks', function() {
+    const list = new WritableTrackingBuffer();
+    const large = Buffer.alloc(CHUNK_SIZE, 0x42);
+    list.append(Buffer.from([1, 2]));
+    list.append(large);
+    list.append(Buffer.from([3]));
+
+    list.consume(2 + CHUNK_SIZE - 1);
+    assert.strictEqual(list.length, 2);
+    assert.deepEqual(list.slice(), Buffer.from([0x42, 3]));
+  });
+
+  it('slices ranges', function() {
+    const list = new WritableTrackingBuffer();
+    list.append(Buffer.from([1, 2, 3]));
+    list.append(Buffer.alloc(CHUNK_SIZE, 4));
+    list.append(Buffer.from([5, 6]));
+
+    assert.deepEqual(list.slice(1, 3), Buffer.from([2, 3]));
+    assert.deepEqual(list.slice(2, 5), Buffer.from([3, 4, 4]));
+    assert.deepEqual(list.slice(CHUNK_SIZE + 2), Buffer.from([4, 5, 6]));
   });
 });

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -1,4 +1,6 @@
-import WritableTrackingBuffer, { CHUNK_SIZE, type Encoding } from '../../../src/tracking-buffer/writable-tracking-buffer';
+import WritableTrackingBuffer, { type Encoding } from '../../../src/tracking-buffer/writable-tracking-buffer';
+
+const { CHUNK_SIZE } = WritableTrackingBuffer;
 import { assert } from 'chai';
 
 function assertBuffer(actual: WritableTrackingBuffer, expected: number[]): void {

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -155,7 +155,7 @@ describe('Writable Tracking Buffer', () => {
 
     const first = buffer.data;
     buffer.writeUInt8(3);
-    buffer.append(Buffer.alloc(CHUNK_SIZE, 4));
+    buffer.writeBuffer(Buffer.alloc(CHUNK_SIZE, 4));
     buffer.writeUInt8(5);
 
     assert.deepEqual(first, Buffer.from([1, 2]));
@@ -164,11 +164,12 @@ describe('Writable Tracking Buffer', () => {
     assert.strictEqual(buffer.data[3 + CHUNK_SIZE], 5);
   });
 
-  it('coalesces small appended buffers into a single chunk', () => {
+  it('coalesces small buffers into a single chunk', () => {
     const buffer = new WritableTrackingBuffer();
-    buffer.append(Buffer.from([1, 2]));
-    buffer.append(Buffer.from([3]));
-    buffer.append([Buffer.from([4]), Buffer.from([5, 6])]);
+    buffer.writeBuffer(Buffer.from([1, 2]));
+    buffer.writeBuffer(Buffer.from([3]));
+    buffer.writeBuffer(Buffer.from([4]));
+    buffer.writeBuffer(Buffer.from([5, 6]));
 
     assert.strictEqual(buffer.length, 6);
     const buffers = buffer.getBuffers();
@@ -179,9 +180,9 @@ describe('Writable Tracking Buffer', () => {
   it('references large buffers instead of copying them', () => {
     const buffer = new WritableTrackingBuffer();
     const large = Buffer.alloc(CHUNK_SIZE, 0x42);
-    buffer.append(Buffer.from([1]));
-    buffer.append(large);
-    buffer.append(Buffer.from([2]));
+    buffer.writeBuffer(Buffer.from([1]));
+    buffer.writeBuffer(large);
+    buffer.writeBuffer(Buffer.from([2]));
 
     const buffers = buffer.getBuffers();
     assert.lengthOf(buffers, 3);
@@ -195,7 +196,7 @@ describe('Writable Tracking Buffer', () => {
     const buffer = new WritableTrackingBuffer();
     const piece = Buffer.alloc(1000, 0x01);
     for (let i = 0; i < 100; i++) {
-      buffer.append(piece);
+      buffer.writeBuffer(piece);
     }
 
     const buffers = buffer.getBuffers();
@@ -208,9 +209,9 @@ describe('Writable Tracking Buffer', () => {
 
   it('encodes strings', () => {
     const buffer = new WritableTrackingBuffer();
-    buffer.append('héllo 🎉', 'ucs2');
-    buffer.append('héllo 🎉', 'utf8');
-    buffer.append('x'.repeat(100), 'ucs2');
+    buffer.writeString('héllo 🎉', 'ucs2');
+    buffer.writeString('héllo 🎉', 'utf8');
+    buffer.writeString('x'.repeat(100), 'ucs2');
 
     const expected = Buffer.concat([
       Buffer.from('héllo 🎉', 'ucs2'),
@@ -255,7 +256,7 @@ describe('Writable Tracking Buffer', () => {
     const buffer = new WritableTrackingBuffer();
     // Fill up to just below the first chunk boundary, then write a value
     // that does not fit into the remaining space.
-    buffer.append(Buffer.alloc(1023, 0x00));
+    buffer.writeBuffer(Buffer.alloc(1023, 0x00));
     buffer.writeUInt32LE(0x01020304);
 
     const data = buffer.slice();
@@ -267,7 +268,7 @@ describe('Writable Tracking Buffer', () => {
 
   it('consumes bytes from the front', () => {
     const buffer = new WritableTrackingBuffer();
-    buffer.append(Buffer.from([1, 2, 3, 4, 5]));
+    buffer.writeBuffer(Buffer.from([1, 2, 3, 4, 5]));
 
     const before = buffer.getBuffers();
     buffer.consume(2);
@@ -281,16 +282,16 @@ describe('Writable Tracking Buffer', () => {
     assert.strictEqual(buffer.length, 0);
     assert.deepEqual(buffer.getBuffers(), []);
 
-    buffer.append(Buffer.from([6]));
+    buffer.writeBuffer(Buffer.from([6]));
     assert.deepEqual(buffer.slice(), Buffer.from([6]));
   });
 
   it('consumes across chunks', () => {
     const buffer = new WritableTrackingBuffer();
     const large = Buffer.alloc(CHUNK_SIZE, 0x42);
-    buffer.append(Buffer.from([1, 2]));
-    buffer.append(large);
-    buffer.append(Buffer.from([3]));
+    buffer.writeBuffer(Buffer.from([1, 2]));
+    buffer.writeBuffer(large);
+    buffer.writeBuffer(Buffer.from([3]));
 
     buffer.consume(2 + CHUNK_SIZE - 1);
     assert.strictEqual(buffer.length, 2);

--- a/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
+++ b/test/unit/tracking-buffer/writable-tracking-buffer-test.ts
@@ -152,14 +152,21 @@ describe('Writable Tracking Buffer', () => {
     const buffer = new WritableTrackingBuffer();
     buffer.writeUInt8(1);
 
+    // A single chunk: `data` is a view of the chunk's own memory.
     const view = buffer.data;
     const [chunk] = buffer.getBuffers();
     assert.strictEqual(view.buffer, chunk.buffer);
     assert.strictEqual(view.byteOffset, chunk.byteOffset);
 
+    // Several chunks: `data` is a fresh copy, so modifying it does not
+    // affect the list. (Whether the copy shares an `ArrayBuffer` with a
+    // chunk is up to Node's allocation pool, so that is not asserted.)
     buffer.writeBuffer(Buffer.alloc(CHUNK_SIZE, 2));
-    assert.notStrictEqual(buffer.data, buffer.data);
-    assert.notStrictEqual(buffer.data.buffer, chunk.buffer);
+    const copy = buffer.data;
+    assert.notStrictEqual(copy, buffer.data);
+    copy[0] = 99;
+    assert.strictEqual(buffer.data[0], 1);
+    assert.strictEqual(chunk[0], 1);
   });
 
   it('returns stable data across later writes', () => {


### PR DESCRIPTION
## Problem

`WritableTrackingBuffer` grows by concatenating everything written so far into a composite buffer on every growth step, and `data` returns that composite. Every growth is a full copy of the data written so far, `Buffer.alloc` zero-fills each new chunk, and callers work around it by computing exact sizes up front (e.g. the RPC payload computes the byte length of each parameter name purely to size a buffer for it). `writeBuffer` always copies, so a large value written through it costs its full size again.

This is the first of a series of changes to the parameter serialization path (a resolve/write type contract and streaming table-valued parameters follow), all of which write into a shared buffer and depend on it not copying on growth.

## Change

`WritableTrackingBuffer` is now a write-side buffer list:

- Bytes are written into an open chunk of at most 8 KB (`WritableTrackingBuffer.CHUNK_SIZE`). The first chunk is 64 bytes and each sealed chunk is followed by one twice its size, up to the cap; a single write larger than the open chunk gets a chunk of exactly its size. When a write does not fit, the open chunk is sealed into a list and a new one started. There is no concatenation on growth.
- Buffers of 8 KB or more passed to `writeBuffer` are referenced rather than copied, so large values cost no extra memory. (Such buffers must not be modified until consumed.)
- Strings are encoded in place into the open chunk with `buffer.write`, as before; there is no intermediate `Buffer.from`.
- The consumer side mirrors `bl`'s `BufferList`: `length`, `getBuffers`, `consume`, `slice`. `data` stays for the existing callers and is a view rather than a copy when everything fits into a single chunk. The returned buffer must not be modified; the one caller that did (see ALL_HEADERS below) is rewritten.

Cleanups that go with the new storage model:

- **No constructor arguments.** The initial size was a hint that cannot be wrong under the chunk model and measurably does not matter (256 B to 8 KB starting chunks are within run-to-run noise); the growth flag is meaningless without growth-by-concatenation. The size computations at the call sites are removed.
- **No instance-level default encoding.** `writeString`, `writeBVarchar` and `writeUsVarchar` take the encoding explicitly. Three call sites in `src` relied on the default, all `ucs2`: the RPC procedure name, the RPC parameter names, and the TVP TYPE_INFO. The constructor encodings in the transaction payloads (three `ascii`, one `ucs2`) were dead, since every string written there passes `ucs2` explicitly. The test call sites now pass what their constructor used to.
- **Unused methods removed.** `writePLPBody` and `writeMoney` had no callers (PLP framing lives in the types, `money.ts` has its own serializer). `writeUsVarbyte` has no callers in `src` and its only test callers pass a `Buffer`, so its string branch and encoding parameter are gone. `copyFrom` is replaced by `writeBuffer`.
- The `buffer`, `position`, `compositeBuffer`, `makeRoomFor` and `newBuffer` internals are gone. Nothing outside the class used them (the NTLM payload reset `position` to zero immediately after construction, a no-op).
- **ALL_HEADERS length.** `writeToTrackingBuffer` patched the TotalLength in place through `data`, relying on it being a live view of the composite. It also wrote the length of *everything* in the buffer, which only equalled the headers' length because the buffer happened to be fresh. It now writes the constant length up front: 4 (TotalLength) + 18 (the transaction descriptor header), per [MS-TDS] s2.2.5.3.

The class is not exported from `src/tedious.ts`. It is reachable by deep-importing `tedious/lib/tracking-buffer/writable-tracking-buffer`, since `package.json` has no `exports` map; anyone doing that sees the constructor and method signature changes.

## Measurements

Against tedious 20.0.0 on the same machine. New benchmark `benchmarks/tracking-buffer/writable-tracking-buffer.js` (a `WritableTrackingBuffer` built from `pieces` groups of small fixed-width writes, a short UCS-2 string and a 16 byte buffer, then read through `data`; it exercises the coalescing path, not pass-through):

| pieces | 20.0.0 (ops/s) | this PR (ops/s) |
|---|---|---|
| 10 | ~85-93k | ~260-290k |
| 100 | ~23k | ~42-45k |
| 1000 | ~3.5k | ~4.6-4.8k |

RPC request serialization (consuming `RpcRequestPayload` for one request; the payload builds a small tracking buffer per parameter and, for several types, per value):

| request | 20.0.0 (req/s) | this PR (req/s) |
|---|---|---|
| 20 params: Int, NVarChar, VarBinary, DateTime, Decimal | ~11.4-12.7k | ~16.6-17.8k |
| 20 params: BigInt, DateTime2, Time, DateTimeOffset, UniqueIdentifier | ~9.5-10.1k | ~14.5k |
| 1 param: 10 MB varbinary(max) (`benchmarks/request/rpcrequest-payload-varbinary.js n=200`) | ~7.4-9.6k | ~9.8-10.1k |

The second table is why the first chunk starts at 64 bytes and `data` returns a view for single-chunk contents: with a 1 KB first chunk and a copying `data`, the many tiny per-value buffers made request serialization ~15% *slower* than 20.0.0 despite the class being 2-3x faster in isolation.

End to end (bulk load, TVP call, varbinary insert against SQL Server 2022) is unchanged within noise; the server round-trip dominates there.

## Validation

- Every payload builder that uses the class (RPC requests across 29 parameter types, SQL batch, the four transaction payloads, PRELOGIN, NTLM, bulk load COLMETADATA and DONE, TVP TYPE_INFO) was built on the base and on this branch with pinned randomness and timestamps and compared byte for byte: identical.
- The class was differentially fuzzed against the previous implementation (3,000 random write sequences across every method).
- Unit suite (457 tests, including tests for coalescing, the chunk size bound, pass-through by identity at the 8 KB threshold and copying below it, string encoding against `Buffer.from` including surrogates and strings larger than the open chunk, `data` being a view of a single chunk and a copy of several, fixed-width writes across chunk boundaries, `consume` and `slice`).
- Full integration suite against SQL Server 2022, all passing except a pre-existing environment-only failure (`should not leave any dangling sockets after connection timeout`).
- Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxv5h4UMCGJEpjgCKcAxug