### PR TITLE
perf: serialize an RPC request into one buffer

### DIFF
--- a/src/rpcrequest-payload.ts
+++ b/src/rpcrequest-payload.ts
@@ -37,7 +37,12 @@ class RpcRequestPayload implements Iterable<Buffer> {
   }
 
   * generateData() {
+    // The whole request is written into one buffer and its chunks are handed
+    // out together: a large value written by reference stays by reference, so
+    // this costs no extra copy, and the request reaches the packetizer as a
+    // few large chunks rather than a small buffer per parameter.
     const buffer = new WritableTrackingBuffer();
+
     if (this.options.tdsVersion >= '7_2') {
       const outstandingRequestCount = 1;
       writeToTrackingBuffer(buffer, this.txnDescriptor, outstandingRequestCount);
@@ -52,21 +57,20 @@ class RpcRequestPayload implements Iterable<Buffer> {
 
     const optionFlags = 0;
     buffer.writeUInt16LE(optionFlags);
-    yield buffer.data;
 
     const parametersLength = this.parameters.length;
     for (let i = 0; i < parametersLength; i++) {
-      yield * this.generateParameterData(this.parameters[i]);
+      this.writeParameterData(buffer, this.parameters[i]);
     }
+
+    yield * buffer.getBuffers();
   }
 
   toString(indent = '') {
     return indent + ('RPC Request - ' + this.procedure);
   }
 
-  * generateParameterData(parameter: ResolvedParameter) {
-    const buffer = new WritableTrackingBuffer();
-
+  writeParameterData(buffer: WritableTrackingBuffer, parameter: ResolvedParameter) {
     if (parameter.name) {
       buffer.writeBVarchar('@' + parameter.name, 'ucs2');
     } else {
@@ -85,10 +89,6 @@ class RpcRequestPayload implements Iterable<Buffer> {
     } catch (error) {
       throw new InputError(`Input parameter '${parameter.name}' could not be validated`, { cause: error });
     }
-
-    // Large values are referenced by the buffer rather than copied; handing
-    // out its chunks keeps them that way.
-    yield * buffer.getBuffers();
   }
 }
 


### PR DESCRIPTION
## Problem

`RpcRequestPayload` writes a small `WritableTrackingBuffer` per parameter and yields each one in turn: a 20-parameter request reaches the packetizer as ~21 separate buffers. Each buffer and each yield is overhead, and downstream `Readable.from(payload)` does a pull cycle per chunk.

## Change

The payload now writes the whole request — the request header, and every parameter's header, TYPE_INFO and value — into a **single** `WritableTrackingBuffer`, and yields its chunks once at the end.

The bytes are unchanged. A large value written by reference is still referenced, not copied: `WritableTrackingBuffer` keeps buffers of 8 KB or more as their own chunks, so `getBuffers()` still hands the value out as a distinct by-reference chunk. So this adds no copy — the request just arrives as a few large chunks instead of a small buffer per parameter. Per-parameter error attribution is unchanged: each parameter's `writeTypeInfo`/`writeValue` is still wrapped in the `InputError` that names it.

## Measurements

Serialization only, same machine, `benchmarks/parameters/scalar-params.js` (20 scalar parameters per request):

| | before | after |
|---|---|---|
| 20 scalar params, req/s | ~48k | ~74–91k |
| 1 MB varbinary(max), req/s | ~11.3k | ~11.2k |
| 10 MB varbinary(max), req/s | ~7.6k | ~7.9k |

About 1.7x for scalar-heavy requests; binary values, dominated by the value itself, are unchanged.

## Validation

- The existing byte-equivalence suite (`test/unit/rpcrequest-payload-test.ts`: 40 parameter cases across TDS 7.4/7.2, with/without collation) and the large-value by-reference test cover this unchanged.
- Unit suite: 498 passing. Parameterised-statement (140), RPC (33) and TVP (2) integration tests pass against SQL Server 2022.
- Lint and typecheck clean.

Stacked on #1774; retargets to `master` once that merges. It also sets up the streaming-parameter work to follow: the payload becomes the one place that decides how a request is written out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxv5h4UMCGJEpjgCKcAxug

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fxv5h4UMCGJEpjgCKcAxug)_