### PR TITLE
fix: surface token parse failures as request errors

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1821,6 +1821,13 @@ class Connection extends EventEmitter {
     };
 
     this._onSocketError = (error) => {
+      // Nothing left to route once the connection is closed: `Final` has no
+      // `socketError` handler, and the error would only surface as noise
+      // after `close()`. (Mirrors `socketEnd()`.)
+      if (this.state === this.STATE.FINAL) {
+        return;
+      }
+
       this.dispatchEvent('socketError', error);
       process.nextTick(() => {
         this.emit('error', this.wrapSocketError(error));
@@ -3494,8 +3501,14 @@ class Connection extends EventEmitter {
 
       const handler = new Login7TokenHandler(this);
       const tokenStreamParser = this.createTokenStreamParser(message, handler);
+      // If the abort wins this race, the pending `once()` is left
+      // unobserved, and a parse error landing afterwards would reject it
+      // with nobody listening. Observe it so that cannot become an
+      // unhandled rejection (same idiom as `withAbortRace`).
+      const endOfMessage = once(tokenStreamParser, 'end');
+      endOfMessage.catch(() => {});
       await Promise.race([
-        once(tokenStreamParser, 'end'),
+        endOfMessage,
         signalAborted
       ]);
 
@@ -3524,8 +3537,14 @@ class Connection extends EventEmitter {
 
         const handler = new Login7TokenHandler(this);
         const tokenStreamParser = this.createTokenStreamParser(message, handler);
+        // If the abort wins this race, the pending `once()` is left
+        // unobserved, and a parse error landing afterwards would reject it
+        // with nobody listening. Observe it so that cannot become an
+        // unhandled rejection (same idiom as `withAbortRace`).
+        const endOfMessage = once(tokenStreamParser, 'end');
+        endOfMessage.catch(() => {});
         await Promise.race([
-          once(tokenStreamParser, 'end'),
+          endOfMessage,
           signalAborted
         ]);
 
@@ -3570,8 +3589,14 @@ class Connection extends EventEmitter {
 
       const handler = new Login7TokenHandler(this);
       const tokenStreamParser = this.createTokenStreamParser(message, handler);
+      // If the abort wins this race, the pending `once()` is left
+      // unobserved, and a parse error landing afterwards would reject it
+      // with nobody listening. Observe it so that cannot become an
+      // unhandled rejection (same idiom as `withAbortRace`).
+      const endOfMessage = once(tokenStreamParser, 'end');
+      endOfMessage.catch(() => {});
       await Promise.race([
-        once(tokenStreamParser, 'end'),
+        endOfMessage,
         signalAborted
       ]);
 
@@ -3668,8 +3693,14 @@ class Connection extends EventEmitter {
       ]);
 
       const tokenStreamParser = this.createTokenStreamParser(message, new InitialSqlTokenHandler(this));
+      // If the abort wins this race, the pending `once()` is left
+      // unobserved, and a parse error landing afterwards would reject it
+      // with nobody listening. Observe it so that cannot become an
+      // unhandled rejection (same idiom as `withAbortRace`).
+      const endOfMessage = once(tokenStreamParser, 'end');
+      endOfMessage.catch(() => {});
       await Promise.race([
-        once(tokenStreamParser, 'end'),
+        endOfMessage,
         signalAborted
       ]);
     });
@@ -3744,10 +3775,7 @@ Connection.prototype.STATE = {
         try {
           message = await this.messageIo.readMessage();
         } catch (err: any) {
-          this.dispatchEvent('socketError', err);
-          process.nextTick(() => {
-            this.emit('error', this.wrapSocketError(err));
-          });
+          this._onSocketError(err);
           return;
         }
         // request timer is stopped on first data package
@@ -3761,10 +3789,16 @@ Connection.prototype.STATE = {
         // here, a parse failure would surface as an unhandled `'error'`
         // event on the parser's internal stream and crash the process.
         const onParserError = (err: Error) => {
-          this.dispatchEvent('socketError', err);
-          process.nextTick(() => {
-            this.emit('error', this.wrapSocketError(err));
-          });
+          // The request is about to fail through the socket error path, so
+          // detach its listeners first: a late `cancel()` must not write an
+          // attention packet to the destroyed socket. (On the canceled-drain
+          // path below these were never attached, and removal is a no-op.)
+          this.request?.removeListener('cancel', this._cancelAfterRequestSent);
+          this.request?.removeListener('cancel', onCancel);
+          this.request?.removeListener('pause', onPause);
+          this.request?.removeListener('resume', onResume);
+
+          this._onSocketError(err);
         };
         tokenStreamParser.on('error', onParserError);
 
@@ -3880,17 +3914,23 @@ Connection.prototype.STATE = {
         try {
           message = await this.messageIo.readMessage();
         } catch (err: any) {
-          this.dispatchEvent('socketError', err);
-          process.nextTick(() => {
-            this.emit('error', this.wrapSocketError(err));
-          });
+          this._onSocketError(err);
           return;
         }
 
         const handler = new AttentionTokenHandler(this, this.request!);
         const tokenStreamParser = this.createTokenStreamParser(message, handler);
 
-        await once(tokenStreamParser, 'end');
+        try {
+          await once(tokenStreamParser, 'end');
+        } catch (err: any) {
+          // A token parse failure in the attention response rejects the
+          // `once()`. Treat it like a socket error - the request fails with
+          // the parse error and the connection is closed - instead of the
+          // process dying on an unhandled rejection.
+          this._onSocketError(err);
+          return;
+        }
         // 3.2.5.7 Sent Attention State
         // Discard any data contained in the response, until we receive the attention response
         if (handler.attentionReceived) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3755,6 +3755,19 @@ Connection.prototype.STATE = {
 
         const tokenStreamParser = this.createTokenStreamParser(message, new RequestTokenHandler(this, this.request!));
 
+        // A token parse failure leaves the connection at an undefined
+        // position in the TDS stream, so it cannot be recovered at the
+        // request level — treat it like a socket error. Without a listener
+        // here, a parse failure would surface as an unhandled `'error'`
+        // event on the parser's internal stream and crash the process.
+        const onParserError = (err: Error) => {
+          this.dispatchEvent('socketError', err);
+          process.nextTick(() => {
+            this.emit('error', this.wrapSocketError(err));
+          });
+        };
+        tokenStreamParser.on('error', onParserError);
+
         // If the request was canceled after the request message was
         // fully sent off, an attention message was sent to the server.
         //
@@ -3809,6 +3822,8 @@ Connection.prototype.STATE = {
         };
 
         const onEndOfMessage = () => {
+          tokenStreamParser.removeListener('error', onParserError);
+
           this.request?.removeListener('cancel', this._cancelAfterRequestSent);
           this.request?.removeListener('cancel', onCancel);
           this.request?.removeListener('pause', onPause);

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -30,6 +30,10 @@ export class Parser extends EventEmitter {
     this.parser.on('end', () => {
       this.emit('end');
     });
+
+    this.parser.on('error', (error: Error) => {
+      this.emit('error', error);
+    });
   }
 
   declare on: (

--- a/test/unit/connection-parse-error-test.ts
+++ b/test/unit/connection-parse-error-test.ts
@@ -1,0 +1,167 @@
+import { assert } from 'chai';
+import * as net from 'net';
+import { Connection, Request } from '../../src/tedious';
+import IncomingMessageStream from '../../src/incoming-message-stream';
+import OutgoingMessageStream from '../../src/outgoing-message-stream';
+import Debug from '../../src/debug';
+import PreloginPayload from '../../src/prelogin-payload';
+import Message from '../../src/message';
+
+function buildLoginAckToken(): Buffer {
+  const progname = 'Tedious SQL Server';
+
+  const buffer = Buffer.from([
+    0xAD, // Type
+    0x00, 0x00, // Length
+    0x00, // interface number - SQL
+    0x74, 0x00, 0x00, 0x04, // TDS version number
+    Buffer.byteLength(progname, 'ucs2') / 2, ...Buffer.from(progname, 'ucs2'), // Progname
+    0x00, // major
+    0x00, // minor
+    0x00, 0x00, // buildNum
+  ]);
+
+  buffer.writeUInt16LE(buffer.length - 3, 1);
+
+  return buffer;
+}
+
+/**
+ * Builds a final `DONE` token.
+ */
+function buildDoneToken(): Buffer {
+  const buffer = Buffer.alloc(13);
+
+  let offset = 0;
+  offset = buffer.writeUInt8(0xFD, offset); // DONE
+  offset = buffer.writeUInt16LE(0x0000, offset); // status = DONE_FINAL
+  offset = buffer.writeUInt16LE(0x0000, offset); // curCmd
+  buffer.writeBigUInt64LE(0n, offset); // rowCount
+
+  return buffer;
+}
+
+/**
+ * Reads and discards all data of the given message.
+ */
+async function drainMessage(message: Message): Promise<void> {
+  const iterator = message[Symbol.asyncIterator]();
+  while (!(await iterator.next()).done) {
+    // Discard the data.
+  }
+}
+
+describe('A token parse failure in a response', function() {
+  let server: net.Server;
+  let _connections: net.Socket[];
+
+  beforeEach(function(done) {
+    _connections = [];
+    server = net.createServer((connection) => {
+      _connections.push(connection);
+    });
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function(done) {
+    _connections.forEach((connection) => {
+      connection.destroy();
+    });
+
+    server.close(done);
+  });
+
+  it('fails the request instead of raising an unhandled stream error', function(done) {
+    server.on('connection', async (connection) => {
+      const debug = new Debug();
+      const incomingMessageStream = new IncomingMessageStream(debug);
+      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+      connection.pipe(incomingMessageStream);
+      outgoingMessageStream.pipe(connection);
+
+      try {
+        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+        // PRELOGIN
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x12);
+
+          await drainMessage(message);
+
+          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+          const responseMessage = new Message({ type: 0x12 });
+          responseMessage.end(responsePayload.data);
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // LOGIN7
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x10);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (Initial SQL)
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end();
+          outgoingMessageStream.write(responseMessage);
+        }
+
+        // SQL Batch (`select 1`) - respond with an invalid token: 0x00 is
+        // not a valid token type, so parsing this response throws inside
+        // the token parser.
+        {
+          const { value: message } = await messageIterator.next();
+          assert.strictEqual(message.type, 0x01);
+
+          await drainMessage(message);
+
+          const responseMessage = new Message({ type: 0x04 });
+          responseMessage.end(Buffer.from([0x00]));
+          outgoingMessageStream.write(responseMessage);
+        }
+      } catch (err: any) {
+        done(err);
+      }
+    });
+
+    const connection = new Connection({
+      server: (server.address() as net.AddressInfo).address,
+      options: {
+        port: (server.address() as net.AddressInfo).port,
+        encrypt: false
+      }
+    });
+
+    connection.on('error', () => {
+      // The parse failure is also surfaced as a connection error.
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, Error);
+        assert.match((err as Error).message, /Unknown type/);
+
+        connection.close();
+        done();
+      });
+
+      connection.execSqlBatch(request);
+    });
+  });
+});

--- a/test/unit/connection-parse-error-test.ts
+++ b/test/unit/connection-parse-error-test.ts
@@ -42,6 +42,33 @@ function buildDoneToken(): Buffer {
 }
 
 /**
+ * Builds an `INFO` token, as a server sends for e.g. a `PRINT` statement.
+ */
+function buildInfoToken(): Buffer {
+  const message = 'hello';
+  const messageData = Buffer.from(message, 'ucs2');
+
+  const data = Buffer.alloc(4 + 1 + 1 + 2 + messageData.length + 1 + 1 + 4);
+
+  let offset = 0;
+  offset = data.writeUInt32LE(50000, offset); // number
+  offset = data.writeUInt8(1, offset); // state
+  offset = data.writeUInt8(0, offset); // class - informational
+  offset = data.writeUInt16LE(message.length, offset); // message length (in characters)
+  offset += messageData.copy(data, offset); // message
+  offset = data.writeUInt8(0, offset); // server name length
+  offset = data.writeUInt8(0, offset); // proc name length
+  data.writeUInt32LE(0, offset); // line number (TDS 7.2+)
+
+  const buffer = Buffer.alloc(3 + data.length);
+  buffer.writeUInt8(0xAB, 0); // INFO
+  buffer.writeUInt16LE(data.length, 1); // token length
+  data.copy(buffer, 3);
+
+  return buffer;
+}
+
+/**
  * Reads and discards all data of the given message.
  */
 async function drainMessage(message: Message): Promise<void> {
@@ -49,6 +76,91 @@ async function drainMessage(message: Message): Promise<void> {
   while (!(await iterator.next()).done) {
     // Discard the data.
   }
+}
+
+interface ScriptedExchange {
+  messageIterator: AsyncIterator<Message>;
+  outgoingMessageStream: OutgoingMessageStream;
+}
+
+/**
+ * Serves the prelogin / login / initial SQL exchange, then hands control to
+ * `onRequest` once the first request message (the one under test) has been
+ * read and drained.
+ */
+function serveUntilRequest(server: net.Server, onRequest: (exchange: ScriptedExchange) => Promise<void> | void, onError: (err: Error) => void) {
+  server.on('connection', async (connection) => {
+    const debug = new Debug();
+    const incomingMessageStream = new IncomingMessageStream(debug);
+    const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
+
+    connection.pipe(incomingMessageStream);
+    outgoingMessageStream.pipe(connection);
+
+    try {
+      const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
+
+      // PRELOGIN
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x12);
+
+        await drainMessage(message);
+
+        const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
+        const responseMessage = new Message({ type: 0x12 });
+        responseMessage.end(responsePayload.data);
+        outgoingMessageStream.write(responseMessage);
+      }
+
+      // LOGIN7
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x10);
+
+        await drainMessage(message);
+
+        const responseMessage = new Message({ type: 0x04 });
+        responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
+        outgoingMessageStream.write(responseMessage);
+      }
+
+      // SQL Batch (Initial SQL)
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x01);
+
+        await drainMessage(message);
+
+        const responseMessage = new Message({ type: 0x04 });
+        responseMessage.end();
+        outgoingMessageStream.write(responseMessage);
+      }
+
+      // SQL Batch (the request under test)
+      {
+        const { value: message } = await messageIterator.next();
+        assert.strictEqual(message.type, 0x01);
+
+        await drainMessage(message);
+
+        await onRequest({ messageIterator, outgoingMessageStream });
+      }
+    } catch (err: any) {
+      onError(err);
+    }
+  });
+}
+
+/**
+ * Responds to the request under test with a message whose payload ends in
+ * `0x00`, which is not a valid token type - parsing it throws inside the
+ * token parser.
+ */
+function respondWithInvalidToken({ outgoingMessageStream }: ScriptedExchange, prefix: Buffer = Buffer.alloc(0)) {
+  const responseMessage = new Message({ type: 0x04 });
+  responseMessage.end(Buffer.concat([prefix, Buffer.from([0x00])]));
+  outgoingMessageStream.write(responseMessage);
 }
 
 describe('A token parse failure in a response', function() {
@@ -71,80 +183,23 @@ describe('A token parse failure in a response', function() {
     server.close(done);
   });
 
-  it('fails the request instead of raising an unhandled stream error', function(done) {
-    server.on('connection', async (connection) => {
-      const debug = new Debug();
-      const incomingMessageStream = new IncomingMessageStream(debug);
-      const outgoingMessageStream = new OutgoingMessageStream(debug, { packetSize: 4 * 1024 });
-
-      connection.pipe(incomingMessageStream);
-      outgoingMessageStream.pipe(connection);
-
-      try {
-        const messageIterator = incomingMessageStream[Symbol.asyncIterator]();
-
-        // PRELOGIN
-        {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x12);
-
-          await drainMessage(message);
-
-          const responsePayload = new PreloginPayload({ encrypt: false, version: { major: 1, minor: 2, build: 3, subbuild: 0 } });
-          const responseMessage = new Message({ type: 0x12 });
-          responseMessage.end(responsePayload.data);
-          outgoingMessageStream.write(responseMessage);
-        }
-
-        // LOGIN7
-        {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x10);
-
-          await drainMessage(message);
-
-          const responseMessage = new Message({ type: 0x04 });
-          responseMessage.end(Buffer.concat([buildLoginAckToken(), buildDoneToken()]));
-          outgoingMessageStream.write(responseMessage);
-        }
-
-        // SQL Batch (Initial SQL)
-        {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x01);
-
-          await drainMessage(message);
-
-          const responseMessage = new Message({ type: 0x04 });
-          responseMessage.end();
-          outgoingMessageStream.write(responseMessage);
-        }
-
-        // SQL Batch (`select 1`) - respond with an invalid token: 0x00 is
-        // not a valid token type, so parsing this response throws inside
-        // the token parser.
-        {
-          const { value: message } = await messageIterator.next();
-          assert.strictEqual(message.type, 0x01);
-
-          await drainMessage(message);
-
-          const responseMessage = new Message({ type: 0x04 });
-          responseMessage.end(Buffer.from([0x00]));
-          outgoingMessageStream.write(responseMessage);
-        }
-      } catch (err: any) {
-        done(err);
-      }
-    });
-
-    const connection = new Connection({
+  function createConnection(options: Record<string, unknown> = {}) {
+    return new Connection({
       server: (server.address() as net.AddressInfo).address,
       options: {
         port: (server.address() as net.AddressInfo).port,
-        encrypt: false
+        encrypt: false,
+        ...options
       }
     });
+  }
+
+  it('fails the request instead of raising an unhandled stream error', function(done) {
+    serveUntilRequest(server, (exchange) => {
+      respondWithInvalidToken(exchange);
+    }, done);
+
+    const connection = createConnection();
 
     connection.on('error', () => {
       // The parse failure is also surfaced as a connection error.
@@ -162,6 +217,137 @@ describe('A token parse failure in a response', function() {
       });
 
       connection.execSqlBatch(request);
+    });
+  });
+
+  it('stays silent when the connection was closed from a token handler while malformed bytes were still buffered', function(done) {
+    // A valid `INFO` token followed by the invalid one: the user closes the
+    // connection from the `infoMessage` handler, so the parse failure lands
+    // after the connection has already reached `Final`.
+    serveUntilRequest(server, (exchange) => {
+      respondWithInvalidToken(exchange, buildInfoToken());
+    }, done);
+
+    const connection = createConnection();
+
+    const connectionErrors: Error[] = [];
+    connection.on('error', (err) => {
+      connectionErrors.push(err);
+    });
+
+    connection.on('infoMessage', () => {
+      connection.close();
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      let callbackCount = 0;
+      const request = new Request('select 1', (err) => {
+        callbackCount += 1;
+        assert.instanceOf(err, Error);
+        assert.strictEqual((err as any).code, 'ECLOSE');
+
+        // Give the buffered parse failure time to be processed.
+        setTimeout(() => {
+          assert.strictEqual(callbackCount, 1);
+          assert.deepEqual(connectionErrors, [], 'nothing should be emitted after close()');
+          done();
+        }, 100);
+      });
+
+      connection.execSqlBatch(request);
+    });
+  });
+
+  it('leaves the failed request without listeners, so a late cancel() is harmless', function(done) {
+    serveUntilRequest(server, (exchange) => {
+      respondWithInvalidToken(exchange);
+    }, done);
+
+    // A short cancel timeout: before the fix, the late `cancel()` below armed
+    // this timer on the already-closed connection, and its expiry dispatched
+    // `socketError` in `Final` (the "No event ... in state 'Final'" error).
+    const connection = createConnection({ cancelTimeout: 50 });
+
+    const connectionErrors: Error[] = [];
+    connection.on('error', (err) => {
+      connectionErrors.push(err);
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, Error);
+        assert.match((err as Error).message, /Unknown type/);
+
+        // A user-side timeout racing the failure: must not write an attention
+        // packet to the destroyed socket nor arm a cancel timer on it.
+        request.cancel();
+
+        // Wait past `cancelTimeout` so a wrongly armed timer would have fired.
+        setTimeout(() => {
+          // Exactly the one wrapped parse error, nothing from the cancel.
+          assert.lengthOf(connectionErrors, 1);
+          assert.match(connectionErrors[0].message, /Unknown type/);
+          done();
+        }, 250);
+      });
+
+      connection.execSqlBatch(request);
+    });
+  });
+
+  it('fails a canceled request whose attention acknowledgement is malformed', function(done) {
+    let signalRequestReceived!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      signalRequestReceived = resolve;
+    });
+
+    serveUntilRequest(server, async ({ messageIterator, outgoingMessageStream }) => {
+      // No response before the attention message arrives.
+      signalRequestReceived();
+
+      // ATTENTION
+      const { value: message } = await messageIterator.next();
+      assert.strictEqual(message.type, 0x06);
+
+      await drainMessage(message);
+
+      // The response to the canceled request, then a malformed
+      // acknowledgement message.
+      const responseMessage = new Message({ type: 0x04 });
+      responseMessage.end(buildDoneToken());
+      outgoingMessageStream.write(responseMessage);
+
+      const ackMessage = new Message({ type: 0x04 });
+      ackMessage.end(Buffer.from([0x00]));
+      outgoingMessageStream.write(ackMessage);
+    }, done);
+
+    const connection = createConnection({ cancelTimeout: 0 });
+
+    connection.on('error', () => {
+      // The parse failure is also surfaced as a connection error.
+    });
+
+    connection.connect((err) => {
+      assert.isUndefined(err);
+
+      const request = new Request('select 1', (err) => {
+        assert.instanceOf(err, Error);
+        assert.match((err as Error).message, /Unknown type/);
+
+        connection.close();
+        done();
+      });
+
+      connection.execSqlBatch(request);
+
+      requestReceived.then(() => {
+        request.cancel();
+      });
     });
   });
 });


### PR DESCRIPTION
Split out of #1765 per the sequencing discussed there — this is the part accepted as a pure bugfix.

The token parser's internal stream (`Readable.from(StreamParser.parseTokens(...))`) has no `'error'` listener, so a parse failure inside a response surfaces as an unhandled `'error'` event and crashes the process instead of failing the request.

This PR re-emits stream errors from `Parser`, and routes them in `SentClientRequest` through the existing socket-error path: the active request fails with the parse error and the connection is closed — a parse failure leaves the connection at an undefined position in the TDS stream, so it cannot be recovered at the request level. The listener is removed at end-of-message; during a canceled response's drain it stays attached, so a parse failure there is still surfaced.

Complements #1759, which fixed the same unhandled-`'error'` hole for the login path.

Test: `connection-parse-error-test.ts` — a scripted server answers a SQL batch with an invalid token type (`0x00`). On current master the test dies with an uncaught `Unknown type: 0` stream error; with this fix the request errors and the process stays alive. Full unit suite and lint pass.

The inactivity-timer half of #1765 will follow separately, targeted at v21 on top of the `AbortSignal` work, per the maintainer's sequencing.
