### PR TITLE
perf: serialize bulk load rows with an async generator, coalesced into packet-sized chunks

### DIFF
--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,15 +1,7 @@
+import { EventEmitter } from 'events';
 import BulkLoad, { type Row } from './bulk-load';
 
-interface EventSource {
-  on(event: 'error', listener: (err: Error) => void): unknown;
-  removeListener(event: 'error', listener: (err: Error) => void): unknown;
-}
-
 function ignoreError() {}
-
-function isEventSource(value: unknown): value is EventSource {
-  return typeof (value as Partial<EventSource>).on === 'function' && typeof (value as Partial<EventSource>).removeListener === 'function';
-}
 
 export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare bulkLoad: BulkLoad;
@@ -24,7 +16,7 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
   /**
    * The row source, while the payload's own `'error'` listener is on it.
    */
-  declare guarded: EventSource | undefined;
+  declare guarded: EventEmitter | undefined;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
@@ -45,8 +37,9 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // With a listener in place the stream keeps the error, and iterating
     // it later rejects with it, so it still reaches the bulk load's
     // callback. The listener comes off again once the rows have been
-    // read, or the payload is closed unread.
-    if (isEventSource(rows)) {
+    // read, or the payload is closed unread. Only a real emitter is
+    // guarded, not anything with a method that happens to be called `on`.
+    if (rows instanceof EventEmitter) {
       this.guarded = rows;
       rows.on('error', ignoreError);
     } else {

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,14 +1,12 @@
 import { EventEmitter } from 'events';
 import BulkLoad, { type Row, type RowSource } from './bulk-load';
 import { RequestError } from './errors';
+import { isPromiseLike } from './promise-like';
 
-// Kept local: `bulk-load.ts` ends with a `module.exports` assignment for
-// its default export, which leaves it no named runtime exports.
+// `bulk-load.ts` has one too, and cannot share it: it ends with a
+// `module.exports` assignment for its default export, which leaves it no
+// named runtime exports.
 function ignoreError() {}
-
-function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
-  return value != null && typeof (value as PromiseLike<T>).then === 'function';
-}
 
 /**
  * Swallows what `emitter` emits as `'error'` until `closing` settles: the
@@ -197,9 +195,20 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
 
   /**
    * Releases the row source of a payload whose rows were never read: the
-   * `INSERT BULK` statement was rejected, or the bulk load was canceled
-   * before its request message was sent. A payload that is being read
-   * closes the source itself when it stops.
+   * `INSERT BULK` statement was rejected, the bulk load was canceled
+   * before its request message was sent, or the connection is no longer
+   * logged in. A payload that is being read closes the source itself
+   * when it stops.
+   *
+   * In order: the payload lets go of the bulk load (`release`) and of
+   * the source (`unguard`), so that nothing of it is retained from here
+   * on; the source's iterator is returned; a stream source is destroyed.
+   * Each of the two releases that may still be running gets a standalone
+   * `'error'` listener on the source for as long as it runs, the
+   * iterator's until its `return()` settles, the stream's until its
+   * destruction has finished, and the source is unguarded once both are
+   * gone. Everything is best effort: a source that fails while being
+   * released has nothing to report it to, the bulk load already failed.
    */
   close() {
     if (this.started) {
@@ -208,8 +217,6 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     this.started = true;
     this.release();
 
-    // Closing is best effort: a source that fails while being released
-    // has nothing to report it to, the bulk load already failed.
     let closing: Promise<unknown> | undefined;
     if (typeof this.source.return === 'function') {
       try {

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -50,7 +50,8 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
   }
 
   /**
-   * Runs until the generator has been pulled.
+   * Marks the payload as started the moment it is first pulled, before
+   * any row is read, then hands over to `serializeRows`.
    */
   async *serialize() {
     this.started = true;
@@ -83,10 +84,16 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
 
     this.unguard();
 
+    // Closing is best effort: a source that fails while being released
+    // has nothing to report it to, the bulk load already failed.
     if (typeof this.source.return === 'function') {
-      const closing = this.source.return();
-      if (closing && typeof (closing as PromiseLike<unknown>).then === 'function') {
-        (closing as PromiseLike<unknown>).then(undefined, ignoreError);
+      try {
+        const closing = this.source.return();
+        if (closing && typeof (closing as PromiseLike<unknown>).then === 'function') {
+          (closing as PromiseLike<unknown>).then(undefined, ignoreError);
+        }
+      } catch {
+        // A synchronous source's `finally` threw.
       }
     }
 

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -257,9 +257,10 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // destruction has finished, since its `_destroy` may report an error
     // later, asynchronously: on `'close'`, on that `'error'`, right away
     // when `destroy` itself throws, or right away when the destruction
-    // has already finished cleanly (Node's default `_destroy` completes
-    // synchronously), which is the only signal from a stream created
-    // with `emitClose: false`.
+    // has already finished (Node's default `_destroy` completes
+    // synchronously; a stream that failed earlier emits nothing more),
+    // which is the only signal from a stream created with
+    // `emitClose: false`.
     const stream = this.rows as { destroy?: () => void, closed?: boolean, errored?: Error | null };
     if (typeof stream.destroy === 'function') {
       const destroyed = () => {
@@ -281,8 +282,15 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
         return;
       }
 
-      if (stream.closed === true && stream.errored == null) {
-        destroyed();
+      if (stream.closed === true) {
+        if (stream.errored == null) {
+          destroyed();
+        } else {
+          // Destroyed with an error before this, on this very tick or
+          // long ago: its `'error'` is either about to be emitted or was
+          // emitted already, so the guard is kept for one more turn.
+          setImmediate(destroyed);
+        }
       }
     }
   }

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { Stream } from 'stream';
 import BulkLoad, { type Row, type RowSource } from './bulk-load';
 import { RequestError } from './errors';
 import { isPromiseLike } from './promise-like';
@@ -252,17 +253,19 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // iterator is returned, in the first `next()`), so the stream itself
     // is destroyed to release what it holds open. The unit test that
     // closes a `Readable` unread pins this against a change in Node. Only
-    // an emitter is taken for a stream, and its `destroy` is as best
-    // effort as the `return` above. A guard stays on until its
-    // destruction has finished, since its `_destroy` may report an error
-    // later, asynchronously: on `'close'`, on that `'error'`, right away
-    // when `destroy` itself throws, or right away when the destruction
-    // has already finished (Node's default `_destroy` completes
+    // a Node stream is destroyed: its destruction ends with a signal,
+    // where another emitter's `destroy` could finish silently and keep
+    // the guard on for good. Its `destroy` is as best effort as the
+    // `return` above. A guard stays on until the destruction has
+    // finished, since its `_destroy` may report an error later,
+    // asynchronously: on `'close'`, on that `'error'`, right away when
+    // `destroy` itself throws, or right away when the destruction has
+    // already finished (Node's default `_destroy` completes
     // synchronously; a stream that failed earlier emits nothing more),
     // which is the only signal from a stream created with
     // `emitClose: false`.
     const stream = this.rows as { destroy?: () => void, closed?: boolean, errored?: Error | null };
-    if (typeof stream.destroy === 'function') {
+    if (this.rows instanceof Stream && typeof stream.destroy === 'function') {
       const destroyed = () => {
         emitter.removeListener('close', destroyed);
         emitter.removeListener('error', destroyed);

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -264,8 +264,7 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // synchronously; a stream that failed earlier emits nothing more),
     // which is the only signal from a stream created with
     // `emitClose: false`.
-    type Destroy = (this: unknown, err: Error | null, callback: (err?: Error | null) => void) => void;
-    const stream = this.rows as { destroy?: () => void, _destroy?: Destroy, closed?: boolean, errored?: Error | null };
+    const stream = this.rows as { destroy?: (err?: Error, callback?: (err?: Error | null) => void) => void, destroyed?: boolean, closed?: boolean, errored?: Error | null };
     if (this.rows instanceof Stream && typeof stream.destroy === 'function') {
       const destroyed = () => {
         emitter.removeListener('close', destroyed);
@@ -279,33 +278,26 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       emitter.on('close', destroyed);
       emitter.on('error', destroyed);
 
-      // `destroy` runs the stream's `_destroy`, and once that has called
-      // back emits `'error'` and `'close'` on the next tick, or nothing
-      // at all for a stream created with `emitClose: false` whose
-      // `_destroy` succeeds. That callback is the one signal every stream
-      // gives, so it is watched for the length of this `destroy` call
-      // (which is when Node takes `_destroy` up), and the listeners come
-      // off a turn after it, once anything the stream emits about the
-      // destruction has been emitted.
-      const original = stream._destroy;
-      if (typeof original === 'function') {
-        stream._destroy = function(err, callback) {
-          original.call(this, err, (error) => {
-            callback(error);
-            setImmediate(destroyed);
-          });
-        };
-      }
-
+      // `destroy` runs the stream's `_destroy` (once the stream is
+      // constructed, if it is not yet), and once that has called back
+      // emits `'error'` and `'close'` on the next tick, or nothing at all
+      // for a stream created with `emitClose: false` whose `_destroy`
+      // succeeds. That callback is the one signal every stream gives.
+      // Node's `destroy` takes a callback of its own that it runs right
+      // after it, so that is what is passed, and the listeners come off a
+      // turn later, once anything the stream emits about the destruction
+      // has been emitted. A stream destroyed before would run the callback
+      // at once, while its destruction may still be going on, so it gets
+      // none and is waited for through its events, as below.
       try {
-        stream.destroy();
+        if (stream.destroyed === true) {
+          stream.destroy();
+        } else {
+          stream.destroy(undefined, () => { setImmediate(destroyed); });
+        }
       } catch {
         destroyed();
         return;
-      } finally {
-        if (typeof original === 'function') {
-          stream._destroy = original;
-        }
       }
 
       // A stream destroyed before this does not run `_destroy` again.

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -17,6 +17,11 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
    * The row source, while the payload's own `'error'` listener is on it.
    */
   declare guarded: EventEmitter | undefined;
+  /**
+   * The first error the guarded source emitted.
+   */
+  declare sourceError: Error | undefined;
+  declare onSourceError: (err: Error) => void;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
@@ -34,14 +39,20 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // error handling only once it is iterated, which does not happen
     // before the `INSERT BULK` statement has been accepted. An `'error'`
     // it emits in the meantime would be unhandled and crash the process.
-    // With a listener in place the stream keeps the error, and iterating
-    // it later rejects with it, so it still reaches the bulk load's
-    // callback. The listener comes off again once the rows have been
-    // read, or the payload is closed unread. Only a real emitter is
-    // guarded, not anything with a method that happens to be called `on`.
+    // With a listener in place a `Readable` keeps the error and iterating
+    // it later rejects with it; an emitter that does not replay it through
+    // its iterator gets it surfaced by `serialize` instead, so either way
+    // it reaches the bulk load's callback. The listener comes off again
+    // once the rows have been read, or the payload is closed unread. Only
+    // a real emitter is guarded, not anything with a method that happens
+    // to be called `on`.
+    this.sourceError = undefined;
+    this.onSourceError = (err) => {
+      this.sourceError ??= err;
+    };
     if (rows instanceof EventEmitter) {
       this.guarded = rows;
-      rows.on('error', ignoreError);
+      rows.on('error', this.onSourceError);
     } else {
       this.guarded = undefined;
     }
@@ -57,7 +68,19 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     this.started = true;
 
     try {
-      yield* this.bulkLoad.serializeRows(this.source);
+      for await (const chunk of this.bulkLoad.serializeRows(this.source)) {
+        // An error the source emitted without failing its iterator ends
+        // the bulk load before another chunk goes out.
+        if (this.sourceError !== undefined) {
+          throw this.sourceError;
+        }
+
+        yield chunk;
+      }
+
+      if (this.sourceError !== undefined) {
+        throw this.sourceError;
+      }
     } finally {
       this.unguard();
     }
@@ -65,7 +88,7 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
 
   unguard() {
     if (this.guarded) {
-      this.guarded.removeListener('error', ignoreError);
+      this.guarded.removeListener('error', this.onSourceError);
       this.guarded = undefined;
     }
   }

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from 'events';
 import BulkLoad, { type Row, type RowSource } from './bulk-load';
 import { RequestError } from './errors';
 
+// Kept local: `bulk-load.ts` ends with a `module.exports` assignment for
+// its default export, which leaves it no named runtime exports.
 function ignoreError() {}
 
 function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -10,6 +10,19 @@ function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
   return value != null && typeof (value as PromiseLike<T>).then === 'function';
 }
 
+/**
+ * Swallows what `emitter` emits as `'error'` until `closing` settles: the
+ * source is being let go of, and a failure it reports while doing so
+ * has nowhere to go but must not crash the process. The listener holds
+ * on to nothing but the emitter, so a source that never finishes closing
+ * does not keep the bulk load alive through it.
+ */
+function guardWhileClosing(emitter: EventEmitter, closing: Promise<unknown>) {
+  emitter.on('error', ignoreError);
+  const unguard = () => { emitter.removeListener('error', ignoreError); };
+  closing.then(unguard, unguard);
+}
+
 export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare bulkLoad: BulkLoad;
   declare rows: Iterable<Row> | AsyncIterable<Row>;
@@ -152,15 +165,13 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       }
     } finally {
       this.release();
+      this.unguard();
 
-      if (closing === undefined) {
-        this.unguard();
-      } else {
-        // A close that never finishes (an async generator stuck in a
-        // read) keeps the guard on the source; the source is broken by
-        // then, and an error it still emits must not crash the process.
-        const unguard = () => { this.unguard(); };
-        closing.then(unguard, unguard);
+      // A close still running (or one that never finishes: an async
+      // generator stuck in a read) keeps a guard on the source, one that
+      // does not hold on to the payload.
+      if (closing !== undefined && this.rows instanceof EventEmitter) {
+        guardWhileClosing(this.rows, closing);
       }
     }
   }
@@ -212,21 +223,17 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       return;
     }
 
-    // The error guard stays on an emitter until everything that releases
-    // it has finished: an asynchronous `return()` may emit `'error'` on
-    // a later tick while letting go of a cursor or a file, and so may a
-    // stream's `_destroy`. `pending` counts what is still to finish.
+    // From here on nothing holds on to the payload: its own guard comes
+    // off, and what stays on the emitter while it finishes closing is a
+    // listener that knows only the emitter. An application that keeps a
+    // destroyed stream around must not keep the rows through it.
     const emitter = this.rows;
-    let pending = 0;
-    const done = () => {
-      if (--pending === 0) {
-        this.unguard();
-      }
-    };
+    this.unguard();
 
+    // An asynchronous `return()` may emit `'error'` on a later tick while
+    // letting go of a cursor or a file.
     if (closing !== undefined) {
-      pending++;
-      closing.then(done, done);
+      guardWhileClosing(emitter, closing);
     }
 
     // A stream's iterator only takes effect once it has been pulled (a
@@ -235,19 +242,21 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // is destroyed to release what it holds open. The unit test that
     // closes a `Readable` unread pins this against a change in Node. Only
     // an emitter is taken for a stream, and its `destroy` is as best
-    // effort as the `return` above. Its destruction is finished on
-    // `'close'`, on the `'error'` a failing `_destroy` reports instead,
-    // or right away when `destroy` itself throws. (A stream that emits
-    // neither, `emitClose: false` and a clean destruction, keeps a
-    // listener; it is dead by then.)
-    const stream = this.rows as { destroy?: () => void };
+    // effort as the `return` above. A guard stays on until its
+    // destruction has finished, since its `_destroy` may report an error
+    // later, asynchronously: on `'close'`, on that `'error'`, right away
+    // when `destroy` itself throws, or right away when the destruction
+    // has already finished cleanly (Node's default `_destroy` completes
+    // synchronously), which is the only signal from a stream created
+    // with `emitClose: false`.
+    const stream = this.rows as { destroy?: () => void, closed?: boolean, errored?: Error | null };
     if (typeof stream.destroy === 'function') {
-      pending++;
       const destroyed = () => {
         emitter.removeListener('close', destroyed);
         emitter.removeListener('error', destroyed);
-        done();
+        emitter.removeListener('error', ignoreError);
       };
+      emitter.on('error', ignoreError);
       emitter.on('close', destroyed);
       emitter.on('error', destroyed);
 
@@ -255,11 +264,12 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
         stream.destroy();
       } catch {
         destroyed();
+        return;
       }
-    }
 
-    if (pending === 0) {
-      this.unguard();
+      if (stream.closed === true && stream.errored == null) {
+        destroyed();
+      }
     }
   }
 

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -160,6 +160,10 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
         yield chunk;
       }
 
+      // An error the source emits after its last row, even once the
+      // final chunk (DONE) is with the consumer, still fails the bulk
+      // load: a source that fails at all fails it, and the message it
+      // ends can still be marked ignored by the server.
       if (this.sourceError !== undefined) {
         throw this.sourceError;
       }
@@ -256,6 +260,9 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
         emitter.removeListener('error', destroyed);
         emitter.removeListener('error', ignoreError);
       };
+      // Its own `ignoreError` next to the one `guardWhileClosing` may
+      // have added: each is taken off once, by its own signal, and the
+      // emitter stays guarded until both are gone.
       emitter.on('error', ignoreError);
       emitter.on('close', destroyed);
       emitter.on('error', destroyed);

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -204,8 +204,11 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       }
     }
 
-    // A stream's iterator only takes effect once it has been pulled, so
-    // the stream itself is destroyed to release what it holds open. Only
+    // A stream's iterator only takes effect once it has been pulled (a
+    // `Readable` sets its iterator up, and destroys the stream when that
+    // iterator is returned, in the first `next()`), so the stream itself
+    // is destroyed to release what it holds open. The unit test that
+    // closes a `Readable` unread pins this against a change in Node. Only
     // an emitter is taken for a stream, and its `destroy` is as best
     // effort as the `return` above. The error guard stays on until the
     // stream has finished destroying itself, since its `_destroy` may

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,13 +1,42 @@
 import BulkLoad, { type Row } from './bulk-load';
 
+interface EventSource {
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  removeListener(event: 'error', listener: (err: Error) => void): unknown;
+}
+
 function ignoreError() {}
+
+function isEventSource(value: unknown): value is EventSource {
+  return typeof (value as Partial<EventSource>).on === 'function' && typeof (value as Partial<EventSource>).removeListener === 'function';
+}
 
 export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare bulkLoad: BulkLoad;
+  declare rows: Iterable<Row> | AsyncIterable<Row>;
+  declare source: Iterator<Row> | AsyncIterator<Row>;
   declare iterator: AsyncGenerator<Buffer, void, undefined>;
+  /**
+   * Whether the rows have started being read, by the consumer or by
+   * `close`. Either one closes the source, once.
+   */
+  declare started: boolean;
+  /**
+   * The row source, while the payload's own `'error'` listener is on it.
+   */
+  declare guarded: EventSource | undefined;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
+    this.rows = rows;
+    this.started = false;
+
+    // Obtaining the iterator reads nothing yet. An object can carry an
+    // `undefined` `Symbol.asyncIterator` property and still be a perfectly
+    // good synchronous iterable.
+    this.source = typeof (rows as Partial<AsyncIterable<Row>>)[Symbol.asyncIterator] === 'function' ?
+      (rows as AsyncIterable<Row>)[Symbol.asyncIterator]() :
+      (rows as Iterable<Row>)[Symbol.iterator]();
 
     // A `Readable` (or another event-emitting source) attaches its own
     // error handling only once it is iterated, which does not happen
@@ -15,14 +44,65 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // it emits in the meantime would be unhandled and crash the process.
     // With a listener in place the stream keeps the error, and iterating
     // it later rejects with it, so it still reaches the bulk load's
-    // callback.
-    const source = rows as { on?: (event: string, listener: () => void) => void };
-    if (typeof source.on === 'function') {
-      source.on('error', ignoreError);
+    // callback. The listener comes off again once the rows have been
+    // read, or the payload is closed unread.
+    if (isEventSource(rows)) {
+      this.guarded = rows;
+      rows.on('error', ignoreError);
+    } else {
+      this.guarded = undefined;
     }
 
-    // The generator does not run, and no row is read, until it is pulled.
-    this.iterator = bulkLoad.serializeRows(rows);
+    this.iterator = this.serialize();
+  }
+
+  /**
+   * Runs until the generator has been pulled.
+   */
+  async *serialize() {
+    this.started = true;
+
+    try {
+      yield* this.bulkLoad.serializeRows(this.source);
+    } finally {
+      this.unguard();
+    }
+  }
+
+  unguard() {
+    if (this.guarded) {
+      this.guarded.removeListener('error', ignoreError);
+      this.guarded = undefined;
+    }
+  }
+
+  /**
+   * Releases the row source of a payload whose rows were never read: the
+   * `INSERT BULK` statement was rejected, or the bulk load was canceled
+   * before its request message was sent. A payload that is being read
+   * closes the source itself when it stops.
+   */
+  close() {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
+    this.unguard();
+
+    if (typeof this.source.return === 'function') {
+      const closing = this.source.return();
+      if (closing && typeof (closing as PromiseLike<unknown>).then === 'function') {
+        (closing as PromiseLike<unknown>).then(undefined, ignoreError);
+      }
+    }
+
+    // A stream's iterator only takes effect once it has been pulled, so
+    // the stream itself is destroyed to release what it holds open.
+    const stream = this.rows as { destroy?: () => void };
+    if (typeof stream.destroy === 'function') {
+      stream.destroy();
+    }
   }
 
   [Symbol.asyncIterator]() {

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,8 +1,12 @@
 import { EventEmitter } from 'events';
-import BulkLoad, { type Row } from './bulk-load';
+import BulkLoad, { type Row, type RowSource } from './bulk-load';
 import { RequestError } from './errors';
 
 function ignoreError() {}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return value != null && typeof (value as PromiseLike<T>).then === 'function';
+}
 
 export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare bulkLoad: BulkLoad;
@@ -97,8 +101,41 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
   async *serialize() {
     this.started = true;
 
+    // `serializeRows` closes the source when it leaves early, without
+    // waiting for it on a failure. The source is watched so that the
+    // error guard can stay on it while an asynchronous close is still
+    // running: an `'error'` the close emits on a later tick would
+    // otherwise be unhandled. `closing` is the close in progress, if any.
+    const source = this.source;
+    let closing: Promise<unknown> | undefined;
+    const watched: RowSource = {
+      next: () => source.next(),
+      return: () => {
+        if (typeof source.return !== 'function') {
+          return undefined;
+        }
+
+        const result = source.return();
+        if (!isPromiseLike(result)) {
+          return result;
+        }
+
+        // Settled into one promise, handed on as such: it may be awaited
+        // and raced by `serializeRows`, and is watched here.
+        const settled = Promise.resolve(result);
+        closing = settled;
+        const done = () => {
+          if (closing === settled) {
+            closing = undefined;
+          }
+        };
+        settled.then(done, done);
+        return settled;
+      }
+    };
+
     try {
-      for await (const chunk of this.bulkLoad.serializeRows(this.source, this.aborted)) {
+      for await (const chunk of this.bulkLoad.serializeRows(watched, this.aborted)) {
         // An error the source emitted without failing its iterator ends
         // the bulk load before another chunk goes out.
         if (this.sourceError !== undefined) {
@@ -113,7 +150,16 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       }
     } finally {
       this.release();
-      this.unguard();
+
+      if (closing === undefined) {
+        this.unguard();
+      } else {
+        // A close that never finishes (an async generator stuck in a
+        // read) keeps the guard on the source; the source is broken by
+        // then, and an error it still emits must not crash the process.
+        const unguard = () => { this.unguard(); };
+        closing.then(unguard, unguard);
+      }
     }
   }
 

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,18 +1,32 @@
-import BulkLoad from './bulk-load';
+import BulkLoad, { type Row } from './bulk-load';
 
-type Row = unknown[] | { [colName: string]: unknown };
+function ignoreError() {}
 
 export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare bulkLoad: BulkLoad;
-  declare rows: Iterable<Row> | AsyncIterable<Row>;
+  declare iterator: AsyncGenerator<Buffer, void, undefined>;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
-    this.rows = rows;
+
+    // A `Readable` (or another event-emitting source) attaches its own
+    // error handling only once it is iterated, which does not happen
+    // before the `INSERT BULK` statement has been accepted. An `'error'`
+    // it emits in the meantime would be unhandled and crash the process.
+    // With a listener in place the stream keeps the error, and iterating
+    // it later rejects with it, so it still reaches the bulk load's
+    // callback.
+    const source = rows as { on?: (event: string, listener: () => void) => void };
+    if (typeof source.on === 'function') {
+      source.on('error', ignoreError);
+    }
+
+    // The generator does not run, and no row is read, until it is pulled.
+    this.iterator = bulkLoad.serializeRows(rows);
   }
 
   [Symbol.asyncIterator]() {
-    return this.bulkLoad.serializeRows(this.rows);
+    return this.iterator;
   }
 
   toString(indent = '') {

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,19 +1,18 @@
 import BulkLoad from './bulk-load';
 
+type Row = unknown[] | { [colName: string]: unknown };
+
 export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare bulkLoad: BulkLoad;
-  declare iterator: AsyncIterableIterator<Buffer>;
+  declare rows: Iterable<Row> | AsyncIterable<Row>;
 
-  constructor(bulkLoad: BulkLoad) {
+  constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
-
-    // We need to grab the iterator here so that `error` event handlers are set up
-    // as early as possible (and are not potentially lost).
-    this.iterator = this.bulkLoad.rowToPacketTransform[Symbol.asyncIterator]();
+    this.rows = rows;
   }
 
   [Symbol.asyncIterator]() {
-    return this.iterator;
+    return this.bulkLoad.serializeRows(this.rows);
   }
 
   toString(indent = '') {

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -23,11 +23,12 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
   declare sourceError: Error | undefined;
   declare onSourceError: (err: Error) => void;
   /**
-   * Rejects with that error, so a row read pending at the time can be
-   * abandoned. Only a guarded source has one.
+   * Rejects once the bulk load must stop reading rows: the source
+   * reported an error out of band, or the bulk load was canceled. A row
+   * read pending at the time is abandoned.
    */
-  declare abort: Promise<never> | undefined;
-  declare failSource: ((err: Error) => void) | undefined;
+  declare aborted: Promise<never>;
+  declare rejectAborted: (err: Error) => void;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
@@ -52,21 +53,20 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // once the rows have been read, or the payload is closed unread. Only
     // a real emitter is guarded, not anything with a method that happens
     // to be called `on`.
+    this.aborted = new Promise<never>((_, reject) => { this.rejectAborted = reject; });
+    // Nobody may be racing against it when it rejects.
+    this.aborted.catch(ignoreError);
+
     this.sourceError = undefined;
     this.onSourceError = (err) => {
       this.sourceError ??= err;
-      this.failSource?.(err);
+      this.rejectAborted(err);
     };
     if (rows instanceof EventEmitter) {
       this.guarded = rows;
-      this.abort = new Promise<never>((_, reject) => { this.failSource = reject; });
-      // Nobody may be racing against it when it rejects.
-      this.abort.catch(ignoreError);
       rows.on('error', this.onSourceError);
     } else {
       this.guarded = undefined;
-      this.abort = undefined;
-      this.failSource = undefined;
     }
 
     this.iterator = this.serialize();
@@ -80,7 +80,7 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     this.started = true;
 
     try {
-      for await (const chunk of this.bulkLoad.serializeRows(this.source, this.abort)) {
+      for await (const chunk of this.bulkLoad.serializeRows(this.source, this.aborted)) {
         // An error the source emitted without failing its iterator ends
         // the bulk load before another chunk goes out.
         if (this.sourceError !== undefined) {
@@ -103,6 +103,18 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       this.guarded.removeListener('error', this.onSourceError);
       this.guarded = undefined;
     }
+  }
+
+  /**
+   * Stops reading rows: a read pending in the payload's generator is
+   * abandoned with `reason`, and the source is closed as on any other
+   * failure. For a bulk load that is canceled while its rows are being
+   * sent; the consumer has stopped pulling by then, so `reason` reaches
+   * nobody, but a source that would otherwise keep a read pending
+   * indefinitely is released.
+   */
+  abort(reason: Error) {
+    this.rejectAborted(reason);
   }
 
   /**
@@ -135,14 +147,25 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // an emitter is taken for a stream, and its `destroy` is as best
     // effort as the `return` above. The error guard stays on until the
     // stream has finished destroying itself, since its `_destroy` may
-    // report an error later, asynchronously; it comes off on `'close'`.
+    // report an error later, asynchronously: it comes off on `'close'`,
+    // on that `'error'`, or right away when `destroy` itself throws. (A
+    // stream that emits neither, `emitClose: false` and a clean
+    // destruction, keeps a listener; it is dead by then.)
     const stream = this.rows as { destroy?: () => void };
     if (this.rows instanceof EventEmitter && typeof stream.destroy === 'function') {
-      this.rows.once('close', () => { this.unguard(); });
+      const emitter = this.rows;
+      const destroyed = () => {
+        emitter.removeListener('close', destroyed);
+        emitter.removeListener('error', destroyed);
+        this.unguard();
+      };
+      emitter.on('close', destroyed);
+      emitter.on('error', destroyed);
+
       try {
         stream.destroy();
       } catch {
-        // Nothing left to report it to.
+        destroyed();
       }
     } else {
       this.unguard();

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -117,8 +117,6 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     }
     this.started = true;
 
-    this.unguard();
-
     // Closing is best effort: a source that fails while being released
     // has nothing to report it to, the bulk load already failed.
     if (typeof this.source.return === 'function') {
@@ -135,14 +133,19 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // A stream's iterator only takes effect once it has been pulled, so
     // the stream itself is destroyed to release what it holds open. Only
     // an emitter is taken for a stream, and its `destroy` is as best
-    // effort as the `return` above.
+    // effort as the `return` above. The error guard stays on until the
+    // stream has finished destroying itself, since its `_destroy` may
+    // report an error later, asynchronously; it comes off on `'close'`.
     const stream = this.rows as { destroy?: () => void };
     if (this.rows instanceof EventEmitter && typeof stream.destroy === 'function') {
+      this.rows.once('close', () => { this.unguard(); });
       try {
         stream.destroy();
       } catch {
         // Nothing left to report it to.
       }
+    } else {
+      this.unguard();
     }
   }
 

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -286,32 +286,36 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       // Node's `destroy` takes a callback of its own that it runs right
       // after it, so that is what is passed, and the listeners come off a
       // turn later, once anything the stream emits about the destruction
-      // has been emitted. A stream destroyed before would run the callback
-      // at once, while its destruction may still be going on, so it gets
-      // none and is waited for through its events, as below.
-      try {
-        if (stream.destroyed === true) {
-          stream.destroy();
-        } else {
+      // has been emitted.
+      if (stream.destroyed !== true) {
+        try {
           stream.destroy(undefined, () => { setImmediate(destroyed); });
+        } catch {
+          destroyed();
         }
-      } catch {
-        destroyed();
         return;
       }
 
-      // A stream destroyed before this does not run `_destroy` again.
-      // Closed already, it emits nothing more, except the `'error'` of a
-      // destruction with an error on this very tick, which is about to
-      // be emitted, so the guard is kept for one more turn then. (Still
-      // closing, it is waited for through its events, as above.)
-      if (stream.closed === true) {
-        if (stream.errored == null) {
-          destroyed();
-        } else {
+      // A stream destroyed before this is not destroyed again: Node
+      // would run the callback at once, while the destruction may still
+      // be going on, and does not run `_destroy` twice. What tells that
+      // it is done is its `closed` flag, set once `_destroy` has called
+      // back, which is looked at until it is set, on a timer that does
+      // not keep the process alive and backs off; the events, when the
+      // stream has them, come sooner. Once closed, the stream emits
+      // nothing more, except the `'error'` of a destruction with an error
+      // on this very tick, which is about to be emitted, so the listeners
+      // come off a turn later either way.
+      let delay = 20;
+      const watch = () => {
+        if (stream.closed === true) {
           setImmediate(destroyed);
+          return;
         }
-      }
+        setTimeout(watch, delay).unref();
+        delay = Math.min(delay * 2, 1000);
+      };
+      watch();
     }
   }
 

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -264,7 +264,8 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // synchronously; a stream that failed earlier emits nothing more),
     // which is the only signal from a stream created with
     // `emitClose: false`.
-    const stream = this.rows as { destroy?: () => void, closed?: boolean, errored?: Error | null };
+    type Destroy = (this: unknown, err: Error | null, callback: (err?: Error | null) => void) => void;
+    const stream = this.rows as { destroy?: () => void, _destroy?: Destroy, closed?: boolean, errored?: Error | null };
     if (this.rows instanceof Stream && typeof stream.destroy === 'function') {
       const destroyed = () => {
         emitter.removeListener('close', destroyed);
@@ -278,20 +279,44 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       emitter.on('close', destroyed);
       emitter.on('error', destroyed);
 
+      // `destroy` runs the stream's `_destroy`, and once that has called
+      // back emits `'error'` and `'close'` on the next tick, or nothing
+      // at all for a stream created with `emitClose: false` whose
+      // `_destroy` succeeds. That callback is the one signal every stream
+      // gives, so it is watched for the length of this `destroy` call
+      // (which is when Node takes `_destroy` up), and the listeners come
+      // off a turn after it, once anything the stream emits about the
+      // destruction has been emitted.
+      const original = stream._destroy;
+      if (typeof original === 'function') {
+        stream._destroy = function(err, callback) {
+          original.call(this, err, (error) => {
+            callback(error);
+            setImmediate(destroyed);
+          });
+        };
+      }
+
       try {
         stream.destroy();
       } catch {
         destroyed();
         return;
+      } finally {
+        if (typeof original === 'function') {
+          stream._destroy = original;
+        }
       }
 
+      // A stream destroyed before this does not run `_destroy` again.
+      // Closed already, it emits nothing more, except the `'error'` of a
+      // destruction with an error on this very tick, which is about to
+      // be emitted, so the guard is kept for one more turn then. (Still
+      // closing, it is waited for through its events, as above.)
       if (stream.closed === true) {
         if (stream.errored == null) {
           destroyed();
         } else {
-          // Destroyed with an error before this, on this very tick or
-          // long ago: its `'error'` is either about to be emitted or was
-          // emitted already, so the guard is kept for one more turn.
           setImmediate(destroyed);
         }
       }

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import BulkLoad, { type Row } from './bulk-load';
+import { RequestError } from './errors';
 
 function ignoreError() {}
 
@@ -29,6 +30,12 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
    */
   declare aborted: Promise<never>;
   declare rejectAborted: (err: Error) => void;
+  /**
+   * On the bulk load until the payload is done with its rows, so that a
+   * completed bulk load an application holds on to does not hold on to
+   * the payload, and with it the rows, through this listener.
+   */
+  declare onCancel: () => void;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
@@ -69,6 +76,17 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       this.guarded = undefined;
     }
 
+    // A cancellation while the rows are being sent stops the payload
+    // stream, but a row read pending inside the payload must be abandoned
+    // as well, or a source that never delivers the row would keep the bulk
+    // load's resources open. The consumer has stopped pulling by then, so
+    // the reason reaches nobody, but the source is closed as on any other
+    // failure.
+    this.onCancel = () => {
+      this.rejectAborted(new RequestError('Canceled.', 'ECANCEL'));
+    };
+    bulkLoad.once('cancel', this.onCancel);
+
     this.iterator = this.serialize();
   }
 
@@ -94,8 +112,17 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
         throw this.sourceError;
       }
     } finally {
+      this.release();
       this.unguard();
     }
+  }
+
+  /**
+   * Takes the payload's listener off the bulk load. The bulk load may be
+   * canceled later, but the payload no longer has a row read to abandon.
+   */
+  release() {
+    this.bulkLoad.removeListener('cancel', this.onCancel);
   }
 
   unguard() {
@@ -103,18 +130,6 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       this.guarded.removeListener('error', this.onSourceError);
       this.guarded = undefined;
     }
-  }
-
-  /**
-   * Stops reading rows: a read pending in the payload's generator is
-   * abandoned with `reason`, and the source is closed as on any other
-   * failure. For a bulk load that is canceled while its rows are being
-   * sent; the consumer has stopped pulling by then, so `reason` reaches
-   * nobody, but a source that would otherwise keep a read pending
-   * indefinitely is released.
-   */
-  abort(reason: Error) {
-    this.rejectAborted(reason);
   }
 
   /**
@@ -128,6 +143,7 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       return;
     }
     this.started = true;
+    this.release();
 
     // Closing is best effort: a source that fails while being released
     // has nothing to report it to, the bulk load already failed.

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -261,7 +261,16 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // `emitClose: false`.
     const stream = this.rows as { destroy?: (err?: Error, callback?: (err?: Error | null) => void) => void, destroyed?: boolean, closed?: boolean, errored?: Error | null };
     if (this.rows instanceof Stream && typeof stream.destroy === 'function') {
+      // Once only: it may be reached both through `destroy`'s callback
+      // and through `'close'`, and a second pass would take off the
+      // `ignoreError` that guards the iterator's own close, if that is
+      // still running.
+      let done = false;
       const destroyed = () => {
+        if (done) {
+          return;
+        }
+        done = true;
         emitter.removeListener('close', destroyed);
         emitter.removeListener('error', destroyed);
         emitter.removeListener('error', ignoreError);

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -2,12 +2,7 @@ import { EventEmitter } from 'events';
 import { Stream } from 'stream';
 import BulkLoad, { type Row, type RowSource } from './bulk-load';
 import { RequestError } from './errors';
-import { isPromiseLike } from './promise-like';
-
-// `bulk-load.ts` has one too, and cannot share it: it ends with a
-// `module.exports` assignment for its default export, which leaves it no
-// named runtime exports.
-function ignoreError() {}
+import { ignoreError, isPromiseLike } from './promise-like';
 
 /**
  * Swallows what `emitter` emits as `'error'` until `closing` settles: the

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -22,6 +22,12 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
    */
   declare sourceError: Error | undefined;
   declare onSourceError: (err: Error) => void;
+  /**
+   * Rejects with that error, so a row read pending at the time can be
+   * abandoned. Only a guarded source has one.
+   */
+  declare abort: Promise<never> | undefined;
+  declare failSource: ((err: Error) => void) | undefined;
 
   constructor(bulkLoad: BulkLoad, rows: Iterable<Row> | AsyncIterable<Row>) {
     this.bulkLoad = bulkLoad;
@@ -49,12 +55,18 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     this.sourceError = undefined;
     this.onSourceError = (err) => {
       this.sourceError ??= err;
+      this.failSource?.(err);
     };
     if (rows instanceof EventEmitter) {
       this.guarded = rows;
+      this.abort = new Promise<never>((_, reject) => { this.failSource = reject; });
+      // Nobody may be racing against it when it rejects.
+      this.abort.catch(ignoreError);
       rows.on('error', this.onSourceError);
     } else {
       this.guarded = undefined;
+      this.abort = undefined;
+      this.failSource = undefined;
     }
 
     this.iterator = this.serialize();
@@ -68,7 +80,7 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     this.started = true;
 
     try {
-      for await (const chunk of this.bulkLoad.serializeRows(this.source)) {
+      for await (const chunk of this.bulkLoad.serializeRows(this.source, this.abort)) {
         // An error the source emitted without failing its iterator ends
         // the bulk load before another chunk goes out.
         if (this.sourceError !== undefined) {
@@ -121,10 +133,16 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     }
 
     // A stream's iterator only takes effect once it has been pulled, so
-    // the stream itself is destroyed to release what it holds open.
+    // the stream itself is destroyed to release what it holds open. Only
+    // an emitter is taken for a stream, and its `destroy` is as best
+    // effort as the `return` above.
     const stream = this.rows as { destroy?: () => void };
-    if (typeof stream.destroy === 'function') {
-      stream.destroy();
+    if (this.rows instanceof EventEmitter && typeof stream.destroy === 'function') {
+      try {
+        stream.destroy();
+      } catch {
+        // Nothing left to report it to.
+      }
     }
   }
 

--- a/src/bulk-load-payload.ts
+++ b/src/bulk-load-payload.ts
@@ -193,15 +193,38 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
 
     // Closing is best effort: a source that fails while being released
     // has nothing to report it to, the bulk load already failed.
+    let closing: Promise<unknown> | undefined;
     if (typeof this.source.return === 'function') {
       try {
-        const closing = this.source.return();
-        if (closing && typeof (closing as PromiseLike<unknown>).then === 'function') {
-          (closing as PromiseLike<unknown>).then(undefined, ignoreError);
+        const result = this.source.return();
+        if (isPromiseLike(result)) {
+          closing = Promise.resolve(result);
+          closing.catch(ignoreError);
         }
       } catch {
         // A synchronous source's `finally` threw.
       }
+    }
+
+    if (!(this.rows instanceof EventEmitter)) {
+      return;
+    }
+
+    // The error guard stays on an emitter until everything that releases
+    // it has finished: an asynchronous `return()` may emit `'error'` on
+    // a later tick while letting go of a cursor or a file, and so may a
+    // stream's `_destroy`. `pending` counts what is still to finish.
+    const emitter = this.rows;
+    let pending = 0;
+    const done = () => {
+      if (--pending === 0) {
+        this.unguard();
+      }
+    };
+
+    if (closing !== undefined) {
+      pending++;
+      closing.then(done, done);
     }
 
     // A stream's iterator only takes effect once it has been pulled (a
@@ -210,19 +233,18 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
     // is destroyed to release what it holds open. The unit test that
     // closes a `Readable` unread pins this against a change in Node. Only
     // an emitter is taken for a stream, and its `destroy` is as best
-    // effort as the `return` above. The error guard stays on until the
-    // stream has finished destroying itself, since its `_destroy` may
-    // report an error later, asynchronously: it comes off on `'close'`,
-    // on that `'error'`, or right away when `destroy` itself throws. (A
-    // stream that emits neither, `emitClose: false` and a clean
-    // destruction, keeps a listener; it is dead by then.)
+    // effort as the `return` above. Its destruction is finished on
+    // `'close'`, on the `'error'` a failing `_destroy` reports instead,
+    // or right away when `destroy` itself throws. (A stream that emits
+    // neither, `emitClose: false` and a clean destruction, keeps a
+    // listener; it is dead by then.)
     const stream = this.rows as { destroy?: () => void };
-    if (this.rows instanceof EventEmitter && typeof stream.destroy === 'function') {
-      const emitter = this.rows;
+    if (typeof stream.destroy === 'function') {
+      pending++;
       const destroyed = () => {
         emitter.removeListener('close', destroyed);
         emitter.removeListener('error', destroyed);
-        this.unguard();
+        done();
       };
       emitter.on('close', destroyed);
       emitter.on('error', destroyed);
@@ -232,7 +254,9 @@ export class BulkLoadPayload implements AsyncIterable<Buffer> {
       } catch {
         destroyed();
       }
-    } else {
+    }
+
+    if (pending === 0) {
       this.unguard();
     }
   }

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -133,7 +133,7 @@ const textPointerAndTimestampBuffer = Buffer.from([
 ]);
 const textPointerNullBuffer = Buffer.from([0x00]);
 
-type Row = unknown[] | { [colName: string]: unknown };
+export type Row = unknown[] | { [colName: string]: unknown };
 
 const IDLE = Symbol('idle');
 
@@ -520,9 +520,11 @@ class BulkLoad extends EventEmitter {
     const options = this.options;
     const columns = this.columns;
 
-    const iterator = Symbol.asyncIterator in rows ?
-      rows[Symbol.asyncIterator]() :
-      rows[Symbol.iterator]();
+    // An object can carry an `undefined` `Symbol.asyncIterator` property
+    // and still be a perfectly good synchronous iterable.
+    const iterator = typeof (rows as Partial<AsyncIterable<Row>>)[Symbol.asyncIterator] === 'function' ?
+      (rows as AsyncIterable<Row>)[Symbol.asyncIterator]() :
+      (rows as Iterable<Row>)[Symbol.iterator]();
 
     // Resolves once the event loop got a turn, i.e. once the row source
     // stopped producing rows back to back (rows arrive through promises and

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -184,10 +184,6 @@ class BulkLoad extends EventEmitter {
   /**
    * @private
    */
-  declare streamingMode: boolean;
-  /**
-   * @private
-   */
   declare table: string;
   /**
    * @private
@@ -290,7 +286,6 @@ class BulkLoad extends EventEmitter {
     this.columns = [];
     this.columnsByName = {};
     this.firstRowWritten = false;
-    this.streamingMode = false;
 
     this.bulkOptions = { checkConstraints, fireTriggers, keepNulls, lockTable, order };
   }

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -137,6 +137,8 @@ export type Row = unknown[] | { [colName: string]: unknown };
 
 const IDLE = Symbol('idle');
 
+function ignoreError() {}
+
 function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
   return value != null && typeof (value as PromiseLike<T>).then === 'function';
 }
@@ -541,9 +543,14 @@ class BulkLoad extends EventEmitter {
         let result: IteratorResult<Row> | Promise<IteratorResult<Row>> = iterator.next();
 
         if (isPromiseLike(result)) {
+          // Settled into one promise up front: a thenable that is not a
+          // native promise may start its work again on every `then`, and
+          // this read can take part in two races.
+          const read = Promise.resolve(result);
+
           idle ??= new Promise((resolve) => { setImmediate(resolve, IDLE); });
 
-          const winner = await Promise.race(abort === undefined ? [result, idle] : [result, idle, abort]);
+          const winner = await Promise.race(abort === undefined ? [read, idle] : [read, idle, abort]);
           if (winner === IDLE) {
             idle = undefined;
 
@@ -554,7 +561,7 @@ class BulkLoad extends EventEmitter {
               buffer.consume(buffer.length);
             }
 
-            result = await (abort === undefined ? result : Promise.race([result, abort]));
+            result = await (abort === undefined ? read : Promise.race([read, abort]));
           } else {
             result = winner;
           }
@@ -618,16 +625,23 @@ class BulkLoad extends EventEmitter {
       // because the bulk load was canceled) closes the source as a
       // `for await` would.
       if (!done && typeof iterator.return === 'function') {
-        try {
-          await iterator.return();
-        } catch (err) {
-          // A source that fails while closing must not hide the row error
-          // that stopped the iteration. Without one (the consumer stopped
-          // pulling), its failure is what the consumer gets.
-          if (!failed) {
-            // eslint-disable-next-line no-unsafe-finally
-            throw err;
+        if (failed) {
+          // Best effort, and not waited for: the failure must reach the
+          // bulk load now, not after the source's cleanup, which may never
+          // finish (an async generator queues `return()` behind a `next()`
+          // that is still pending, which is exactly what an abort leaves
+          // behind). A close failure must not hide the row error either.
+          try {
+            const closing = iterator.return();
+            if (isPromiseLike(closing)) {
+              closing.then(undefined, ignoreError);
+            }
+          } catch {
+            // A synchronous source's `finally` threw.
           }
+        } else {
+          // The consumer stopped pulling; a close failure is what it gets.
+          await iterator.return();
         }
       }
     }

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -527,11 +527,13 @@ class BulkLoad extends EventEmitter {
     // buffered is a no-op.
     let idle: Promise<typeof IDLE> | undefined;
 
-    buffer.writeBuffer(this.getColMetaData());
-
     let done = false;
     let failed = false;
     try {
+      // Inside the `try` so that a column type that fails to write its
+      // TYPE_INFO still closes the source.
+      buffer.writeBuffer(this.getColMetaData());
+
       while (true) {
         let result: IteratorResult<Row> | Promise<IteratorResult<Row>> = iterator.next();
 

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -520,8 +520,11 @@ class BulkLoad extends EventEmitter {
     // stopped producing rows back to back (rows arrive through promises and
     // microtasks, so an immediate only runs when the source is waiting on
     // something). Armed whenever an asynchronous source is awaited and no
-    // immediate is pending; when it fires with nothing buffered, the flush
-    // is a no-op.
+    // immediate is pending. One that fired while no row was being awaited
+    // (the consumer was slow to pull, or the source handed over a row
+    // without a promise) wins the next race outright; that costs one
+    // smaller chunk, never a wrong byte, and a flush with nothing
+    // buffered is a no-op.
     let idle: Promise<typeof IDLE> | undefined;
 
     buffer.writeBuffer(this.getColMetaData());

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -507,11 +507,14 @@ class BulkLoad extends EventEmitter {
    *
    * A row that fails validation or serialization ends the iteration with
    * that error; nothing written for it (or for rows still coalescing with
-   * it) is yielded. The row source is closed either way.
+   * it) is yielded. The row source is closed either way. `abort`, when
+   * given, is raced against every pending row read, so that a source
+   * that signals failure out of band (an `'error'` event) while a read
+   * is pending ends the iteration too instead of hanging it.
    *
    * @private
    */
-  async *serializeRows(iterator: Iterator<Row> | AsyncIterator<Row>): AsyncGenerator<Buffer, void, undefined> {
+  async *serializeRows(iterator: Iterator<Row> | AsyncIterator<Row>, abort?: Promise<never>): AsyncGenerator<Buffer, void, undefined> {
     const buffer = new WritableTrackingBuffer();
     const options = this.options;
     const columns = this.columns;
@@ -540,7 +543,7 @@ class BulkLoad extends EventEmitter {
         if (isPromiseLike(result)) {
           idle ??= new Promise((resolve) => { setImmediate(resolve, IDLE); });
 
-          const winner = await Promise.race([result, idle]);
+          const winner = await Promise.race(abort === undefined ? [result, idle] : [result, idle, abort]);
           if (winner === IDLE) {
             idle = undefined;
 
@@ -551,7 +554,7 @@ class BulkLoad extends EventEmitter {
               buffer.consume(buffer.length);
             }
 
-            result = await result;
+            result = await (abort === undefined ? result : Promise.race([result, abort]));
           } else {
             result = winner;
           }

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -581,23 +581,24 @@ class BulkLoad extends EventEmitter {
             value: value
           };
 
-          if (c.type.name === 'Text' || c.type.name === 'Image' || c.type.name === 'NText') {
-            if (value == null) {
-              buffer.writeBuffer(textPointerNullBuffer);
-              continue;
+          const isTextType = c.type.name === 'Text' || c.type.name === 'Image' || c.type.name === 'NText';
+
+          if (isTextType && value == null) {
+            buffer.writeBuffer(textPointerNullBuffer);
+          } else {
+            if (isTextType) {
+              buffer.writeBuffer(textPointerAndTimestampBuffer);
             }
 
-            buffer.writeBuffer(textPointerAndTimestampBuffer);
+            buffer.writeBuffer(c.type.generateParameterLength(parameter, options));
+            for (const chunk of c.type.generateParameterData(parameter, options)) {
+              buffer.writeBuffer(chunk);
+            }
           }
 
-          buffer.writeBuffer(c.type.generateParameterLength(parameter, options));
-          for (const chunk of c.type.generateParameterData(parameter, options)) {
-            buffer.writeBuffer(chunk);
-          }
-
-          // Checked after every cell, not only after every row, so that a
-          // wide row of large cells goes downstream as it is serialized
-          // rather than accumulating whole.
+          // Checked after every cell (a null text pointer included), not
+          // only after every row, so that a wide row of large cells goes
+          // downstream as it is serialized rather than accumulating whole.
           if (buffer.length >= WritableTrackingBuffer.CHUNK_SIZE) {
             for (const chunk of buffer.getBuffers()) {
               yield chunk;

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -268,7 +268,8 @@ class RowTransform extends Transform {
   }
 
   /**
-   * Hands everything serialized so far downstream.
+   * Hands everything serialized so far downstream. Does nothing when the
+   * buffer is empty.
    *
    * @private
    */

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -152,6 +152,21 @@ class RowTransform extends Transform {
    * @private
    */
   declare columns: BulkLoad['columns'];
+  /**
+   * Rows are serialized into this buffer and handed downstream in
+   * packet-sized chunks, not one chunk per row.
+   *
+   * @private
+   */
+  declare buffer: WritableTrackingBuffer;
+  /**
+   * Whether a flush of `buffer` is already scheduled for when the row
+   * source goes idle. A chunk-sized flush in the meantime does not cancel
+   * it; the scheduled flush then finds an empty buffer and does nothing.
+   *
+   * @private
+   */
+  declare flushScheduled: boolean;
 
   /**
    * @private
@@ -164,18 +179,22 @@ class RowTransform extends Transform {
     this.columns = bulkLoad.columns;
 
     this.columnMetadataWritten = false;
+    this.buffer = new WritableTrackingBuffer();
+    this.flushScheduled = false;
   }
 
   /**
    * @private
    */
   _transform(row: Array<unknown> | { [colName: string]: unknown }, _encoding: string, callback: (error?: Error) => void) {
+    const buffer = this.buffer;
+
     if (!this.columnMetadataWritten) {
-      this.push(this.bulkLoad.getColMetaData());
+      buffer.writeBuffer(this.bulkLoad.getColMetaData());
       this.columnMetadataWritten = true;
     }
 
-    this.push(rowTokenBuffer);
+    buffer.writeBuffer(rowTokenBuffer);
 
     for (let i = 0; i < this.columns.length; i++) {
       const c = this.columns[i];
@@ -198,21 +217,41 @@ class RowTransform extends Transform {
 
       if (c.type.name === 'Text' || c.type.name === 'Image' || c.type.name === 'NText') {
         if (value == null) {
-          this.push(textPointerNullBuffer);
+          buffer.writeBuffer(textPointerNullBuffer);
           continue;
         }
 
-        this.push(textPointerAndTimestampBuffer);
+        buffer.writeBuffer(textPointerAndTimestampBuffer);
       }
 
       try {
-        this.push(c.type.generateParameterLength(parameter, this.mainOptions));
+        buffer.writeBuffer(c.type.generateParameterLength(parameter, this.mainOptions));
         for (const chunk of c.type.generateParameterData(parameter, this.mainOptions)) {
-          this.push(chunk);
+          buffer.writeBuffer(chunk);
         }
       } catch (error: any) {
         return callback(error);
       }
+    }
+
+    if (buffer.length >= WritableTrackingBuffer.CHUNK_SIZE) {
+      this.flushBuffer();
+    } else if (!this.flushScheduled) {
+      // Rows that arrive back to back are coalesced up to a chunk. Rows are
+      // fed through `nextTick` and microtasks, so an immediate only runs
+      // once the row source has gone idle (waiting on something), at which
+      // point holding back what has accumulated would gain nothing.
+      this.flushScheduled = true;
+      setImmediate(() => {
+        this.flushScheduled = false;
+
+        // A row that failed part-way leaves its bytes in the buffer; the
+        // error destroys this stream synchronously, before this runs, so
+        // the check on `destroyed` keeps them from going downstream.
+        if (!this.destroyed && this.buffer.length > 0) {
+          this.flushBuffer();
+        }
+      });
     }
 
     process.nextTick(callback);
@@ -222,9 +261,25 @@ class RowTransform extends Transform {
    * @private
    */
   _flush(callback: () => void) {
-    this.push(this.bulkLoad.createDoneToken());
+    this.buffer.writeBuffer(this.bulkLoad.createDoneToken());
+    this.flushBuffer();
 
     process.nextTick(callback);
+  }
+
+  /**
+   * Hands everything serialized so far downstream.
+   *
+   * @private
+   */
+  flushBuffer() {
+    const buffer = this.buffer;
+
+    for (const chunk of buffer.getBuffers()) {
+      this.push(chunk);
+    }
+
+    buffer.consume(buffer.length);
   }
 }
 

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -136,6 +136,16 @@ const textPointerNullBuffer = Buffer.from([0x00]);
 export type Row = unknown[] | { [colName: string]: unknown };
 
 const IDLE = Symbol('idle');
+const ABORTED = Symbol('aborted');
+
+/**
+ * What `serializeRows` needs of a row source: an iterator's `next`, and
+ * its `return` if it has one.
+ */
+export interface RowSource {
+  next(): IteratorResult<Row> | PromiseLike<IteratorResult<Row>>;
+  return?(): unknown;
+}
 
 function ignoreError() {}
 
@@ -516,11 +526,13 @@ class BulkLoad extends EventEmitter {
    * it) is yielded. The row source is closed either way. `abort`, when
    * given, is raced against every pending row read, so that a source
    * that signals failure out of band (an `'error'` event) while a read
-   * is pending ends the iteration too instead of hanging it.
+   * is pending ends the iteration too instead of hanging it, and a
+   * consumer that stops early does not wait for the source to close once
+   * the bulk load is aborted.
    *
    * @private
    */
-  async *serializeRows(iterator: Iterator<Row> | AsyncIterator<Row>, abort?: Promise<never>): AsyncGenerator<Buffer, void, undefined> {
+  async *serializeRows(iterator: RowSource, abort?: Promise<never>): AsyncGenerator<Buffer, void, undefined> {
     const buffer = new WritableTrackingBuffer();
     const options = this.options;
     const columns = this.columns;
@@ -544,7 +556,7 @@ class BulkLoad extends EventEmitter {
       buffer.writeBuffer(this.getColMetaData());
 
       while (true) {
-        let result: IteratorResult<Row> | Promise<IteratorResult<Row>> = iterator.next();
+        let result: IteratorResult<Row> | PromiseLike<IteratorResult<Row>> = iterator.next();
 
         if (isPromiseLike(result)) {
           // Settled into one promise up front: a thenable that is not a
@@ -645,7 +657,20 @@ class BulkLoad extends EventEmitter {
           }
         } else {
           // The consumer stopped pulling; a close failure is what it gets.
-          await iterator.return();
+          // Unless the bulk load is aborted, now or while the source is
+          // closing: it was canceled while a chunk sat with the consumer,
+          // and its source may be stuck in a read (an async generator
+          // queues `return()` behind it), so the wait could never end.
+          const closing = iterator.return();
+          if (abort === undefined || !isPromiseLike(closing)) {
+            await closing;
+          } else {
+            const settled = Promise.resolve(closing);
+            const winner = await Promise.race([settled, abort.then(undefined, () => ABORTED)]);
+            if (winner === ABORTED) {
+              settled.then(undefined, ignoreError);
+            }
+          }
         }
       }
     }

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -503,9 +503,13 @@ class BulkLoad extends EventEmitter {
    * (`WritableTrackingBuffer.CHUNK_SIZE`), or as soon as an asynchronous
    * row source goes idle. The second rule matters for a source that
    * yields a row and then waits on something: its rows must not be held
-   * back until a chunk has accumulated. Rows from a synchronous source, or
-   * from an asynchronous source that keeps producing, are coalesced up to
-   * a full chunk.
+   * back until a chunk has accumulated. That is a guarantee, not an
+   * optimization: a source may be waiting on the server's reaction to the
+   * rows it has already produced (the cancellation tests do), and would
+   * deadlock with them stuck in the buffer. Rows from a synchronous
+   * source, or from an asynchronous source that keeps producing, are
+   * coalesced up to a full chunk. The unit tests under "row
+   * serialization" pin both rules and the abort race below.
    *
    * A row that fails validation or serialization ends the iteration with
    * that error; nothing written for it (or for rows still coalescing with

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -6,6 +6,7 @@ import { TYPE as TOKEN_TYPE } from './token/token';
 
 import { type DataType, type Parameter } from './data-type';
 import { Collation } from './collation';
+import { isPromiseLike } from './promise-like';
 
 /**
  * @private
@@ -148,10 +149,6 @@ export interface RowSource {
 }
 
 function ignoreError() {}
-
-function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
-  return value != null && typeof (value as PromiseLike<T>).then === 'function';
-}
 
 /**
  * A BulkLoad instance is used to perform a bulk insert.

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -497,8 +497,9 @@ class BulkLoad extends EventEmitter {
   }
 
   /**
-   * Serializes `rows` into the TDS byte stream of this bulk load:
-   * COLMETADATA, a ROW token per row, and a DONE token at the end.
+   * Serializes the rows produced by `iterator` into the TDS byte stream of
+   * this bulk load: COLMETADATA, a ROW token per row, and a DONE token at
+   * the end.
    *
    * Rows are written into one buffer that lives for the whole bulk load.
    * Its contents are yielded once it holds a chunk's worth
@@ -515,16 +516,10 @@ class BulkLoad extends EventEmitter {
    *
    * @private
    */
-  async *serializeRows(rows: Iterable<Row> | AsyncIterable<Row>): AsyncGenerator<Buffer, void, undefined> {
+  async *serializeRows(iterator: Iterator<Row> | AsyncIterator<Row>): AsyncGenerator<Buffer, void, undefined> {
     const buffer = new WritableTrackingBuffer();
     const options = this.options;
     const columns = this.columns;
-
-    // An object can carry an `undefined` `Symbol.asyncIterator` property
-    // and still be a perfectly good synchronous iterable.
-    const iterator = typeof (rows as Partial<AsyncIterable<Row>>)[Symbol.asyncIterator] === 'function' ?
-      (rows as AsyncIterable<Row>)[Symbol.asyncIterator]() :
-      (rows as Iterable<Row>)[Symbol.iterator]();
 
     // Resolves once the event loop got a turn, i.e. once the row source
     // stopped producing rows back to back (rows arrive through promises and
@@ -535,6 +530,7 @@ class BulkLoad extends EventEmitter {
     buffer.writeBuffer(this.getColMetaData());
 
     let done = false;
+    let failed = false;
     try {
       while (true) {
         let result: IteratorResult<Row> | Promise<IteratorResult<Row>> = iterator.next();
@@ -605,12 +601,25 @@ class BulkLoad extends EventEmitter {
           buffer.consume(buffer.length);
         }
       }
+    } catch (err) {
+      failed = true;
+      throw err;
     } finally {
       // Leaving early (a failed row, or the consumer stopped pulling, e.g.
       // because the bulk load was canceled) closes the source as a
       // `for await` would.
       if (!done && typeof iterator.return === 'function') {
-        await iterator.return();
+        try {
+          await iterator.return();
+        } catch (err) {
+          // A source that fails while closing must not hide the row error
+          // that stopped the iteration. Without one (the consumer stopped
+          // pulling), its failure is what the consumer gets.
+          if (!failed) {
+            // eslint-disable-next-line no-unsafe-finally
+            throw err;
+          }
+        }
       }
     }
 

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from 'events';
 import WritableTrackingBuffer from './tracking-buffer/writable-tracking-buffer';
 import Connection, { type InternalConnectionOptions } from './connection';
 
-import { Transform } from 'stream';
 import { TYPE as TOKEN_TYPE } from './token/token';
 
 import { type DataType, type Parameter } from './data-type';
@@ -134,154 +133,12 @@ const textPointerAndTimestampBuffer = Buffer.from([
 ]);
 const textPointerNullBuffer = Buffer.from([0x00]);
 
-// A transform that converts rows to packets.
-class RowTransform extends Transform {
-  /**
-   * @private
-   */
-  declare columnMetadataWritten: boolean;
-  /**
-   * @private
-   */
-  declare bulkLoad: BulkLoad;
-  /**
-   * @private
-   */
-  declare mainOptions: BulkLoad['options'];
-  /**
-   * @private
-   */
-  declare columns: BulkLoad['columns'];
-  /**
-   * Rows are serialized into this buffer and handed downstream in
-   * packet-sized chunks, not one chunk per row.
-   *
-   * @private
-   */
-  declare buffer: WritableTrackingBuffer;
-  /**
-   * Whether a flush of `buffer` is already scheduled for when the row
-   * source goes idle. A chunk-sized flush in the meantime does not cancel
-   * it; the scheduled flush then finds an empty buffer and does nothing.
-   *
-   * @private
-   */
-  declare flushScheduled: boolean;
+type Row = unknown[] | { [colName: string]: unknown };
 
-  /**
-   * @private
-   */
-  constructor(bulkLoad: BulkLoad) {
-    super({ writableObjectMode: true });
+const IDLE = Symbol('idle');
 
-    this.bulkLoad = bulkLoad;
-    this.mainOptions = bulkLoad.options;
-    this.columns = bulkLoad.columns;
-
-    this.columnMetadataWritten = false;
-    this.buffer = new WritableTrackingBuffer();
-    this.flushScheduled = false;
-  }
-
-  /**
-   * @private
-   */
-  _transform(row: Array<unknown> | { [colName: string]: unknown }, _encoding: string, callback: (error?: Error) => void) {
-    const buffer = this.buffer;
-
-    if (!this.columnMetadataWritten) {
-      buffer.writeBuffer(this.bulkLoad.getColMetaData());
-      this.columnMetadataWritten = true;
-    }
-
-    buffer.writeBuffer(rowTokenBuffer);
-
-    for (let i = 0; i < this.columns.length; i++) {
-      const c = this.columns[i];
-      let value = Array.isArray(row) ? row[i] : row[c.objName];
-
-      if (!this.bulkLoad.firstRowWritten) {
-        try {
-          value = c.type.validate(value, c.collation);
-        } catch (error: any) {
-          return callback(error);
-        }
-      }
-
-      const parameter = {
-        length: c.length,
-        scale: c.scale,
-        precision: c.precision,
-        value: value
-      };
-
-      if (c.type.name === 'Text' || c.type.name === 'Image' || c.type.name === 'NText') {
-        if (value == null) {
-          buffer.writeBuffer(textPointerNullBuffer);
-          continue;
-        }
-
-        buffer.writeBuffer(textPointerAndTimestampBuffer);
-      }
-
-      try {
-        buffer.writeBuffer(c.type.generateParameterLength(parameter, this.mainOptions));
-        for (const chunk of c.type.generateParameterData(parameter, this.mainOptions)) {
-          buffer.writeBuffer(chunk);
-        }
-      } catch (error: any) {
-        return callback(error);
-      }
-    }
-
-    if (buffer.length >= WritableTrackingBuffer.CHUNK_SIZE) {
-      this.flushBuffer();
-    } else if (!this.flushScheduled) {
-      // Rows that arrive back to back are coalesced up to a chunk. Rows are
-      // fed through `nextTick` and microtasks, so an immediate only runs
-      // once the row source has gone idle (waiting on something), at which
-      // point holding back what has accumulated would gain nothing.
-      this.flushScheduled = true;
-      setImmediate(() => {
-        this.flushScheduled = false;
-
-        // A row that failed part-way leaves its bytes in the buffer; the
-        // error destroys this stream synchronously, before this runs, so
-        // the check on `destroyed` keeps them from going downstream.
-        if (!this.destroyed && this.buffer.length > 0) {
-          this.flushBuffer();
-        }
-      });
-    }
-
-    process.nextTick(callback);
-  }
-
-  /**
-   * @private
-   */
-  _flush(callback: () => void) {
-    this.buffer.writeBuffer(this.bulkLoad.createDoneToken());
-    this.flushBuffer();
-
-    process.nextTick(callback);
-  }
-
-  /**
-   * Hands everything serialized so far downstream. Does nothing when the
-   * buffer is empty.
-   *
-   * @private
-   */
-  flushBuffer() {
-    const buffer = this.buffer;
-
-    for (const chunk of buffer.getBuffers()) {
-      this.push(chunk);
-    }
-
-    buffer.consume(buffer.length);
-  }
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return value != null && typeof (value as PromiseLike<T>).then === 'function';
 }
 
 /**
@@ -362,11 +219,6 @@ class BulkLoad extends EventEmitter {
   /**
    * @private
    */
-  declare rowToPacketTransform: RowTransform;
-
-  /**
-   * @private
-   */
   declare bulkOptions: InternalOptions;
 
   /**
@@ -439,8 +291,6 @@ class BulkLoad extends EventEmitter {
     this.columnsByName = {};
     this.firstRowWritten = false;
     this.streamingMode = false;
-
-    this.rowToPacketTransform = new RowTransform(this);
 
     this.bulkOptions = { checkConstraints, fireTriggers, keepNulls, lockTable, order };
   }
@@ -644,6 +494,129 @@ class BulkLoad extends EventEmitter {
    */
   setTimeout(timeout?: number) {
     this.timeout = timeout;
+  }
+
+  /**
+   * Serializes `rows` into the TDS byte stream of this bulk load:
+   * COLMETADATA, a ROW token per row, and a DONE token at the end.
+   *
+   * Rows are written into one buffer that lives for the whole bulk load.
+   * Its contents are yielded once it holds a chunk's worth
+   * (`WritableTrackingBuffer.CHUNK_SIZE`), or as soon as an asynchronous
+   * row source goes idle. The second rule matters for a source that
+   * yields a row and then waits on something: its rows must not be held
+   * back until a chunk has accumulated. Rows from a synchronous source, or
+   * from an asynchronous source that keeps producing, are coalesced up to
+   * a full chunk.
+   *
+   * A row that fails validation or serialization ends the iteration with
+   * that error; nothing written for it (or for rows still coalescing with
+   * it) is yielded. The row source is closed either way.
+   *
+   * @private
+   */
+  async *serializeRows(rows: Iterable<Row> | AsyncIterable<Row>): AsyncGenerator<Buffer, void, undefined> {
+    const buffer = new WritableTrackingBuffer();
+    const options = this.options;
+    const columns = this.columns;
+
+    const iterator = Symbol.asyncIterator in rows ?
+      rows[Symbol.asyncIterator]() :
+      rows[Symbol.iterator]();
+
+    // Resolves once the event loop got a turn, i.e. once the row source
+    // stopped producing rows back to back (rows arrive through promises and
+    // microtasks, so an immediate only runs when the source is waiting on
+    // something). Armed while there are unflushed bytes and an async source.
+    let idle: Promise<typeof IDLE> | undefined;
+
+    buffer.writeBuffer(this.getColMetaData());
+
+    let done = false;
+    try {
+      while (true) {
+        let result: IteratorResult<Row> | Promise<IteratorResult<Row>> = iterator.next();
+
+        if (isPromiseLike(result)) {
+          idle ??= new Promise((resolve) => { setImmediate(resolve, IDLE); });
+
+          const winner = await Promise.race([result, idle]);
+          if (winner === IDLE) {
+            idle = undefined;
+
+            if (buffer.length > 0) {
+              for (const chunk of buffer.getBuffers()) {
+                yield chunk;
+              }
+              buffer.consume(buffer.length);
+            }
+
+            result = await result;
+          } else {
+            result = winner;
+          }
+        }
+
+        if (result.done) {
+          done = true;
+          break;
+        }
+
+        const row = result.value;
+
+        buffer.writeBuffer(rowTokenBuffer);
+
+        for (let i = 0; i < columns.length; i++) {
+          const c = columns[i];
+          let value = Array.isArray(row) ? row[i] : row[c.objName];
+
+          if (!this.firstRowWritten) {
+            value = c.type.validate(value, c.collation);
+          }
+
+          const parameter = {
+            length: c.length,
+            scale: c.scale,
+            precision: c.precision,
+            value: value
+          };
+
+          if (c.type.name === 'Text' || c.type.name === 'Image' || c.type.name === 'NText') {
+            if (value == null) {
+              buffer.writeBuffer(textPointerNullBuffer);
+              continue;
+            }
+
+            buffer.writeBuffer(textPointerAndTimestampBuffer);
+          }
+
+          buffer.writeBuffer(c.type.generateParameterLength(parameter, options));
+          for (const chunk of c.type.generateParameterData(parameter, options)) {
+            buffer.writeBuffer(chunk);
+          }
+        }
+
+        if (buffer.length >= WritableTrackingBuffer.CHUNK_SIZE) {
+          for (const chunk of buffer.getBuffers()) {
+            yield chunk;
+          }
+          buffer.consume(buffer.length);
+        }
+      }
+    } finally {
+      // Leaving early (a failed row, or the consumer stopped pulling, e.g.
+      // because the bulk load was canceled) closes the source as a
+      // `for await` would.
+      if (!done && typeof iterator.return === 'function') {
+        await iterator.return();
+      }
+    }
+
+    buffer.writeBuffer(this.createDoneToken());
+    for (const chunk of buffer.getBuffers()) {
+      yield chunk;
+    }
+    buffer.consume(buffer.length);
   }
 
   /**

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -6,7 +6,7 @@ import { TYPE as TOKEN_TYPE } from './token/token';
 
 import { type DataType, type Parameter } from './data-type';
 import { Collation } from './collation';
-import { isPromiseLike } from './promise-like';
+import { ignoreError, isPromiseLike } from './promise-like';
 
 /**
  * @private
@@ -147,8 +147,6 @@ export interface RowSource {
   next(): IteratorResult<Row> | PromiseLike<IteratorResult<Row>>;
   return?(): unknown;
 }
-
-function ignoreError() {}
 
 /**
  * A BulkLoad instance is used to perform a bulk insert.
@@ -658,9 +656,7 @@ class BulkLoad extends EventEmitter {
           // and its source may be stuck in a read (an async generator
           // queues `return()` behind it), so the wait could never end.
           const closing = iterator.return();
-          if (!isPromiseLike(closing)) {
-            await closing;
-          } else {
+          if (isPromiseLike(closing)) {
             const settled = Promise.resolve(closing);
             const winner = await Promise.race([settled, abort.then(undefined, () => ABORTED)]);
             if (winner === ABORTED) {

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -551,44 +551,59 @@ class BulkLoad extends EventEmitter {
 
       while (true) {
         let result: IteratorResult<Row> | PromiseLike<IteratorResult<Row>> = iterator.next();
+        let row: unknown;
 
-        if (isPromiseLike(result)) {
-          // Settled into one promise up front: a thenable that is not a
-          // native promise may start its work again on every `then`, and
-          // this read can take part in two races.
-          const read = Promise.resolve(result);
+        // A read that is pending is waited for; so is a promised row,
+        // the same way, since `Readable.from` settled a promised element
+        // before handing it on and a JavaScript caller may hand over
+        // promises for rows.
+        while (true) {
+          if (isPromiseLike(result)) {
+            // Settled into one promise up front: a thenable that is not a
+            // native promise may start its work again on every `then`,
+            // and this read can take part in two races.
+            const read = Promise.resolve(result);
 
-          idle ??= new Promise((resolve) => { setImmediate(resolve, IDLE); });
+            idle ??= new Promise((resolve) => { setImmediate(resolve, IDLE); });
 
-          const winner = await Promise.race([read, idle, abort]);
-          if (winner === IDLE) {
-            idle = undefined;
+            const winner = await Promise.race([read, idle, abort]);
+            if (winner === IDLE) {
+              idle = undefined;
 
-            if (buffer.length > 0) {
-              for (const chunk of buffer.getBuffers()) {
-                yield chunk;
+              if (buffer.length > 0) {
+                for (const chunk of buffer.getBuffers()) {
+                  yield chunk;
+                }
+                buffer.consume(buffer.length);
               }
-              buffer.consume(buffer.length);
-            }
 
-            result = await Promise.race([read, abort]);
-          } else {
-            result = winner;
+              result = await Promise.race([read, abort]);
+            } else {
+              result = winner;
+            }
           }
+
+          if (result.done) {
+            done = true;
+            break;
+          }
+
+          row = result.value;
+          if (!isPromiseLike(row)) {
+            break;
+          }
+          result = Promise.resolve(row).then((value) => ({ done: false, value: value as Row }));
         }
 
-        if (result.done) {
-          done = true;
+        if (done) {
           break;
         }
-
-        const row = result.value;
 
         buffer.writeBuffer(rowTokenBuffer);
 
         for (let i = 0; i < columns.length; i++) {
           const c = columns[i];
-          let value = Array.isArray(row) ? row[i] : row[c.objName];
+          let value = Array.isArray(row) ? row[i] : (row as { [colName: string]: unknown })[c.objName];
 
           if (!this.firstRowWritten) {
             value = c.type.validate(value, c.collation);

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -519,7 +519,9 @@ class BulkLoad extends EventEmitter {
     // Resolves once the event loop got a turn, i.e. once the row source
     // stopped producing rows back to back (rows arrive through promises and
     // microtasks, so an immediate only runs when the source is waiting on
-    // something). Armed while there are unflushed bytes and an async source.
+    // something). Armed whenever an asynchronous source is awaited and no
+    // immediate is pending; when it fires with nothing buffered, the flush
+    // is a no-op.
     let idle: Promise<typeof IDLE> | undefined;
 
     buffer.writeBuffer(this.getColMetaData());

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -523,16 +523,15 @@ class BulkLoad extends EventEmitter {
    *
    * A row that fails validation or serialization ends the iteration with
    * that error; nothing written for it (or for rows still coalescing with
-   * it) is yielded. The row source is closed either way. `abort`, when
-   * given, is raced against every pending row read, so that a source
-   * that signals failure out of band (an `'error'` event) while a read
-   * is pending ends the iteration too instead of hanging it, and a
-   * consumer that stops early does not wait for the source to close once
-   * the bulk load is aborted.
+   * it) is yielded. The row source is closed either way. `abort` is raced
+   * against every pending row read, so that a source that signals failure
+   * out of band (an `'error'` event) while a read is pending ends the
+   * iteration too instead of hanging it, and a consumer that stops early
+   * does not wait for the source to close once the bulk load is aborted.
    *
    * @private
    */
-  async *serializeRows(iterator: RowSource, abort?: Promise<never>): AsyncGenerator<Buffer, void, undefined> {
+  async *serializeRows(iterator: RowSource, abort: Promise<never>): AsyncGenerator<Buffer, void, undefined> {
     const buffer = new WritableTrackingBuffer();
     const options = this.options;
     const columns = this.columns;
@@ -566,7 +565,7 @@ class BulkLoad extends EventEmitter {
 
           idle ??= new Promise((resolve) => { setImmediate(resolve, IDLE); });
 
-          const winner = await Promise.race(abort === undefined ? [read, idle] : [read, idle, abort]);
+          const winner = await Promise.race([read, idle, abort]);
           if (winner === IDLE) {
             idle = undefined;
 
@@ -577,7 +576,7 @@ class BulkLoad extends EventEmitter {
               buffer.consume(buffer.length);
             }
 
-            result = await (abort === undefined ? read : Promise.race([read, abort]));
+            result = await Promise.race([read, abort]);
           } else {
             result = winner;
           }
@@ -662,7 +661,7 @@ class BulkLoad extends EventEmitter {
           // and its source may be stuck in a read (an async generator
           // queues `return()` behind it), so the wait could never end.
           const closing = iterator.return();
-          if (abort === undefined || !isPromiseLike(closing)) {
+          if (!isPromiseLike(closing)) {
             await closing;
           } else {
             const settled = Promise.resolve(closing);

--- a/src/bulk-load.ts
+++ b/src/bulk-load.ts
@@ -594,13 +594,16 @@ class BulkLoad extends EventEmitter {
           for (const chunk of c.type.generateParameterData(parameter, options)) {
             buffer.writeBuffer(chunk);
           }
-        }
 
-        if (buffer.length >= WritableTrackingBuffer.CHUNK_SIZE) {
-          for (const chunk of buffer.getBuffers()) {
-            yield chunk;
+          // Checked after every cell, not only after every row, so that a
+          // wide row of large cells goes downstream as it is serialized
+          // rather than accumulating whole.
+          if (buffer.length >= WritableTrackingBuffer.CHUNK_SIZE) {
+            for (const chunk of buffer.getBuffers()) {
+              yield chunk;
+            }
+            buffer.consume(buffer.length);
           }
-          buffer.consume(buffer.length);
         }
       }
     } catch (err) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -17,7 +17,7 @@ import {
 } from '@azure/identity';
 import { type AccessToken, type TokenCredential, isTokenCredential } from '@azure/core-auth';
 
-import BulkLoad, { type Options as BulkLoadOptions, type Callback as BulkLoadCallback } from './bulk-load';
+import BulkLoad, { type Options as BulkLoadOptions, type Callback as BulkLoadCallback, type Row as BulkLoadRow } from './bulk-load';
 import Debug from './debug';
 import { EventEmitter, once } from 'events';
 import { instanceLookup } from './instance-lookup';
@@ -2819,9 +2819,9 @@ class Connection extends EventEmitter {
    * @param bulkLoad A previously created [[BulkLoad]].
    * @param rows A [[Iterable]] or [[AsyncIterable]] that contains the rows that should be bulk loaded.
    */
-  execBulkLoad(bulkLoad: BulkLoad, rows: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>): void
+  execBulkLoad(bulkLoad: BulkLoad, rows: AsyncIterable<BulkLoadRow> | Iterable<BulkLoadRow>): void
 
-  execBulkLoad(bulkLoad: BulkLoad, rows?: AsyncIterable<unknown[] | { [columnName: string]: unknown }> | Iterable<unknown[] | { [columnName: string]: unknown }>) {
+  execBulkLoad(bulkLoad: BulkLoad, rows?: AsyncIterable<BulkLoadRow> | Iterable<BulkLoadRow>) {
     bulkLoad.executionStarted = true;
 
     if (rows) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2861,6 +2861,10 @@ class Connection extends EventEmitter {
       this.makeRequest(bulkLoad, TYPE.BULK_LOAD, payload);
     });
 
+    // Cancels the `INSERT BULK` statement while it is in flight. The
+    // payload has its own listener, from its creation until its rows have
+    // been read, to abandon a row read that is pending when the bulk load
+    // is canceled while the rows are being sent.
     bulkLoad.once('cancel', onCancel);
 
     this.execSqlBatch(request);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2832,36 +2832,15 @@ class Connection extends EventEmitter {
       if (bulkLoad.firstRowWritten) {
         throw new Error("Connection.execBulkLoad can't be called with a BulkLoad that already has rows written to it.");
       }
-
-      const rowStream = Readable.from(rows);
-
-      // Destroy the packet transform if an error happens in the row stream,
-      // e.g. if an error is thrown from within a generator or stream.
-      rowStream.on('error', (err) => {
-        bulkLoad.rowToPacketTransform.destroy(err);
-      });
-
-      // Destroy the row stream if an error happens in the packet transform,
-      // e.g. if the bulk load is cancelled.
-      bulkLoad.rowToPacketTransform.on('error', (err) => {
-        rowStream.destroy(err);
-      });
-
-      rowStream.pipe(bulkLoad.rowToPacketTransform);
-    } else if (!bulkLoad.streamingMode) {
-      // If the bulkload was not put into streaming mode by the user,
-      // we end the rowToPacketTransform here for them.
-      //
-      // If it was put into streaming mode, it's the user's responsibility
-      // to end the stream.
-      bulkLoad.rowToPacketTransform.end();
     }
+
+    // The rows are only read once the server has accepted the
+    // `INSERT BULK` statement and the request message is being sent.
+    const payload = new BulkLoadPayload(bulkLoad, rows ?? []);
 
     const onCancel = () => {
       request.cancel();
     };
-
-    const payload = new BulkLoadPayload(bulkLoad);
 
     const request = new Request(bulkLoad.getBulkInsertSql(), (error: (Error & { code?: string }) | null | undefined) => {
       bulkLoad.removeListener('cancel', onCancel);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2856,14 +2856,6 @@ class Connection extends EventEmitter {
         // connection that is no longer logged in, without reading its
         // payload.
         payload.close();
-      } else {
-        // A cancellation while the rows are being sent stops the payload
-        // stream, but a row read pending inside the payload must be
-        // abandoned as well, or a source that never delivers the row would
-        // keep the bulk load's resources open.
-        bulkLoad.once('cancel', () => {
-          payload.abort(new RequestError('Canceled.', 'ECANCEL'));
-        });
       }
 
       this.makeRequest(bulkLoad, TYPE.BULK_LOAD, payload);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2825,10 +2825,6 @@ class Connection extends EventEmitter {
     bulkLoad.executionStarted = true;
 
     if (rows) {
-      if (bulkLoad.streamingMode) {
-        throw new Error("Connection.execBulkLoad can't be called with a BulkLoad that was put in streaming mode.");
-      }
-
       if (bulkLoad.firstRowWritten) {
         throw new Error("Connection.execBulkLoad can't be called with a BulkLoad that already has rows written to it.");
       }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2856,6 +2856,14 @@ class Connection extends EventEmitter {
         // connection that is no longer logged in, without reading its
         // payload.
         payload.close();
+      } else {
+        // A cancellation while the rows are being sent stops the payload
+        // stream, but a row read pending inside the payload must be
+        // abandoned as well, or a source that never delivers the row would
+        // keep the bulk load's resources open.
+        bulkLoad.once('cancel', () => {
+          payload.abort(new RequestError('Canceled.', 'ECANCEL'));
+        });
       }
 
       this.makeRequest(bulkLoad, TYPE.BULK_LOAD, payload);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2849,9 +2849,16 @@ class Connection extends EventEmitter {
         if (error.code === 'UNKNOWN') {
           error.message += ' This is likely because the schema of the BulkLoad does not match the schema of the table you are attempting to insert into.';
         }
+        payload.close();
         bulkLoad.error = error;
         bulkLoad.callback(error);
         return;
+      }
+
+      if (bulkLoad.canceled) {
+        // `makeRequest` completes a canceled bulk load without reading
+        // its payload.
+        payload.close();
       }
 
       this.makeRequest(bulkLoad, TYPE.BULK_LOAD, payload);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -2851,9 +2851,10 @@ class Connection extends EventEmitter {
         return;
       }
 
-      if (bulkLoad.canceled) {
-        // `makeRequest` completes a canceled bulk load without reading
-        // its payload.
+      if (bulkLoad.canceled || this.state !== this.STATE.LOGGED_IN) {
+        // `makeRequest` completes a canceled bulk load, or one on a
+        // connection that is no longer logged in, without reading its
+        // payload.
         payload.close();
       }
 

--- a/src/promise-like.ts
+++ b/src/promise-like.ts
@@ -1,0 +1,7 @@
+/**
+ * Whether `value` is a thenable: a promise, or anything else with a
+ * `then` method that `await` would assimilate.
+ */
+export function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return value != null && typeof (value as PromiseLike<T>).then === 'function';
+}

--- a/src/promise-like.ts
+++ b/src/promise-like.ts
@@ -5,3 +5,10 @@
 export function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
   return value != null && typeof (value as PromiseLike<T>).then === 'function';
 }
+
+/**
+ * For a rejection that has nowhere to go: the failure it reports is one
+ * the bulk load has already failed for, or one of a source being let go
+ * of.
+ */
+export function ignoreError() {}

--- a/test/integration/bulk-load-test.ts
+++ b/test/integration/bulk-load-test.ts
@@ -555,6 +555,59 @@ describe('BulkLoad', function() {
     connection.execSqlBatch(request);
   });
 
+  it('supports a bulk load with no rows', function(done) {
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(rowCount, 0);
+
+      done();
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+
+    const request = new Request(bulkLoad.getTableCreationSql(), (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, []);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
+  it('releases the row source if `cancel` was called before executing the bulk load', function(done) {
+    const source = Readable.from([[1]], { objectMode: true });
+
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
+      assert.instanceOf(err, RequestError);
+      assert.strictEqual(err.message, 'Canceled.');
+      assert.isUndefined(rowCount);
+
+      assert.isTrue(source.destroyed);
+
+      done();
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+
+    const request = new Request(bulkLoad.getTableCreationSql(), (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      // The `INSERT BULK` statement itself goes through; the bulk load is
+      // then completed as canceled without its rows being read.
+      bulkLoad.cancel();
+      connection.execBulkLoad(bulkLoad, source);
+    });
+
+    connection.execSqlBatch(request);
+  });
+
   it('releases the row source if `cancel` is called immediately after executing the bulk load', function(done) {
     const source = Readable.from([[1]], { objectMode: true });
 

--- a/test/integration/bulk-load-test.ts
+++ b/test/integration/bulk-load-test.ts
@@ -595,6 +595,21 @@ describe('BulkLoad', function() {
     connection.execSqlBatch(request);
   });
 
+  it('releases the row source when the `INSERT BULK` statement is rejected', function(done) {
+    const source = Readable.from([[1]], { objectMode: true });
+
+    const bulkLoad = connection.newBulkLoad('#does_not_exist', (err) => {
+      assert.instanceOf(err, Error);
+      assert.isTrue(source.destroyed);
+
+      done();
+    });
+
+    bulkLoad.addColumn('i', TYPES.Int, { nullable: false });
+
+    connection.execBulkLoad(bulkLoad, source);
+  });
+
   it('supports streaming bulk load rows from a Stream', function(done) {
     const bulkLoad = connection.newBulkLoad('#tmpTestTable', (err, rowCount) => {
       if (err) {

--- a/test/integration/bulk-load-test.ts
+++ b/test/integration/bulk-load-test.ts
@@ -555,6 +555,31 @@ describe('BulkLoad', function() {
     connection.execSqlBatch(request);
   });
 
+  it('releases the row source if `cancel` is called immediately after executing the bulk load', function(done) {
+    const source = Readable.from([[1]], { objectMode: true });
+
+    const bulkLoad = connection.newBulkLoad('#tmpTestTable5', (err) => {
+      assert.instanceOf(err, RequestError);
+      assert.strictEqual(err.message, 'Canceled.');
+      assert.isTrue(source.destroyed);
+
+      done();
+    });
+
+    bulkLoad.addColumn('id', TYPES.Int, { nullable: true });
+
+    const request = new Request('CREATE TABLE #tmpTestTable5 ([id] int NULL)', (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      connection.execBulkLoad(bulkLoad, source);
+      bulkLoad.cancel();
+    });
+
+    connection.execSqlBatch(request);
+  });
+
   it('should not do anything if canceled after completion', function(done) {
     const bulkLoad = connection.newBulkLoad('#tmpTestTable5', { keepNulls: true }, (err, rowCount) => {
       if (err) {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -4,7 +4,8 @@ import { EventEmitter } from 'events';
 import BulkLoad from '../../src/bulk-load';
 import { BulkLoadPayload } from '../../src/bulk-load-payload';
 import { RequestError } from '../../src/errors';
-import { type InternalConnectionOptions } from '../../src/connection';
+import Connection, { type InternalConnectionOptions } from '../../src/connection';
+import { type Request } from '../../src/tedious';
 import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
 import { typeByName as TYPES, type DataType } from '../../src/data-type';
 
@@ -929,6 +930,35 @@ describe('BulkLoad', function() {
   it('starts out as not being canceled', function() {
     const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
     assert.strictEqual(request.canceled, false);
+  });
+
+  describe('#execBulkLoad', function() {
+    it('releases the row source when the connection is not logged in by the time the rows would be sent', function(done) {
+      // Never connected, so it is not logged in when the `INSERT BULK`
+      // statement's callback runs; `makeRequest` rejects the bulk load
+      // without reading its rows, and the source must not be left open.
+      const connection = new Connection({ server: 'localhost', options: {} });
+      connection.execSqlBatch = (request: Request) => {
+        process.nextTick(() => { request.callback(undefined); });
+      };
+
+      const source = new Readable({ objectMode: true, read() {} });
+      const bulkLoad = connection.newBulkLoad('tablename', (err: any) => {
+        try {
+          assert.instanceOf(err, RequestError);
+          assert.strictEqual(err.code, 'EINVALIDSTATE');
+          assert.isTrue(source.destroyed);
+          assert.strictEqual(bulkLoad.listenerCount('cancel'), 0);
+          done();
+        } catch (assertion) {
+          done(assertion);
+        }
+      });
+      bulkLoad.addColumn('id', TYPES.Int, { nullable: false });
+
+      connection.execBulkLoad(bulkLoad, source);
+      assert.isFalse(source.destroyed);
+    });
   });
 
   describe('#cancel', function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -511,7 +511,61 @@ describe('BulkLoad', function() {
       const emitter = new Emitter();
       new BulkLoadPayload(request, emitter).close();
       assert.strictEqual(destroyCalls, 1);
+
+      // The guard stays on until the destroyed source says it is closed.
+      assert.strictEqual(emitter.listenerCount('error'), 1);
+      emitter.emit('close');
       assert.strictEqual(emitter.listenerCount('error'), 0);
+    });
+
+    it('ends the bulk load when an async generator source fails while a row read is pending', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // An async generator queues `return()` behind its pending `next()`,
+      // so the source's cleanup can never finish here; the bulk load must
+      // not wait for it.
+      const expected = new Error('source broke mid-read');
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+          setImmediate(() => { this.emit('error', expected); });
+          await new Promise(() => {});
+        }
+      }
+      const source = new Source();
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
+    it('keeps guarding a stream source closed unread until it has been destroyed', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // `_destroy` reports its failure asynchronously; without a listener
+      // at that point the `'error'` would be unhandled.
+      const source = new Readable({
+        objectMode: true,
+        read() {},
+        destroy(_error, callback) {
+          setImmediate(() => { callback(new Error('destroy failed')); });
+        }
+      });
+
+      const payload = new BulkLoadPayload(request, source);
+      payload.close();
+      assert.isTrue(source.destroyed);
+      assert.strictEqual(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => source.once('close', resolve));
+      assert.strictEqual(source.listenerCount('error'), 0);
     });
 
     it('takes its error listener off an event-emitting source once the rows are read', async function() {
@@ -546,6 +600,8 @@ describe('BulkLoad', function() {
 
       payload.close();
       assert.isTrue(source.destroyed);
+
+      await new Promise((resolve) => source.once('close', resolve));
       assert.strictEqual(source.listenerCount('error'), 0);
 
       // Closing is a one-time thing; a close after the rows were read is a no-op.

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -1067,6 +1067,52 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('close'), 0);
     });
 
+    it('keeps guarding the iterator of a stream closed unread whose destruction reports twice', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The destruction is reported both through `destroy`'s callback
+      // and through `'close'`, while the iterator is still closing and
+      // about to report a failure; that guard must stay on.
+      let returned = false;
+      class Source extends Stream {
+        destroy(_error?: Error, callback?: (error?: Error | null) => void) {
+          callback?.();
+          process.nextTick(() => { this.emit('close'); });
+        }
+
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => Promise.resolve({ done: false, value: [1] }),
+            return: () => {
+              return new Promise<IteratorResult<unknown[]>>((resolve) => {
+                setImmediate(() => {
+                  setImmediate(() => {
+                    this.emit('error', new Error('cleanup failed'));
+                    returned = true;
+                    resolve({ done: true, value: undefined });
+                  });
+                });
+              });
+            }
+          };
+        }
+      }
+      const source = new Source();
+
+      new BulkLoadPayload(request, source).close();
+      await new Promise((resolve) => setImmediate(resolve));
+      // Destroyed, and reported twice: the iterator's guard is still on.
+      assert.isFalse(returned);
+      assert.strictEqual(source.listenerCount('close'), 0);
+      assert.strictEqual(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(returned);
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
     it('takes everything of its own off a stream closed unread that finishes destroying itself silently', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -532,9 +532,12 @@ describe('BulkLoad', function() {
         }
       }
       const emitter = new Emitter();
-      new BulkLoadPayload(request, emitter).close();
+      const payload = new BulkLoadPayload(request, emitter);
+      payload.close();
 
-      assert.strictEqual(emitter.listenerCount('error'), 2);
+      // Guarded while it finishes closing, by nothing that holds on to the payload.
+      assert.isAtLeast(emitter.listenerCount('error'), 1);
+      assert.notInclude(emitter.listeners('error'), payload.onSourceError);
       emitter.emit('close');
       assert.strictEqual(emitter.listenerCount('close'), 0);
 
@@ -795,6 +798,24 @@ describe('BulkLoad', function() {
       // The source can be handed to another bulk load without listeners piling up.
       await collect(new BulkLoadPayload(request, source));
       assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
+    it('takes everything of its own off a stream closed unread that never emits close', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // Node's default `_destroy` completes synchronously, and with
+      // `emitClose: false` that completion is the only signal there is.
+      const source = new Readable({ objectMode: true, emitClose: false, read() {} });
+      const payload = new BulkLoadPayload(request, source);
+
+      payload.close();
+      assert.isTrue(source.destroyed);
+      assert.notInclude(source.listeners('error'), payload.onSourceError);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(source.listenerCount('close'), 0);
     });
 
     it('releases a stream source that is closed unread', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -568,8 +568,91 @@ describe('BulkLoad', function() {
       }
       assert.instanceOf(error, RequestError);
       assert.strictEqual(error.code, 'ECANCEL');
-      assert.strictEqual(source.listenerCount('error'), 0);
       assert.strictEqual(request.listenerCount('cancel'), 0);
+      // The source's `return()` is queued behind the read that never
+      // settles, so it never finishes closing, and stays guarded.
+      assert.strictEqual(source.listenerCount('error'), 1);
+    });
+
+    it('closes without waiting for a stuck source when the bulk load is canceled with a chunk downstream', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The source hands over one row and then never delivers another.
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+          await new Promise(() => {});
+        }
+      }
+      const source = new Source();
+      const payload = new BulkLoadPayload(request, source);
+      const iterator = payload[Symbol.asyncIterator]();
+
+      // The first row comes out once the source is idle; the payload is
+      // now suspended handing it over, with the next read pending.
+      const first = await iterator.next();
+      assert.isFalse(first.done);
+
+      // Cancellation stops the consumer, which closes the payload as a
+      // destroyed stream would. The source's `return()` is queued behind
+      // its pending read and never settles; the close must not wait for it.
+      request.cancel();
+      const closed = await iterator.return(undefined);
+      assert.isTrue(closed.done);
+      assert.strictEqual(request.listenerCount('cancel'), 0);
+    });
+
+    it('keeps guarding an event-emitting source while it is still closing after a failure', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The source fails out of band with a read pending, and its close
+      // reports a failure on a later tick, as a stream's `_destroy` may.
+      // Without a listener at that point the `'error'` would be unhandled.
+      const expected = new Error('source broke mid-read');
+      let closed = false;
+      class Source extends EventEmitter {
+        [Symbol.asyncIterator]() {
+          let count = 0;
+          return {
+            next: () => {
+              if (count++ === 0) {
+                return Promise.resolve({ done: false, value: [1] });
+              }
+              setImmediate(() => { this.emit('error', expected); });
+              return new Promise<IteratorResult<unknown[]>>(() => {});
+            },
+            return: () => {
+              return new Promise<IteratorResult<unknown[]>>((resolve) => {
+                setImmediate(() => {
+                  this.emit('error', new Error('cleanup failed'));
+                  closed = true;
+                  resolve({ done: true, value: undefined });
+                });
+              });
+            }
+          };
+        }
+      }
+      const source = new Source();
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+
+      // The failure reached the bulk load before the close finished.
+      assert.isFalse(closed);
+      assert.strictEqual(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(closed);
+      assert.strictEqual(source.listenerCount('error'), 0);
     });
 
     it('takes its cancel listener off the bulk load once the rows are read', async function() {
@@ -621,7 +704,9 @@ describe('BulkLoad', function() {
         error = err;
       }
       assert.strictEqual(error, expected);
-      assert.strictEqual(source.listenerCount('error'), 0);
+      // The source's `return()` is queued behind the read that never
+      // settles, so it never finishes closing, and stays guarded.
+      assert.strictEqual(source.listenerCount('error'), 1);
     });
 
     it('keeps guarding a stream source closed unread until it has been destroyed', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -482,7 +482,7 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('error'), 0);
     });
 
-    it('only destroys an emitter source when closed unread, and never throws doing so', function() {
+    it('only destroys an emitter source when closed unread, and never throws doing so', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
@@ -513,12 +513,13 @@ describe('BulkLoad', function() {
       new BulkLoadPayload(request, emitter).close();
       assert.strictEqual(destroyCalls, 1);
 
-      // `destroy` threw, so nothing more can come from the source and the
-      // guard comes off right away.
+      // `destroy` threw, so nothing more can come from it; the guard
+      // comes off once the iterator's own `return()` has settled too.
+      await new Promise((resolve) => setImmediate(resolve));
       assert.strictEqual(emitter.listenerCount('error'), 0);
     });
 
-    it('takes its guard off a stream source closed unread once it says it is closed', function() {
+    it('takes its guard off a stream source closed unread once it says it is closed', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
@@ -534,8 +535,47 @@ describe('BulkLoad', function() {
 
       assert.strictEqual(emitter.listenerCount('error'), 2);
       emitter.emit('close');
-      assert.strictEqual(emitter.listenerCount('error'), 0);
       assert.strictEqual(emitter.listenerCount('close'), 0);
+
+      // The guard also waits for the iterator's `return()` to settle.
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(emitter.listenerCount('error'), 0);
+    });
+
+    it('keeps guarding an emitter source closed unread while its iterator is still closing', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // No `destroy`; the iterator's `return()` lets go of what the source
+      // holds open, and reports a failure on a later tick. Without a
+      // listener at that point the `'error'` would be unhandled.
+      let closed = false;
+      class Source extends EventEmitter {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => Promise.resolve({ done: false, value: [1] }),
+            return: () => {
+              return new Promise<IteratorResult<unknown[]>>((resolve) => {
+                setImmediate(() => {
+                  this.emit('error', new Error('cleanup failed'));
+                  closed = true;
+                  resolve({ done: true, value: undefined });
+                });
+              });
+            }
+          };
+        }
+      }
+      const source = new Source();
+
+      new BulkLoadPayload(request, source).close();
+      assert.isFalse(closed);
+      assert.strictEqual(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(closed);
+      assert.strictEqual(source.listenerCount('error'), 0);
     });
 
     it('abandons a pending row read when the bulk load is canceled', async function() {
@@ -766,7 +806,10 @@ describe('BulkLoad', function() {
       payload.close();
       assert.isTrue(source.destroyed);
 
+      // The guard comes off once the stream has closed and its iterator's
+      // `return()` has settled.
       await new Promise((resolve) => source.once('close', resolve));
+      await new Promise((resolve) => setImmediate(resolve));
       assert.strictEqual(source.listenerCount('error'), 0);
 
       // Closing is a one-time thing; a close after the rows were read is a no-op.

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -971,6 +971,42 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('close'), 0);
     });
 
+    it('takes everything of its own off a stream closed unread while it was already destroying itself silently', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // Destroyed by its owner while the `INSERT BULK` statement was in
+      // flight, with a `_destroy` that succeeds later and `emitClose:
+      // false`: nothing is ever emitted about it, and Node does not run
+      // `_destroy` again for the payload.
+      let finish: (() => void) | undefined;
+      const source = new Readable({
+        objectMode: true,
+        emitClose: false,
+        read() {},
+        destroy(_error, callback) {
+          finish = () => { callback(); };
+        }
+      });
+      const payload = new BulkLoadPayload(request, source);
+      source.destroy();
+      assert.isFunction(finish);
+
+      payload.close();
+      assert.notInclude(source.listeners('error'), payload.onSourceError);
+      // Still destroying: still guarded.
+      assert.isAtLeast(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      assert.isAtLeast(source.listenerCount('error'), 1);
+
+      finish!();
+      assert.isTrue(source.closed);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(source.listenerCount('close'), 0);
+    });
+
     it('takes everything of its own off a stream closed unread before it was even constructed', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -448,6 +448,38 @@ describe('BulkLoad', function() {
       assert.lengthOf(chunks, 0);
     });
 
+    it('surfaces an error an event-emitting source emits once its last chunk is with the consumer', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+        }
+      }
+      const source = new Source();
+      const iterator = new BulkLoadPayload(request, source)[Symbol.asyncIterator]();
+
+      // The one row and DONE come out together.
+      const last = await iterator.next();
+      assert.isFalse(last.done);
+      assert.strictEqual(last.value[last.value.length - 13], 0xFD);
+
+      // The error arrives after that; the bulk load still ends with it
+      // (the message it ends can still be marked ignored).
+      const expected = new Error('source broke after the end');
+      source.emit('error', expected);
+
+      let error;
+      try {
+        await iterator.next();
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
     it('ends the bulk load when an event-emitting source fails while a row read is pending', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
@@ -797,6 +829,56 @@ describe('BulkLoad', function() {
 
       // The source can be handed to another bulk load without listeners piling up.
       await collect(new BulkLoadPayload(request, source));
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
+    it('keeps guarding a source closed unread until both its iterator and its destruction have finished', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // Both the iterator's `return()` and `destroy` finish later, on
+      // different ticks; the guard must outlast the slower one.
+      let returned = false;
+      let closed = false;
+      class Source extends EventEmitter {
+        destroy() {
+          setImmediate(() => {
+            closed = true;
+            this.emit('close');
+          });
+        }
+
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => Promise.resolve({ done: false, value: [1] }),
+            return: () => {
+              return new Promise<IteratorResult<unknown[]>>((resolve) => {
+                setImmediate(() => {
+                  setImmediate(() => {
+                    returned = true;
+                    this.emit('error', new Error('cleanup failed'));
+                    resolve({ done: true, value: undefined });
+                  });
+                });
+              });
+            }
+          };
+        }
+      }
+      const source = new Source();
+
+      new BulkLoadPayload(request, source).close();
+      assert.isAtLeast(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(closed);
+      assert.isFalse(returned);
+      // Destroyed, but the iterator is still closing: still guarded.
+      assert.isAtLeast(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(returned);
       assert.strictEqual(source.listenerCount('error'), 0);
     });
 

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -939,6 +939,38 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('close'), 0);
     });
 
+    it('takes everything of its own off a stream closed unread that finishes destroying itself silently', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // With `emitClose: false` and a `_destroy` that succeeds later,
+      // the stream emits nothing at all about its destruction; only its
+      // `_destroy` calling back tells it has finished.
+      let finished = false;
+      const destroy = (_error: Error | null, callback: (error?: Error | null) => void) => {
+        setImmediate(() => {
+          finished = true;
+          callback();
+        });
+      };
+      const source = new Readable({ objectMode: true, emitClose: false, read() {}, destroy });
+      const payload = new BulkLoadPayload(request, source);
+
+      payload.close();
+      assert.isTrue(source.destroyed);
+      assert.isFalse(finished);
+      assert.notInclude(source.listeners('error'), payload.onSourceError);
+      // Still destroying: still guarded, and the stream is left as it was.
+      assert.isAtLeast(source.listenerCount('error'), 1);
+      assert.strictEqual(source._destroy, destroy);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(finished);
+      assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(source.listenerCount('close'), 0);
+    });
+
     it('takes everything of its own off a stream closed unread that never emits close', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -332,6 +332,50 @@ describe('BulkLoad', function() {
       payload.close();
     });
 
+    it('does not throw when a synchronous source fails to close unread', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let closed = false;
+      const payload = new BulkLoadPayload(request, (function*() {
+        try {
+          yield [1];
+        } finally {
+          closed = true;
+          // eslint-disable-next-line no-unsafe-finally
+          throw new Error('close failed');
+        }
+      })());
+
+      // The generator has not started, so `return()` completes it without
+      // running its body; nothing to release, nothing thrown.
+      assert.doesNotThrow(() => payload.close());
+      assert.isFalse(closed);
+    });
+
+    it('does not throw when a started synchronous source fails to close', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let closed = false;
+      const source = (function*() {
+        try {
+          yield [1];
+          yield [2];
+        } finally {
+          closed = true;
+          // eslint-disable-next-line no-unsafe-finally
+          throw new Error('close failed');
+        }
+      })();
+      // Pull the first row ourselves so the generator sits inside its `try`.
+      source.next();
+
+      const payload = new BulkLoadPayload(request, source);
+      assert.doesNotThrow(() => payload.close());
+      assert.isTrue(closed);
+    });
+
     it('hands what it has downstream once the row source goes idle', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -3,6 +3,7 @@ import { Readable } from 'stream';
 import { EventEmitter } from 'events';
 import BulkLoad from '../../src/bulk-load';
 import { BulkLoadPayload } from '../../src/bulk-load-payload';
+import { RequestError } from '../../src/errors';
 import { type InternalConnectionOptions } from '../../src/connection';
 import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
 import { typeByName as TYPES, type DataType } from '../../src/data-type';
@@ -537,7 +538,7 @@ describe('BulkLoad', function() {
       assert.strictEqual(emitter.listenerCount('close'), 0);
     });
 
-    it('abandons a pending row read when the bulk load is aborted', async function() {
+    it('abandons a pending row read when the bulk load is canceled', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
@@ -556,18 +557,44 @@ describe('BulkLoad', function() {
       const first = await iterator.next();
       assert.isFalse(first.done);
 
-      const reason = new Error('canceled');
       const pending = iterator.next();
-      payload.abort(reason);
+      request.cancel();
 
-      let error;
+      let error: any;
       try {
         await pending;
       } catch (err) {
         error = err;
       }
-      assert.strictEqual(error, reason);
+      assert.instanceOf(error, RequestError);
+      assert.strictEqual(error.code, 'ECANCEL');
       assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(request.listenerCount('cancel'), 0);
+    });
+
+    it('takes its cancel listener off the bulk load once the rows are read', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const payload = new BulkLoadPayload(request, [[1], [2]]);
+      assert.strictEqual(request.listenerCount('cancel'), 1);
+
+      await collect(payload);
+      assert.strictEqual(request.listenerCount('cancel'), 0);
+
+      // A cancellation of the completed bulk load reaches nothing of the payload.
+      request.cancel();
+    });
+
+    it('takes its cancel listener off the bulk load when it is closed unread', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const payload = new BulkLoadPayload(request, [[1], [2]]);
+      assert.strictEqual(request.listenerCount('cancel'), 1);
+
+      payload.close();
+      assert.strictEqual(request.listenerCount('cancel'), 0);
     });
 
     it('ends the bulk load when an async generator source fails while a row read is pending', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -882,6 +882,45 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('error'), 0);
     });
 
+    it('takes everything of its own off a stream closed unread that had already failed', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The stream failed while the `INSERT BULK` statement was in
+      // flight, which the payload's guard handled; it has emitted both
+      // `'error'` and `'close'` by the time the statement is rejected and
+      // the payload is closed, and destroying it again emits nothing.
+      const source = new Readable({ objectMode: true, read() {} });
+      const payload = new BulkLoadPayload(request, source);
+      source.destroy(new Error('source failed early'));
+      await new Promise((resolve) => source.once('close', resolve));
+
+      payload.close();
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(source.listenerCount('close'), 0);
+    });
+
+    it('keeps guarding a stream closed unread whose failure is still to be emitted', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // Destroyed with an error on the same tick: the stream is closed
+      // already, but its `'error'` only comes on the next one.
+      const source = new Readable({ objectMode: true, read() {} });
+      const payload = new BulkLoadPayload(request, source);
+      source.destroy(new Error('source failed just now'));
+
+      payload.close();
+      assert.isAtLeast(source.listenerCount('error'), 1);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(source.listenerCount('close'), 0);
+    });
+
     it('takes everything of its own off a stream closed unread that never emits close', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -281,6 +281,56 @@ describe('BulkLoad', function() {
       assert.deepEqual(fromObjects, fromArrays);
     });
 
+    it('settles promised rows, as piping the rows through Readable.from did', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+      request.addColumn('name', TYPES.NVarChar, { nullable: true, length: 10 });
+
+      const plain = Buffer.concat(await collect(new BulkLoadPayload(request, [[1, 'one'], { id: 2, name: null }, [3, 'three']])));
+      // Promised rows are outside the declared type; JavaScript callers hand them over.
+      const rows = [Promise.resolve([1, 'one']), { id: 2, name: null }, Promise.resolve([3, 'three'])] as unknown as Iterable<unknown[]>;
+      const promised = Buffer.concat(await collect(new BulkLoadPayload(request, rows)));
+      assert.deepEqual(promised, plain);
+    });
+
+    it('hands what it has downstream while a promised row is pending', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const rows = [[1], new Promise<unknown[]>(() => {})] as unknown as Iterable<unknown[]>;
+      const iterator = new BulkLoadPayload(request, rows)[Symbol.asyncIterator]();
+      const first = await iterator.next();
+      assert.isFalse(first.done);
+      // COLMETADATA, then the row: ROW, and the int with its length.
+      assert.deepEqual(first.value.subarray(-6), Buffer.from([0xD1, 0x04, 0x01, 0x00, 0x00, 0x00]));
+    });
+
+    it('fails the bulk load with the rejection of a promised row, and closes the source', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const expected = new Error('row lookup failed');
+      let closed = false;
+      const rows = (function*() {
+        try {
+          yield [1];
+          yield Promise.reject(expected);
+        } finally {
+          closed = true;
+        }
+      })() as unknown as Iterable<unknown[]>;
+      const payload = new BulkLoadPayload(request, rows);
+
+      let error;
+      try {
+        await collect(payload);
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.isTrue(closed);
+    });
+
     it('writes a text pointer and timestamp before a text value, and a null pointer for none', async function() {
       const collation = Collation.fromBuffer(Buffer.from([0x09, 0x04, 0xD0, 0x00, 0x34]));
       const request = new BulkLoad('tablename', collation, connectionOptions, { }, () => {});

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import { Readable } from 'stream';
 import BulkLoad from '../../src/bulk-load';
 import { BulkLoadPayload } from '../../src/bulk-load-payload';
 import { type InternalConnectionOptions } from '../../src/connection';
@@ -56,6 +57,40 @@ describe('BulkLoad', function() {
       // Creating the payload and its iterator touches nothing.
       payload[Symbol.asyncIterator]();
       assert.isFalse(pulled);
+    });
+
+    it('accepts a synchronous iterable with an undefined async iterator property', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const rows = { [Symbol.asyncIterator]: undefined, *[Symbol.iterator]() { yield [1]; yield [2]; } };
+      const data = Buffer.concat(await collect(new BulkLoadPayload(request, rows)));
+
+      assert.strictEqual(data[0], 0x81);
+      assert.strictEqual(data[data.length - 13], 0xFD);
+      assert.lengthOf(data.filter((byte) => byte === 0xD1), 2);
+    });
+
+    it('keeps an error a stream source emits before the rows are read', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const source = new Readable({ objectMode: true, read() {} });
+      const payload = new BulkLoadPayload(request, source);
+
+      // The stream fails while nothing reads from it yet. Without a
+      // listener this would be an unhandled `'error'` event.
+      const expected = new Error('source failed');
+      source.destroy(expected);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      let error;
+      try {
+        await collect(payload);
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
     });
 
     it('hands a chunk downstream right away once a row fills it', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -5,7 +5,7 @@ import BulkLoad from '../../src/bulk-load';
 import { BulkLoadPayload } from '../../src/bulk-load-payload';
 import { type InternalConnectionOptions } from '../../src/connection';
 import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
-import { typeByName as TYPES } from '../../src/data-type';
+import { typeByName as TYPES, type DataType } from '../../src/data-type';
 
 // Test options - using type assertion since tests only exercise code paths
 // that use a subset of the full InternalConnectionOptions
@@ -302,6 +302,61 @@ describe('BulkLoad', function() {
 
       const data = Buffer.concat(await collect(new BulkLoadPayload(request, source)));
       assert.strictEqual(data[0], 0x81);
+    });
+
+    it('closes the row source when a column fails to write its TYPE_INFO', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      const expected = new Error('no TYPE_INFO for you');
+      const type: DataType = { ...TYPES.Int, generateTypeInfo() { throw expected; } };
+      request.addColumn('id', type, { nullable: false });
+
+      // A generator that was never pulled skips its `finally` on `return()`,
+      // so the call is recorded on a hand-written iterator instead.
+      let closed = false;
+      const source: AsyncIterable<unknown[]> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next: async (): Promise<IteratorResult<unknown[]>> => ({ value: [1], done: false }),
+            return: async (): Promise<IteratorResult<unknown[]>> => {
+              closed = true;
+              return { value: undefined, done: true };
+            }
+          };
+        }
+      };
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.isTrue(closed);
+    });
+
+    it('surfaces an error an event-emitting source emits without failing its iterator', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const expected = new Error('source broke');
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+          this.emit('error', expected);
+          yield [2];
+        }
+      }
+      const source = new Source();
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.strictEqual(source.listenerCount('error'), 0);
     });
 
     it('takes its error listener off an event-emitting source once the rows are read', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -228,11 +228,11 @@ describe('BulkLoad', function() {
       request.addColumn('id', TYPES.Int, { nullable: false });
 
       const rows = [[1], ['not a number']];
-      const source = {
+      const source: AsyncIterable<unknown[]> = {
         [Symbol.asyncIterator]() {
           let i = 0;
           return {
-            next: async () => i < rows.length ? { value: rows[i++], done: false } : { value: undefined, done: true },
+            next: async (): Promise<IteratorResult<unknown[]>> => (i < rows.length ? { value: rows[i++], done: false } : { value: undefined, done: true }),
             return: async () => { throw new Error('close failed'); }
           };
         }
@@ -252,11 +252,11 @@ describe('BulkLoad', function() {
       request.addColumn('id', TYPES.Int, { nullable: false });
 
       const expected = new Error('close failed');
-      const source = {
+      const source: AsyncIterable<unknown[]> = {
         [Symbol.asyncIterator]() {
           let i = 0;
           return {
-            next: async () => ({ value: [i++], done: false }),
+            next: async (): Promise<IteratorResult<unknown[]>> => ({ value: [i++], done: false }),
             return: async () => { throw expected; }
           };
         }

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -512,10 +512,62 @@ describe('BulkLoad', function() {
       new BulkLoadPayload(request, emitter).close();
       assert.strictEqual(destroyCalls, 1);
 
-      // The guard stays on until the destroyed source says it is closed.
-      assert.strictEqual(emitter.listenerCount('error'), 1);
+      // `destroy` threw, so nothing more can come from the source and the
+      // guard comes off right away.
+      assert.strictEqual(emitter.listenerCount('error'), 0);
+    });
+
+    it('takes its guard off a stream source closed unread once it says it is closed', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      class Emitter extends EventEmitter {
+        destroy() {}
+
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+        }
+      }
+      const emitter = new Emitter();
+      new BulkLoadPayload(request, emitter).close();
+
+      assert.strictEqual(emitter.listenerCount('error'), 2);
       emitter.emit('close');
       assert.strictEqual(emitter.listenerCount('error'), 0);
+      assert.strictEqual(emitter.listenerCount('close'), 0);
+    });
+
+    it('abandons a pending row read when the bulk load is aborted', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The source hands over one row and then never delivers another.
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+          await new Promise(() => {});
+        }
+      }
+      const source = new Source();
+      const payload = new BulkLoadPayload(request, source);
+      const iterator = payload[Symbol.asyncIterator]();
+
+      // The first row comes out once the source is idle.
+      const first = await iterator.next();
+      assert.isFalse(first.done);
+
+      const reason = new Error('canceled');
+      const pending = iterator.next();
+      payload.abort(reason);
+
+      let error;
+      try {
+        await pending;
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, reason);
+      assert.strictEqual(source.listenerCount('error'), 0);
     });
 
     it('ends the bulk load when an async generator source fails while a row read is pending', async function() {
@@ -562,7 +614,8 @@ describe('BulkLoad', function() {
       const payload = new BulkLoadPayload(request, source);
       payload.close();
       assert.isTrue(source.destroyed);
-      assert.strictEqual(source.listenerCount('error'), 1);
+      // The guard stays on (alongside the listener waiting for destruction to finish).
+      assert.isAtLeast(source.listenerCount('error'), 1);
 
       await new Promise((resolve) => source.once('close', resolve));
       assert.strictEqual(source.listenerCount('error'), 0);

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -1,12 +1,168 @@
 import { assert } from 'chai';
 import BulkLoad from '../../src/bulk-load';
 import { type InternalConnectionOptions } from '../../src/connection';
+import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
+import { typeByName as TYPES } from '../../src/data-type';
 
 // Test options - using type assertion since tests only exercise code paths
 // that use a subset of the full InternalConnectionOptions
 const connectionOptions = { tdsVersion: '7_2' } as InternalConnectionOptions;
 
 describe('BulkLoad', function() {
+  describe('row serialization', function() {
+    it('hands rows downstream in packet-sized chunks rather than one chunk per row', function(done) {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+      request.addColumn('name', TYPES.NVarChar, { length: 50, nullable: true });
+
+      const rowCount = 2000;
+      const chunks: Buffer[] = [];
+      const transform = request.rowToPacketTransform;
+
+      transform.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      transform.on('end', () => {
+        const data = Buffer.concat(chunks);
+
+        // COLMETADATA first, DONE (13 bytes on TDS 7.2+) last, and the
+        // rows in between coalesced into chunks of at most CHUNK_SIZE bytes.
+        assert.strictEqual(data[0], 0x81);
+        assert.strictEqual(data[data.length - 13], 0xFD);
+        assert.isBelow(chunks.length, rowCount / 20);
+        for (const chunk of chunks) {
+          assert.isAtMost(chunk.length, WritableTrackingBuffer.CHUNK_SIZE);
+        }
+
+        done();
+      });
+
+      for (let i = 0; i < rowCount; i++) {
+        transform.write([i, 'row ' + i]);
+      }
+      transform.end();
+    });
+
+    it('hands a chunk downstream right away once a row fills it', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('blob', TYPES.VarBinary, { length: WritableTrackingBuffer.CHUNK_SIZE + 1000, nullable: false });
+
+      const chunks: Buffer[] = [];
+      const transform = request.rowToPacketTransform;
+      transform.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      // A single row larger than a chunk is flushed synchronously, without
+      // waiting for further rows or for the source to go idle.
+      const value = Buffer.alloc(WritableTrackingBuffer.CHUNK_SIZE + 1000, 0xAB);
+      transform.write([value]);
+
+      assert.isAtLeast(chunks.length, 1);
+      const data = Buffer.concat(chunks);
+      assert.strictEqual(data[0], 0x81);
+      // The value is the last thing in the row, ahead of the 4-byte PLP terminator.
+      assert.strictEqual(data.indexOf(value), data.length - value.length - 4);
+    });
+
+    it('produces the same bytes as serializing each row on its own', function(done) {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+      request.addColumn('name', TYPES.NVarChar, { length: 50, nullable: true });
+      request.addColumn('blob', TYPES.VarBinary, { length: 9000, nullable: true });
+
+      const rows: unknown[][] = [];
+      for (let i = 0; i < 300; i++) {
+        rows.push([i, i % 7 ? 'row ' + i : null, i % 5 ? Buffer.alloc(i % 3 ? 10 : 9000, i) : null]);
+      }
+
+      // The reference: COLMETADATA, each row serialized into its own buffer
+      // (a ROW token, then every cell), DONE.
+      const expected = [request.getColMetaData()];
+      for (const row of rows) {
+        const buffer = new WritableTrackingBuffer();
+        buffer.writeUInt8(0xD1);
+        request.columns.forEach((column, i) => {
+          const value = column.type.validate(row[i], column.collation);
+          const parameter = { length: column.length, scale: column.scale, precision: column.precision, value };
+          buffer.writeBuffer(column.type.generateParameterLength(parameter, connectionOptions));
+          for (const chunk of column.type.generateParameterData(parameter, connectionOptions)) {
+            buffer.writeBuffer(chunk);
+          }
+        });
+        expected.push(buffer.slice());
+      }
+      expected.push(request.createDoneToken());
+
+      const chunks: Buffer[] = [];
+      const transform = request.rowToPacketTransform;
+      transform.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      transform.on('end', () => {
+        assert.deepEqual(Buffer.concat(chunks), Buffer.concat(expected));
+        done();
+      });
+
+      for (const row of rows) {
+        transform.write(row);
+      }
+      transform.end();
+    });
+
+    it('hands nothing downstream after a row fails, even with a flush pending', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const chunks: Buffer[] = [];
+      const transform = request.rowToPacketTransform;
+      transform.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      const failed = new Promise<Error>((resolve) => transform.on('error', resolve));
+
+      // A valid row schedules an idle flush; the next row fails validation
+      // before that flush gets a turn.
+      transform.write([1]);
+      transform.write(['not a number']);
+
+      const error = await failed;
+      assert.instanceOf(error, TypeError);
+      assert.isTrue(transform.destroyed);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.lengthOf(chunks, 0);
+    });
+
+    it('hands what it has downstream once the row source goes idle', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const chunks: Buffer[] = [];
+      const transform = request.rowToPacketTransform;
+      transform.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      transform.write([1]);
+      assert.lengthOf(chunks, 0);
+
+      // The row is far smaller than a chunk; it still goes downstream as
+      // soon as no further rows arrive.
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.lengthOf(chunks, 1);
+      assert.strictEqual(chunks[0][0], 0x81);
+
+      const ended = new Promise((resolve) => transform.on('end', resolve));
+      transform.end();
+      await ended;
+
+      assert.lengthOf(chunks, 2);
+      assert.strictEqual(chunks[1][0], 0xFD);
+    });
+  });
+
   it('starts out as not being canceled', function() {
     const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
     assert.strictEqual(request.canceled, false);

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import BulkLoad from '../../src/bulk-load';
+import { BulkLoadPayload } from '../../src/bulk-load-payload';
 import { type InternalConnectionOptions } from '../../src/connection';
 import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
 import { typeByName as TYPES } from '../../src/data-type';
@@ -10,63 +11,87 @@ const connectionOptions = { tdsVersion: '7_2' } as InternalConnectionOptions;
 
 describe('BulkLoad', function() {
   describe('row serialization', function() {
-    it('hands rows downstream in packet-sized chunks rather than one chunk per row', function(done) {
+    async function collect(payload: AsyncIterable<Buffer>) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of payload) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    }
+
+    it('hands rows downstream in packet-sized chunks rather than one chunk per row', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
       request.addColumn('name', TYPES.NVarChar, { length: 50, nullable: true });
 
       const rowCount = 2000;
-      const chunks: Buffer[] = [];
-      const transform = request.rowToPacketTransform;
-
-      transform.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-
-      transform.on('end', () => {
-        const data = Buffer.concat(chunks);
-
-        // COLMETADATA first, DONE (13 bytes on TDS 7.2+) last, and the
-        // rows in between coalesced into chunks of at most CHUNK_SIZE bytes.
-        assert.strictEqual(data[0], 0x81);
-        assert.strictEqual(data[data.length - 13], 0xFD);
-        assert.isBelow(chunks.length, rowCount / 20);
-        for (const chunk of chunks) {
-          assert.isAtMost(chunk.length, WritableTrackingBuffer.CHUNK_SIZE);
-        }
-
-        done();
-      });
-
+      const rows: unknown[][] = [];
       for (let i = 0; i < rowCount; i++) {
-        transform.write([i, 'row ' + i]);
+        rows.push([i, 'row ' + i]);
       }
-      transform.end();
+
+      const chunks = await collect(new BulkLoadPayload(request, rows));
+      const data = Buffer.concat(chunks);
+
+      // COLMETADATA first, DONE (13 bytes on TDS 7.2+) last, and the
+      // rows in between coalesced into chunks of at most CHUNK_SIZE bytes.
+      assert.strictEqual(data[0], 0x81);
+      assert.strictEqual(data[data.length - 13], 0xFD);
+      assert.isBelow(chunks.length, rowCount / 20);
+      for (const chunk of chunks) {
+        assert.isAtMost(chunk.length, WritableTrackingBuffer.CHUNK_SIZE);
+      }
     });
 
-    it('hands a chunk downstream right away once a row fills it', function() {
+    it('does not read rows before the bytes are consumed', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let pulled = false;
+      const payload = new BulkLoadPayload(request, (function*() {
+        pulled = true;
+        yield [1];
+      })());
+
+      // Creating the payload and its iterator touches nothing.
+      payload[Symbol.asyncIterator]();
+      assert.isFalse(pulled);
+    });
+
+    it('hands a chunk downstream right away once a row fills it', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('blob', TYPES.VarBinary, { length: WritableTrackingBuffer.CHUNK_SIZE + 1000, nullable: false });
 
-      const chunks: Buffer[] = [];
-      const transform = request.rowToPacketTransform;
-      transform.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-
-      // A single row larger than a chunk is flushed synchronously, without
-      // waiting for further rows or for the source to go idle.
       const value = Buffer.alloc(WritableTrackingBuffer.CHUNK_SIZE + 1000, 0xAB);
-      transform.write([value]);
+      let secondRowPulled = false;
+      const payload = new BulkLoadPayload(request, (async function*() {
+        yield [value];
+        secondRowPulled = true;
+        yield [Buffer.alloc(1)];
+      })());
 
-      assert.isAtLeast(chunks.length, 1);
-      const data = Buffer.concat(chunks);
+      // A single row larger than a chunk is handed downstream before the
+      // next row is read, without waiting for the source to go idle.
+      // Pull chunks until the whole row (the value is followed by the 4-byte
+      // PLP terminator) has arrived, then stop.
+      const chunks: Buffer[] = [];
+      let data = Buffer.alloc(0);
+      for await (const chunk of payload) {
+        chunks.push(chunk);
+        data = Buffer.concat(chunks);
+        const index = data.indexOf(value);
+        if (index !== -1 && data.length >= index + value.length + 4) {
+          break;
+        }
+      }
+
+      assert.isFalse(secondRowPulled);
       assert.strictEqual(data[0], 0x81);
       // The value is the last thing in the row, ahead of the 4-byte PLP terminator.
       assert.strictEqual(data.indexOf(value), data.length - value.length - 4);
     });
 
-    it('produces the same bytes as serializing each row on its own', function(done) {
+    it('produces the same bytes as serializing each row on its own', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
       request.addColumn('name', TYPES.NVarChar, { length: 50, nullable: true });
@@ -95,71 +120,124 @@ describe('BulkLoad', function() {
       }
       expected.push(request.createDoneToken());
 
-      const chunks: Buffer[] = [];
-      const transform = request.rowToPacketTransform;
-      transform.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-      transform.on('end', () => {
-        assert.deepEqual(Buffer.concat(chunks), Buffer.concat(expected));
-        done();
-      });
+      const fromArray = await collect(new BulkLoadPayload(request, rows));
+      assert.deepEqual(Buffer.concat(fromArray), Buffer.concat(expected));
 
-      for (const row of rows) {
-        transform.write(row);
-      }
-      transform.end();
+      const fromAsyncSource = await collect(new BulkLoadPayload(request, (async function*() {
+        for (const row of rows) {
+          await new Promise((resolve) => setImmediate(resolve));
+          yield row;
+        }
+      })()));
+      assert.deepEqual(Buffer.concat(fromAsyncSource), Buffer.concat(expected));
     });
 
-    it('hands nothing downstream after a row fails, even with a flush pending', async function() {
+    it('hands nothing downstream after a row fails, and closes the row source', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
+      let closed = false;
+      const payload = new BulkLoadPayload(request, (async function*() {
+        try {
+          // A valid row, then one that fails validation before the first
+          // one was handed downstream.
+          yield [1];
+          yield ['not a number'];
+          yield [2];
+        } finally {
+          closed = true;
+        }
+      })());
+
       const chunks: Buffer[] = [];
-      const transform = request.rowToPacketTransform;
-      transform.on('data', (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-      const failed = new Promise<Error>((resolve) => transform.on('error', resolve));
+      let error;
+      try {
+        for await (const chunk of payload) {
+          chunks.push(chunk);
+        }
+      } catch (err) {
+        error = err;
+      }
 
-      // A valid row schedules an idle flush; the next row fails validation
-      // before that flush gets a turn.
-      transform.write([1]);
-      transform.write(['not a number']);
-
-      const error = await failed;
       assert.instanceOf(error, TypeError);
-      assert.isTrue(transform.destroyed);
-
-      await new Promise((resolve) => setImmediate(resolve));
       assert.lengthOf(chunks, 0);
+      assert.isTrue(closed);
+    });
+
+    it('closes the row source when the consumer stops early', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let closed = false;
+      const payload = new BulkLoadPayload(request, (async function*() {
+        try {
+          let i = 0;
+          while (true) {
+            yield [i++];
+          }
+        } finally {
+          closed = true;
+        }
+      })());
+
+      const iterator = payload[Symbol.asyncIterator]();
+      await iterator.next();
+      await iterator.return();
+
+      assert.isTrue(closed);
     });
 
     it('hands what it has downstream once the row source goes idle', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
-      const chunks: Buffer[] = [];
-      const transform = request.rowToPacketTransform;
-      transform.on('data', (chunk: Buffer) => {
+      let resumed = false;
+      const payload = new BulkLoadPayload(request, (async function*() {
+        yield [1];
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        resumed = true;
+        yield [2];
+      })());
+
+      const iterator = payload[Symbol.asyncIterator]();
+
+      // The first row is far smaller than a chunk; it still goes downstream
+      // as soon as the source is waiting, before it produces the next row.
+      const first = await iterator.next();
+      assert.isFalse(first.done);
+      assert.isFalse(resumed);
+      assert.strictEqual(first.value![0], 0x81);
+
+      const chunks = [first.value!];
+      for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
         chunks.push(chunk);
-      });
+      }
+      assert.isTrue(resumed);
+      const data = Buffer.concat(chunks);
+      assert.strictEqual(data[data.length - 13], 0xFD);
+    });
 
-      transform.write([1]);
-      assert.lengthOf(chunks, 0);
+    it('serializes rows from a synchronous source without touching the event loop', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
 
-      // The row is far smaller than a chunk; it still goes downstream as
-      // soon as no further rows arrive.
-      await new Promise((resolve) => setImmediate(resolve));
-      assert.lengthOf(chunks, 1);
-      assert.strictEqual(chunks[0][0], 0x81);
+      const rows: unknown[][] = [];
+      for (let i = 0; i < 5000; i++) {
+        rows.push([i]);
+      }
 
-      const ended = new Promise((resolve) => transform.on('end', resolve));
-      transform.end();
-      await ended;
+      let turns = 0;
+      const tick = () => { turns++; setImmediate(tick); };
+      const timer = setImmediate(tick);
+      try {
+        await collect(new BulkLoadPayload(request, rows));
+      } finally {
+        clearImmediate(timer);
+      }
 
-      assert.lengthOf(chunks, 2);
-      assert.strictEqual(chunks[1][0], 0xFD);
+      // The consumer's `for await` yields to the microtask queue, never to
+      // the event loop, and neither does reading from the array.
+      assert.strictEqual(turns, 0);
     });
   });
 

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import { Readable } from 'stream';
+import { EventEmitter } from 'events';
 import BulkLoad from '../../src/bulk-load';
 import { BulkLoadPayload } from '../../src/bulk-load-payload';
 import { type InternalConnectionOptions } from '../../src/connection';
@@ -220,6 +221,95 @@ describe('BulkLoad', function() {
       await iterator.return();
 
       assert.isTrue(closed);
+    });
+
+    it('keeps the row error when the source fails to close', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const rows = [[1], ['not a number']];
+      const source = {
+        [Symbol.asyncIterator]() {
+          let i = 0;
+          return {
+            next: async () => i < rows.length ? { value: rows[i++], done: false } : { value: undefined, done: true },
+            return: async () => { throw new Error('close failed'); }
+          };
+        }
+      };
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.instanceOf(error, TypeError);
+    });
+
+    it('reports a source that fails to close when the consumer stops early', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const expected = new Error('close failed');
+      const source = {
+        [Symbol.asyncIterator]() {
+          let i = 0;
+          return {
+            next: async () => ({ value: [i++], done: false }),
+            return: async () => { throw expected; }
+          };
+        }
+      };
+
+      const iterator = new BulkLoadPayload(request, source)[Symbol.asyncIterator]();
+      await iterator.next();
+
+      let error;
+      try {
+        await iterator.return();
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+    });
+
+    it('takes its error listener off an event-emitting source once the rows are read', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+          yield [2];
+        }
+      }
+      const source = new Source();
+
+      const payload = new BulkLoadPayload(request, source);
+      assert.strictEqual(source.listenerCount('error'), 1);
+
+      await collect(payload);
+      assert.strictEqual(source.listenerCount('error'), 0);
+
+      // The source can be handed to another bulk load without listeners piling up.
+      await collect(new BulkLoadPayload(request, source));
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
+    it('releases a stream source that is closed unread', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const source = new Readable({ objectMode: true, read() {} });
+      const payload = new BulkLoadPayload(request, source);
+
+      payload.close();
+      assert.isTrue(source.destroyed);
+      assert.strictEqual(source.listenerCount('error'), 0);
+
+      // Closing is a one-time thing; a close after the rows were read is a no-op.
+      payload.close();
     });
 
     it('hands what it has downstream once the row source goes idle', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -137,6 +137,40 @@ describe('BulkLoad', function() {
       assert.strictEqual(data.indexOf(value), data.length - value.length - 4);
     });
 
+    it('hands a chunk downstream in the middle of a wide row', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+
+      // Three cells of 6,000 bytes: the second one takes the buffer past
+      // CHUNK_SIZE, so the first chunk goes out before the third cell is
+      // serialized.
+      const serialized: string[] = [];
+      const tracking = (name: string): DataType => ({
+        ...TYPES.VarBinary,
+        *generateParameterData(parameter, options) {
+          serialized.push(name);
+          yield* TYPES.VarBinary.generateParameterData(parameter, options);
+        }
+      });
+      request.addColumn('a', tracking('a'), { length: 6000, nullable: false });
+      request.addColumn('b', tracking('b'), { length: 6000, nullable: false });
+      request.addColumn('c', tracking('c'), { length: 6000, nullable: false });
+
+      const row = [Buffer.alloc(6000, 1), Buffer.alloc(6000, 2), Buffer.alloc(6000, 3)];
+      const iterator = new BulkLoadPayload(request, [row])[Symbol.asyncIterator]();
+
+      const first = await iterator.next();
+      assert.isFalse(first.done);
+      assert.deepEqual(serialized, ['a', 'b']);
+
+      const chunks = [first.value!];
+      for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
+        chunks.push(chunk);
+      }
+      assert.deepEqual(serialized, ['a', 'b', 'c']);
+      const data = Buffer.concat(chunks);
+      assert.strictEqual(data[data.length - 13], 0xFD);
+    });
+
     it('produces the same bytes as serializing each row on its own', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
@@ -445,10 +479,14 @@ describe('BulkLoad', function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
+      // The source hands over one row and then waits on something only the
+      // test releases, so the order of events does not depend on timers.
+      let resume!: () => void;
+      const gate = new Promise<void>((resolve) => { resume = resolve; });
       let resumed = false;
       const payload = new BulkLoadPayload(request, (async function*() {
         yield [1];
-        await new Promise((resolve) => setTimeout(resolve, 20));
+        await gate;
         resumed = true;
         yield [2];
       })());
@@ -462,6 +500,7 @@ describe('BulkLoad', function() {
       assert.isFalse(resumed);
       assert.strictEqual(first.value![0], 0x81);
 
+      resume();
       const chunks = [first.value!];
       for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
         chunks.push(chunk);

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -446,6 +446,74 @@ describe('BulkLoad', function() {
       assert.lengthOf(chunks, 0);
     });
 
+    it('ends the bulk load when an event-emitting source fails while a row read is pending', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The source hands over one row, then emits `'error'` while its next
+      // read stays pending forever.
+      const expected = new Error('source broke mid-read');
+      class Source extends EventEmitter implements AsyncIterable<unknown[]> {
+        [Symbol.asyncIterator]() {
+          let reads = 0;
+          return {
+            next: (): Promise<IteratorResult<unknown[]>> => {
+              if (reads++ === 0) {
+                return Promise.resolve({ value: [1], done: false });
+              }
+
+              setImmediate(() => { this.emit('error', expected); });
+              return new Promise(() => {});
+            },
+            return: async (): Promise<IteratorResult<unknown[]>> => ({ value: undefined, done: true })
+          };
+        }
+      }
+      const source = new Source();
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
+    it('only destroys an emitter source when closed unread, and never throws doing so', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let destroyCalls = 0;
+      const plain = {
+        destroy() {
+          destroyCalls++;
+          throw new Error('not a stream');
+        },
+        *[Symbol.iterator]() {
+          yield [1];
+        }
+      };
+      new BulkLoadPayload(request, plain).close();
+      assert.strictEqual(destroyCalls, 0);
+
+      class Emitter extends EventEmitter {
+        destroy() {
+          destroyCalls++;
+          throw new Error('destroy failed');
+        }
+
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+        }
+      }
+      const emitter = new Emitter();
+      new BulkLoadPayload(request, emitter).close();
+      assert.strictEqual(destroyCalls, 1);
+      assert.strictEqual(emitter.listenerCount('error'), 0);
+    });
+
     it('takes its error listener off an event-emitting source once the rows are read', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -7,6 +7,7 @@ import { RequestError } from '../../src/errors';
 import Connection, { type InternalConnectionOptions } from '../../src/connection';
 import { type Request } from '../../src/tedious';
 import WritableTrackingBuffer from '../../src/tracking-buffer/writable-tracking-buffer';
+import { Collation } from '../../src/collation';
 import { typeByName as TYPES, type DataType } from '../../src/data-type';
 
 // Test options - using type assertion since tests only exercise code paths
@@ -268,6 +269,133 @@ describe('BulkLoad', function() {
       assert.instanceOf(error, TypeError);
       assert.lengthOf(chunks, 0);
       assert.isTrue(closed);
+    });
+
+    it('serializes rows given as objects the same as rows given as arrays', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+      request.addColumn('name', TYPES.NVarChar, { nullable: true, length: 10 });
+
+      const fromArrays = Buffer.concat(await collect(new BulkLoadPayload(request, [[1, 'one'], [2, null]])));
+      const fromObjects = Buffer.concat(await collect(new BulkLoadPayload(request, [{ id: 1, name: 'one' }, { id: 2, name: null }])));
+      assert.deepEqual(fromObjects, fromArrays);
+    });
+
+    it('writes a text pointer and timestamp before a text value, and a null pointer for none', async function() {
+      const collation = Collation.fromBuffer(Buffer.from([0x09, 0x04, 0xD0, 0x00, 0x34]));
+      const request = new BulkLoad('tablename', collation, connectionOptions, { }, () => {});
+      request.addColumn('note', TYPES.Text, { nullable: true });
+
+      const data = Buffer.concat(await collect(new BulkLoadPayload(request, [['ab'], [null]])));
+      const rows = data.subarray(data.indexOf(0xD1), data.length - 13);
+
+      // ROW, 16-byte pointer prefixed by its length, 8-byte timestamp, 4-byte length, data.
+      const withValue = Buffer.concat([Buffer.from([0xD1, 0x10]), Buffer.alloc(16, 0), Buffer.alloc(8, 0), Buffer.from([2, 0, 0, 0]), Buffer.from('ab', 'ascii')]);
+      // ROW, null pointer.
+      const withoutValue = Buffer.from([0xD1, 0x00]);
+      assert.deepEqual(rows, Buffer.concat([withValue, withoutValue]));
+    });
+
+    it('writes the shorter DONE token of TDS versions before 7.2', async function() {
+      const request = new BulkLoad('tablename', undefined, { tdsVersion: '7_1' } as InternalConnectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const data = Buffer.concat(await collect(new BulkLoadPayload(request, [])));
+      assert.strictEqual(data[data.length - 9], 0xFD);
+      assert.strictEqual(data.readUInt32LE(data.length - 4), 0);
+    });
+
+    it('describes itself for the debug log', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      assert.strictEqual(new BulkLoadPayload(request, []).toString(), 'BulkLoad');
+      assert.strictEqual(new BulkLoadPayload(request, []).toString('  '), '  BulkLoad');
+    });
+
+    it('closes a synchronous source when the consumer stops early', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let closed = false;
+      const payload = new BulkLoadPayload(request, (function*() {
+        try {
+          let i = 0;
+          while (true) {
+            yield [i++];
+          }
+        } finally {
+          closed = true;
+        }
+      })());
+
+      const iterator = payload[Symbol.asyncIterator]();
+      await iterator.next();
+      await iterator.return();
+
+      assert.isTrue(closed);
+    });
+
+    it('closes a synchronous source when a row fails', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      let closed = false;
+      const payload = new BulkLoadPayload(request, (function*() {
+        try {
+          yield [1];
+          yield ['not a number'];
+        } finally {
+          closed = true;
+        }
+      })());
+
+      let error;
+      try {
+        await collect(payload);
+      } catch (err) {
+        error = err;
+      }
+      assert.instanceOf(error, TypeError);
+      assert.isTrue(closed);
+    });
+
+    it('gets on without a return on the source when a row fails', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const rows = [[1], ['not a number']];
+      const source: Iterable<unknown[]> = {
+        [Symbol.iterator]() {
+          let i = 0;
+          return {
+            next: () => (i < rows.length ? { done: false, value: rows[i++] } : { done: true, value: undefined })
+          };
+        }
+      };
+
+      let error;
+      try {
+        await collect(new BulkLoadPayload(request, source));
+      } catch (err) {
+        error = err;
+      }
+      assert.instanceOf(error, TypeError);
+    });
+
+    it('lets go of an event-emitting synchronous source closed unread at once', function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      class Source extends EventEmitter {
+        *[Symbol.iterator]() {
+          yield [1];
+        }
+      }
+      const source = new Source();
+      const payload = new BulkLoadPayload(request, source);
+      assert.strictEqual(source.listenerCount('error'), 1);
+
+      payload.close();
+      assert.strictEqual(source.listenerCount('error'), 0);
     });
 
     it('closes the row source when the consumer stops early', async function() {

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -971,6 +971,57 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('close'), 0);
     });
 
+    it('takes everything of its own off a stream closed unread before it was even constructed', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // Destruction waits for construction to finish, and with
+      // `emitClose: false` nothing is emitted about it afterwards.
+      let constructed = false;
+      const source = new Readable({
+        objectMode: true,
+        emitClose: false,
+        read() {},
+        construct(callback) {
+          setImmediate(() => {
+            constructed = true;
+            callback();
+          });
+        }
+      });
+      const payload = new BulkLoadPayload(request, source);
+
+      payload.close();
+      assert.isTrue(source.destroyed);
+      assert.isFalse(constructed);
+      assert.notInclude(source.listeners('error'), payload.onSourceError);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.isTrue(constructed);
+      assert.isTrue(source.closed);
+      assert.strictEqual(source.listenerCount('error'), 0);
+      assert.strictEqual(source.listenerCount('close'), 0);
+    });
+
+    it('closes a stream source whose destruction hook cannot be replaced unread without throwing', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // Its `_destroy` cannot be replaced, so it must be destroyed as it is.
+      const source = new Readable({ objectMode: true, read() {} });
+      Object.defineProperty(source, '_destroy', { value: source._destroy, writable: false, configurable: false });
+      const payload = new BulkLoadPayload(request, source);
+
+      payload.close();
+      assert.isTrue(source.destroyed);
+
+      await new Promise((resolve) => source.once('close', resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(source.listenerCount('error'), 0);
+    });
+
     it('takes everything of its own off a stream closed unread that never emits close', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -274,6 +274,26 @@ describe('BulkLoad', function() {
       assert.strictEqual(error, expected);
     });
 
+    it('does not treat an unrelated `on` method as an event emitter', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const source = {
+        on() {
+          throw new Error('not an event emitter');
+        },
+        removeListener() {
+          throw new Error('not an event emitter');
+        },
+        *[Symbol.iterator]() {
+          yield [1];
+        }
+      };
+
+      const data = Buffer.concat(await collect(new BulkLoadPayload(request, source)));
+      assert.strictEqual(data[0], 0x81);
+    });
+
     it('takes its error listener off an event-emitting source once the rows are read', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -137,6 +137,30 @@ describe('BulkLoad', function() {
       assert.strictEqual(data.indexOf(value), data.length - value.length - 4);
     });
 
+    it('hands rows of null text cells downstream in chunks', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('t', TYPES.Text, { nullable: true });
+
+      // A null text cell is a single null text pointer byte; the chunk
+      // boundary must still be checked for it, or a source of such rows
+      // would be buffered whole.
+      const rowCount = 10000;
+      const rows: unknown[][] = [];
+      for (let i = 0; i < rowCount; i++) {
+        rows.push([null]);
+      }
+
+      const chunks = await collect(new BulkLoadPayload(request, rows));
+      const data = Buffer.concat(chunks);
+
+      assert.isAbove(chunks.length, 1);
+      for (const chunk of chunks) {
+        assert.isAtMost(chunk.length, WritableTrackingBuffer.CHUNK_SIZE);
+      }
+      assert.strictEqual(data[0], 0x81);
+      assert.strictEqual(data[data.length - 13], 0xFD);
+    });
+
     it('hands a chunk downstream in the middle of a wide row', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
 
@@ -520,11 +544,18 @@ describe('BulkLoad', function() {
       }
 
       let turns = 0;
-      const tick = () => { turns++; setImmediate(tick); };
+      let stopped = false;
+      const tick = () => {
+        turns++;
+        if (!stopped) {
+          setImmediate(tick);
+        }
+      };
       const timer = setImmediate(tick);
       try {
         await collect(new BulkLoadPayload(request, rows));
       } finally {
+        stopped = true;
         clearImmediate(timer);
       }
 

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { Readable } from 'stream';
+import { Readable, Stream } from 'stream';
 import { EventEmitter } from 'events';
 import BulkLoad from '../../src/bulk-load';
 import { BulkLoadPayload } from '../../src/bulk-load-payload';
@@ -515,7 +515,7 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('error'), 0);
     });
 
-    it('only destroys an emitter source when closed unread, and never throws doing so', async function() {
+    it('only destroys a stream source when closed unread, and never throws doing so', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
@@ -532,7 +532,25 @@ describe('BulkLoad', function() {
       new BulkLoadPayload(request, plain).close();
       assert.strictEqual(destroyCalls, 0);
 
+      // An emitter that is not a stream is not destroyed either: its
+      // `destroy` could finish without any signal, and the guard would
+      // never come off.
       class Emitter extends EventEmitter {
+        destroy() {
+          destroyCalls++;
+        }
+
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+        }
+      }
+      const emitter = new Emitter();
+      new BulkLoadPayload(request, emitter).close();
+      assert.strictEqual(destroyCalls, 0);
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(emitter.listenerCount('error'), 0);
+
+      class Failing extends Stream {
         destroy() {
           destroyCalls++;
           throw new Error('destroy failed');
@@ -542,21 +560,21 @@ describe('BulkLoad', function() {
           yield [1];
         }
       }
-      const emitter = new Emitter();
-      new BulkLoadPayload(request, emitter).close();
+      const failing = new Failing();
+      new BulkLoadPayload(request, failing).close();
       assert.strictEqual(destroyCalls, 1);
 
       // `destroy` threw, so nothing more can come from it; the guard
       // comes off once the iterator's own `return()` has settled too.
       await new Promise((resolve) => setImmediate(resolve));
-      assert.strictEqual(emitter.listenerCount('error'), 0);
+      assert.strictEqual(failing.listenerCount('error'), 0);
     });
 
     it('takes its guard off a stream source closed unread once it says it is closed', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });
 
-      class Emitter extends EventEmitter {
+      class Emitter extends Stream {
         destroy() {}
 
         async *[Symbol.asyncIterator]() {
@@ -840,7 +858,7 @@ describe('BulkLoad', function() {
       // different ticks; the guard must outlast the slower one.
       let returned = false;
       let closed = false;
-      class Source extends EventEmitter {
+      class Source extends Stream {
         destroy() {
           setImmediate(() => {
             closed = true;

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -45,6 +45,16 @@ describe('BulkLoad', function() {
       }
     });
 
+    it('sends COLMETADATA and DONE for a bulk load with no rows', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      const data = Buffer.concat(await collect(new BulkLoadPayload(request, [])));
+
+      // The server rejects a bulk load message that carries only DONE.
+      assert.deepEqual(data, Buffer.concat([request.getColMetaData(), request.createDoneToken()]));
+    });
+
     it('does not read rows before the bytes are consumed', function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });

--- a/test/unit/bulk-load-test.ts
+++ b/test/unit/bulk-load-test.ts
@@ -417,6 +417,35 @@ describe('BulkLoad', function() {
       assert.strictEqual(source.listenerCount('error'), 0);
     });
 
+    it('surfaces an error an event-emitting source emits after its last row', async function() {
+      const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
+      request.addColumn('id', TYPES.Int, { nullable: false });
+
+      // The error arrives while the source is being asked for the row
+      // after its last one, so the bulk load ends with it before DONE
+      // goes out.
+      const expected = new Error('source broke late');
+      class Source extends EventEmitter {
+        async *[Symbol.asyncIterator]() {
+          yield [1];
+          this.emit('error', expected);
+        }
+      }
+      const source = new Source();
+
+      const chunks: Buffer[] = [];
+      let error;
+      try {
+        for await (const chunk of new BulkLoadPayload(request, source)) {
+          chunks.push(chunk);
+        }
+      } catch (err) {
+        error = err;
+      }
+      assert.strictEqual(error, expected);
+      assert.lengthOf(chunks, 0);
+    });
+
     it('takes its error listener off an event-emitting source once the rows are read', async function() {
       const request = new BulkLoad('tablename', undefined, connectionOptions, { }, () => {});
       request.addColumn('id', TYPES.Int, { nullable: false });


### PR DESCRIPTION
## Problem

`RowTransform` pushes COLMETADATA, every row token, every cell's length prefix and every data chunk downstream as its own buffer. A bulk load of small rows therefore reaches the packetizer as many tiny chunks per row, and each row passes through `Readable.from(rows)`, `pipe`, a `Transform` with a `nextTick` callback, that transform's async iterator, and `Readable.from(payload)` before it gets there.

## Change

`RowTransform` is replaced by `BulkLoad.serializeRows(iterator)`, an async generator. It writes COLMETADATA, a ROW token per row, and the DONE token into one `WritableTrackingBuffer` that lives for the whole bulk load, and yields the buffer's contents:

- once it holds a chunk's worth, `WritableTrackingBuffer.CHUNK_SIZE` (8 KB), checked after every cell so that a wide row of large cells goes downstream as it is serialized, or
- as soon as an asynchronous row source goes idle.

`BulkLoadPayload` takes the rows, obtains their iterator, and returns that generator, so the bulk load payload reaches the outgoing message the way RPC payloads do: `Readable.from(payload).pipe(message)`. The `Readable.from(rows).pipe(transform)` plumbing in `execBulkLoad`, and the error handlers wired between the two streams, are gone, and so is `streamingMode`, which only existed to keep the transform open for rows written after the call.

Rows from a synchronous source (an array, a generator) are serialized without touching the event loop in between: `iterator.next()` returns a plain result and nothing is awaited until the next chunk is yielded. Rows from an asynchronous source are awaited one at a time; each `next()` is raced against a `setImmediate` so that, when the source waits on something, what has accumulated goes downstream instead of being held back until 8 KB have arrived. The immediate is armed once per stall, not once per row.

Behaviour changes that fall out of pulling rows instead of piping them:

- **A bulk load with no rows now works.** COLMETADATA is written before the rows are read, so an empty source sends COLMETADATA followed by DONE. On `master` the transform wrote COLMETADATA lazily before the first row, so an empty bulk load sent only DONE, which SQL Server rejects with "While reading current row from host, a premature end-of-message was encountered". A unit test pins the bytes and an integration test loads zero rows.
- Rows are not read before the server has accepted the `INSERT BULK` statement. Previously the row source was piped, and pulled up to the stream's high-water mark, as soon as `execBulkLoad` was called.
- A row given as a promise is settled before it is serialized, as `Readable.from` settled a promised element before handing it on. It is waited for the same way a pending read is: the idle flush hands what is already serialized downstream while it is pending, a cancel abandons it, and its rejection fails the bulk load and closes the source.
- The row source is closed (`return()`) when a row fails validation or serialization, when a column fails to write its TYPE_INFO, and when the consumer stops early because the bulk load was canceled. A source that fails while closing does not hide the row error. Previously the source was left dangling.
- A row source that is never read, because the `INSERT BULK` statement was rejected, the bulk load was canceled before it was executed, or the connection is no longer logged in when the rows would be sent, is released: its iterator is returned and a Node stream source is destroyed. On `master` the piped stream was left open in that case.
- A bulk load canceled while its rows are being sent abandons a row read that is pending in the source at that moment, and does not wait for a source stuck in such a read to close, so a source that never delivers that row does not keep the bulk load's resources open. On `master` the transform was destroyed but the pending read stayed pending.
- An `EventEmitter` source (a `Readable`) gets an error listener from the payload while the `INSERT BULK` statement is in flight, so an error it emits before the rows are read is not an unhandled `'error'` event. A `Readable` replays the error through its iterator; an emitter that does not gets it surfaced by the payload, which ends the bulk load with it before the next chunk goes out, even when it arrives once the final chunk is already with the consumer. The payload's listener comes off once the rows have been read or the payload is closed unread. While a source closed early is still closing (its `return()` pending, or a stream still destroying itself), a standalone no-op listener that holds nothing but the source stays on it, so a failure the close reports on a later tick cannot crash the process, and a source that never finishes closing does not keep the payload or the rows alive through it. For a stream the end of its destruction is taken from the completion callback Node's `destroy()` accepts, which runs once `_destroy` has called back, deferred construction included, the one signal every stream gives (one created with `emitClose: false` emits nothing about a clean destruction); nothing on the stream is touched. A stream that was destroyed before is not destroyed again; its `closed` flag is watched on a backing-off timer that does not keep the process alive, and its `'close'` and `'error'` events, when it has them, let go of it sooner.

The bytes for a bulk load with rows are unchanged: COLMETADATA, rows and DONE are written in the same order, and large values are still referenced rather than copied. A unit test serializes 300 rows of `int`, nullable `nvarchar` and `varbinary` (values above and below the by-reference threshold) once per row through the same `generate*` methods and once through the generator, from an array and from an async source, and asserts the byte streams are identical.

One observable difference on the error path: when a row fails, rows serialized before it that were still coalescing in the buffer are dropped rather than having already been pushed downstream. The bulk load is aborted either way, so nothing downstream depends on those bytes, and a failed row's partial bytes never leave the buffer. A unit test pins this.

`rowToPacketTransform` no longer exists. It was `@private`, and there was no supported way to feed it rows directly.

## Measurements

Serializer in isolation, in the pipeline shape `makeRequest` uses (rows → serializer → `Readable.from(payload)` → sink), 200,000 rows from an array, against `master`'s transform and against the first version of this PR (the same transform, coalescing into 8 KB chunks):

| rows | `master` | transform, coalescing | generator |
|---|---|---|---|
| `int`, `nvarchar(50)`, `float` | ~490k rows/s | ~490–520k rows/s | ~790–860k rows/s |
| 40 × `int` | ~77k rows/s | ~136–146k rows/s | ~154–158k rows/s |

End to end against SQL Server 2022, 50 bulk loads of 10,000 rows each:

| source | `master` | transform, coalescing | generator |
|---|---|---|---|
| one `int` column, array | ~166k rows/s | ~180k rows/s | ~200–210k rows/s |
| three columns, array | ~139k rows/s | ~151k rows/s | ~166k rows/s |
| three columns, async generator | | ~141–146k rows/s | ~125–135k rows/s |

The async-source case is slower by about a microsecond per row: that is the `Promise.race` for the idle flush. Without it (flush only at 8 KB) async sources reach ~141–157k rows/s and the integration suite still passes, but the fake-server cancellation tests in `connection-cancel-test.ts` deadlock, because their row source waits for a server response to bytes that never left the buffer. That ordering guarantee is kept. For real asynchronous sources (files, cursors, network) the cost is noise next to the source itself.

Event-loop starvation was checked as well: for a synchronous source, both the transform pipeline and the generator are driven by microtasks and `nextTick` until socket backpressure forces a turn, so neither yields to the loop between rows on its own. Measured on a 500,000-row array load, the distribution of gaps between event-loop turns is the same for both (99th percentile 3–4 ms, a couple of hundred gaps over 1 ms, one or two over 10 ms, a maximum of 50–75 ms that is garbage collection of the row array and shows up identically with a forced turn every 1 MB of output).

The wide-row case is still dominated by the per-cell `generateParameterLength`/`generateParameterData` allocations, which #1774 removes; the two changes compound.

## Validation

- New unit tests: rows are handed downstream in chunks of at most `CHUNK_SIZE` and far fewer than one per row; a bulk load with no rows sends COLMETADATA and DONE, and the shorter DONE of TDS versions before 7.2; rows given as objects serialize the same as rows given as arrays; rows given as promises serialize the same as plain rows, what is already serialized goes downstream while a promised row is pending, and a promised row's rejection fails the bulk load and closes the source; a `text` value is written behind its pointer and timestamp, and a null one as a null pointer; rows are not read before the bytes are consumed; a row that fills a chunk by itself is handed downstream before the next row is read, and a wide row hands a chunk downstream before its last cell is serialized; a single small row goes downstream once an async source goes idle; the output equals per-row serialization byte for byte, from an array and from an async source; nothing goes downstream after a row fails and the source is closed; the source, synchronous or not, and with or without a `return()`, is closed when the consumer stops early, when a row fails, and when a column fails to write its TYPE_INFO; a source that fails to close does not hide the row error, and is reported when there is none; a synchronous source is serialized without an event-loop turn; an iterable with an `undefined` `Symbol.asyncIterator` property is accepted; an error a `Readable` source emits before the rows are read comes out of the iteration, and so does one an `EventEmitter` source emits without failing its iterator, after its last row, or once its final chunk is with the consumer; the error listener comes off an `EventEmitter` source after the load, and an unrelated `on` method is never called; only a stream source closed unread is destroyed, and closing never throws even when a synchronous source's `finally` does or the stream's `_destroy` cannot be replaced.
- New unit tests for the cancel and release paths: a pending row read is abandoned when the bulk load is canceled; a bulk load canceled with a chunk already downstream closes without waiting for a source stuck in a read; a source whose close reports an error on a later tick stays guarded until that close has settled, whether it was being read or is closed unread, and until both its iterator and its destruction have finished when both are late; the guard on a stream closed unread comes off on `'close'`, on `'error'`, when `destroy()` throws, once its destruction has completed for a stream created with `emitClose: false` (synchronously, later, only after an asynchronous construction, or when its owner had already started destroying it), and for a stream that had already failed once its `'error'` has had its turn, with nothing of the payload left on it; the payload's cancel listener comes off the bulk load once the rows are read or the payload is closed unread; a bulk load whose connection is not logged in when its rows would be sent releases its source.
- New integration tests: a bulk load with no rows completes with a row count of zero; a bulk load whose `INSERT BULK` statement is rejected, one canceled immediately after `execBulkLoad`, and one canceled before `execBulkLoad` all destroy their `Readable` source by the time the callback runs.
- Unit suite: 517 passing. Full integration suite against SQL Server 2022 passes except the pre-existing environment-only `should not leave any dangling sockets after connection timeout`. Lint and typecheck clean.

Targets `master` directly; it only needs #1773's `WritableTrackingBuffer`, which is already there. #1774 changes the cell serialization in the same place (cells are written through `writeValue`), so whichever of the two lands second gets a small merge of `serializeRows`; the resolution is mechanical (keep the generator, write cells through `writeValue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fxv5h4UMCGJEpjgCKcAxug