### PR TITLE
perf: parse incoming messages with a push based token parser

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -37,6 +37,7 @@ import { connectInParallel, connectInSequence } from './connector';
 import { name as libraryName } from './library';
 import { versions } from './tds-versions';
 import Message from './message';
+import IncomingMessage from './incoming-message';
 import { type Metadata } from './metadata-parser';
 import { createNTLMRequest } from './ntlm';
 import { ColumnEncryptionAzureKeyVaultProvider } from './always-encrypted/keystore-provider-azure-key-vault';
@@ -2215,7 +2216,7 @@ class Connection extends EventEmitter {
   /**
    * @private
    */
-  createTokenStreamParser(message: Message, handler: TokenHandler) {
+  createTokenStreamParser(message: IncomingMessage, handler: TokenHandler) {
     return new TokenStreamParser(message, this.debug, handler, this.config.options);
   }
 

--- a/src/incoming-message-stream.ts
+++ b/src/incoming-message-stream.ts
@@ -2,18 +2,22 @@ import BufferList from 'bl';
 import { Transform } from 'stream';
 
 import Debug from './debug';
-import Message from './message';
+import IncomingMessage from './incoming-message';
 import { Packet, HEADER_LENGTH } from './packet';
 import { ConnectionError } from './errors';
 
 /**
   IncomingMessageStream
-  Transform received TDS data into individual IncomingMessage streams.
+  Transform received TDS data into individual IncomingMessage objects.
+
+  The data of each message is written to the message as its packets arrive.
+  Processing of further packets is held back while a message's consumer
+  cannot accept more data, which propagates as backpressure to the socket.
 */
 class IncomingMessageStream extends Transform {
   declare debug: Debug;
   declare bl: any;
-  declare currentMessage: Message | undefined;
+  declare currentMessage: IncomingMessage | undefined;
 
   constructor(debug: Debug) {
     super({ readableObjectMode: true });
@@ -22,26 +26,6 @@ class IncomingMessageStream extends Transform {
 
     this.currentMessage = undefined;
     this.bl = new BufferList();
-  }
-
-  pause() {
-    super.pause();
-
-    if (this.currentMessage) {
-      this.currentMessage.pause();
-    }
-
-    return this;
-  }
-
-  resume() {
-    super.resume();
-
-    if (this.currentMessage) {
-      this.currentMessage.resume();
-    }
-
-    return this;
   }
 
   processBufferedData(callback: (err?: ConnectionError) => void) {
@@ -53,40 +37,38 @@ class IncomingMessageStream extends Transform {
         return callback(new ConnectionError('Unable to process incoming packet'));
       }
 
-      if (this.bl.length >= length) {
-        const data = this.bl.slice(0, length);
-        this.bl.consume(length);
-
-        // TODO: Get rid of creating `Packet` instances here.
-        const packet = new Packet(data);
-        this.debug.packet('Received', packet);
-        this.debug.data(packet);
-
-        let message = this.currentMessage;
-        if (message === undefined) {
-          this.currentMessage = message = new Message({ type: packet.type(), resetConnection: false });
-          this.push(message);
-        }
-
-        if (packet.isLast()) {
-          // Wait until the current message was fully processed before we
-          // continue processing any remaining messages.
-          message.once('end', () => {
-            this.currentMessage = undefined;
-            this.processBufferedData(callback);
-          });
-          message.end(packet.data());
-          return;
-        } else if (!message.write(packet.data())) {
-          // If too much data is buffering up in the
-          // current message, wait for it to drain.
-          message.once('drain', () => {
-            this.processBufferedData(callback);
-          });
-          return;
-        }
-      } else {
+      if (this.bl.length < length) {
         break;
+      }
+
+      const data = this.bl.slice(0, length);
+      this.bl.consume(length);
+
+      // TODO: Get rid of creating `Packet` instances here.
+      const packet = new Packet(data);
+      this.debug.packet('Received', packet);
+      this.debug.data(packet);
+
+      let message = this.currentMessage;
+      if (message === undefined) {
+        this.currentMessage = message = new IncomingMessage({ type: packet.type() });
+        this.push(message);
+      }
+
+      const accepted = message.write(packet.data());
+
+      if (packet.isLast()) {
+        this.currentMessage = undefined;
+        message.end();
+      }
+
+      if (!accepted) {
+        // The message's consumer cannot accept more data right now. Wait
+        // until it can before processing any further packets.
+        message.onDrain = () => {
+          this.processBufferedData(callback);
+        };
+        return;
       }
     }
 

--- a/src/incoming-message.ts
+++ b/src/incoming-message.ts
@@ -1,0 +1,185 @@
+import { Readable } from 'stream';
+
+/**
+ * A consumer of an incoming message's data that receives it synchronously,
+ * as it arrives.
+ */
+export interface MessageSink {
+  /**
+   * Receives a chunk of the message's data. Returns `false` if no more
+   * data should be delivered until the sink calls `IncomingMessage.continueSink`.
+   */
+  push(data: Buffer): boolean;
+
+  /**
+   * Called once all of the message's data has been delivered.
+   */
+  end(): void;
+}
+
+/**
+ * An incoming TDS message.
+ *
+ * The message's data can be consumed in one of two ways:
+ *
+ * - as a regular `Readable` stream (e.g. via `for await`), in which case
+ *   the data is buffered by the stream until it is read, or
+ * - by attaching a `MessageSink`, which receives every chunk synchronously
+ *   as it is written to the message, without any buffering or stream
+ *   machinery in between.
+ */
+class IncomingMessage extends Readable {
+  declare type: number;
+  declare resetConnection: boolean;
+
+  declare sink: MessageSink | undefined;
+  /**
+   * Whether the sink has asked for delivery to be suspended.
+   */
+  declare stalled: boolean;
+  /**
+   * Whether all of the message's data has been written.
+   */
+  declare ended: boolean;
+  declare endDelivered: boolean;
+  /**
+   * Called when the message can accept more data after `write` returned
+   * `false`.
+   */
+  declare onDrain: (() => void) | undefined;
+  /**
+   * Whether buffered data is currently being delivered to the sink.
+   */
+  declare flushing: boolean;
+
+  constructor({ type }: { type: number }) {
+    super();
+
+    this.type = type;
+    this.resetConnection = false;
+    this.sink = undefined;
+    this.stalled = false;
+    this.ended = false;
+    this.endDelivered = false;
+    this.onDrain = undefined;
+    this.flushing = false;
+  }
+
+  _read() {
+    // While buffered data is being delivered to the sink, the stream's
+    // buffer draining must not let the writer add data, as it would be
+    // delivered ahead of what is still buffered.
+    if (!this.flushing) {
+      this.notifyDrain();
+    }
+  }
+
+  notifyDrain() {
+    const onDrain = this.onDrain;
+    if (onDrain !== undefined) {
+      this.onDrain = undefined;
+      onDrain();
+    }
+  }
+
+  /**
+   * Adds data to the message. Returns `false` if no more data should be
+   * written until `onDrain` is called.
+   */
+  write(data: Buffer): boolean {
+    const sink = this.sink;
+    if (sink !== undefined && !this.stalled) {
+      if (sink.push(data)) {
+        return true;
+      }
+
+      this.stalled = true;
+      return false;
+    }
+
+    // No sink yet, or the sink asked for delivery to be suspended while
+    // data was still buffered: buffer the data, and hold the writer back
+    // while the sink is stalled.
+    const accepted = this.push(data);
+    return accepted && !this.stalled;
+  }
+
+  /**
+   * Marks the message's data as complete.
+   */
+  end() {
+    this.ended = true;
+
+    if (this.sink !== undefined) {
+      if (!this.stalled) {
+        this.endDelivered = true;
+        this.sink.end();
+      }
+    } else {
+      this.push(null);
+    }
+  }
+
+  /**
+   * Attaches a sink that receives the message's data. Data that was already
+   * buffered is delivered to the sink right away.
+   */
+  attach(sink: MessageSink) {
+    if (this.sink !== undefined) {
+      throw new Error('A sink is already attached to this message');
+    }
+
+    this.sink = sink;
+    this.flushToSink();
+
+    if (!this.stalled) {
+      // The writer may have been held back by the stream's buffer.
+      this.notifyDrain();
+    }
+  }
+
+  /**
+   * Delivers buffered data (and the end of the message) to the sink.
+   */
+  flushToSink() {
+    const sink = this.sink!;
+
+    this.flushing = true;
+    try {
+      let chunk;
+      while ((chunk = this.read()) !== null) {
+        if (!sink.push(chunk)) {
+          this.stalled = true;
+          return;
+        }
+      }
+
+      if (this.ended && !this.endDelivered) {
+        this.endDelivered = true;
+        sink.end();
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  /**
+   * To be called by the sink once it can accept more data after its `push`
+   * returned `false`.
+   */
+  continueSink() {
+    if (!this.stalled) {
+      return;
+    }
+
+    this.stalled = false;
+    this.flushToSink();
+
+    if (!this.stalled) {
+      this.notifyDrain();
+    }
+  }
+}
+
+export default IncomingMessage;
+module.exports = IncomingMessage;

--- a/src/message-io.ts
+++ b/src/message-io.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from 'events';
 import Debug from './debug';
 
 import Message from './message';
+import IncomingMessage from './incoming-message';
 import { TYPE } from './packet';
 
 import IncomingMessageStream from './incoming-message-stream';
@@ -32,7 +33,7 @@ class MessageIO extends EventEmitter {
     encrypted: Duplex;
   };
 
-  declare incomingMessageIterator: AsyncIterableIterator<Message>;
+  declare incomingMessageIterator: AsyncIterableIterator<IncomingMessage>;
 
   constructor(socket: Socket, packetSize: number, debug: Debug) {
     super();
@@ -192,7 +193,7 @@ class MessageIO extends EventEmitter {
   /**
    * Read the next incoming message from the socket.
    */
-  async readMessage(): Promise<Message> {
+  async readMessage(): Promise<IncomingMessage> {
     const result = await this.incomingMessageIterator.next();
 
     if (result.done) {

--- a/src/metadata-parser.ts
+++ b/src/metadata-parser.ts
@@ -1,5 +1,5 @@
 import { Collation } from './collation';
-import Parser, { type ParserOptions } from './token/stream-parser';
+import { type ParserOptions } from './token/stream-parser';
 import { TYPE, type DataType } from './data-type';
 import { type CryptoMetadata } from './always-encrypted/types';
 
@@ -354,30 +354,8 @@ function readMetadata(buf: Buffer, offset: number, options: ParserOptions): Resu
   }
 }
 
-function metadataParse(parser: Parser, options: ParserOptions, callback: (metadata: Metadata) => void) {
-  (async () => {
-    while (true) {
-      let result;
-      try {
-        result = readMetadata(parser.buffer, parser.position, options);
-      } catch (err: any) {
-        if (err instanceof NotEnoughDataError) {
-          await parser.waitForChunk();
-          continue;
-        }
-
-        throw err;
-      }
-
-      parser.position = result.offset;
-      return callback(result.value);
-    }
-  })();
-}
-
-export default metadataParse;
 export { readCollation, readMetadata };
 
-module.exports = metadataParse;
+module.exports = {};
 module.exports.readCollation = readCollation;
 module.exports.readMetadata = readMetadata;

--- a/src/token/colmetadata-token-parser.ts
+++ b/src/token/colmetadata-token-parser.ts
@@ -2,7 +2,7 @@ import { readMetadata, type Metadata } from '../metadata-parser';
 
 import Parser, { type ParserOptions } from './stream-parser';
 import { ColMetadataToken } from './token';
-import { NotEnoughDataError, Result, readBVarChar, readUInt16LE, readUInt8, readUsVarChar } from './helpers';
+import { Result, readBVarChar, readUInt16LE, readUInt8, readUsVarChar } from './helpers';
 
 export interface ColumnMetadata extends Metadata {
   /**
@@ -76,49 +76,19 @@ function readColumn(buf: Buffer, offset: number, options: ParserOptions, index: 
   }, offset);
 }
 
-async function colMetadataParser(parser: Parser): Promise<ColMetadataToken> {
+/**
+ * Parses a column metadata token. Not resumable: if the buffered data runs
+ * out, parsing is retried from the start of the token.
+ */
+function colMetadataParser(parser: Parser): ColMetadataToken {
   let columnCount;
-
-  while (true) {
-    let offset;
-
-    try {
-      ({ offset, value: columnCount } = readUInt16LE(parser.buffer, parser.position));
-    } catch (err) {
-      if (err instanceof NotEnoughDataError) {
-        await parser.waitForChunk();
-        continue;
-      }
-
-      throw err;
-    }
-
-    parser.position = offset;
-    break;
-  }
+  ({ offset: parser.position, value: columnCount } = readUInt16LE(parser.buffer, parser.position));
 
   const columns: ColumnMetadata[] = [];
   for (let i = 0; i < columnCount; i++) {
-    while (true) {
-      let column: ColumnMetadata;
-      let offset;
-
-      try {
-        ({ offset, value: column } = readColumn(parser.buffer, parser.position, parser.options, i));
-      } catch (err: any) {
-        if (err instanceof NotEnoughDataError) {
-          await parser.waitForChunk();
-          continue;
-        }
-
-        throw err;
-      }
-
-      parser.position = offset;
-      columns.push(column);
-
-      break;
-    }
+    let column: ColumnMetadata;
+    ({ offset: parser.position, value: column } = readColumn(parser.buffer, parser.position, parser.options, i));
+    columns.push(column);
   }
 
   return new ColMetadataToken(columns);

--- a/src/token/nbcrow-token-parser.ts
+++ b/src/token/nbcrow-token-parser.ts
@@ -1,102 +1,43 @@
 // s2.2.7.13 (introduced in TDS 7.3.B)
 
 import Parser from './stream-parser';
-import { type ColumnMetadata } from './colmetadata-token-parser';
-
 import { NBCRowToken } from './token';
-import * as iconv from 'iconv-lite';
-
-import { isPLPStream, readPLPStream, readValue } from '../value-parser';
 import { NotEnoughDataError } from './helpers';
 
-interface Column {
-  value: unknown;
-  metadata: ColumnMetadata;
-}
-
-async function nbcRowParser(parser: Parser): Promise<NBCRowToken> {
+/**
+ * Parses a NBC (null bitmap compressed) row token. Resumable in the same
+ * way as the row token parser.
+ */
+function nbcRowParser(parser: Parser): NBCRowToken {
   const colMetadata = parser.colMetadata;
-  const columns: Column[] = [];
-  const bitmap: boolean[] = [];
-  const bitmapByteLength = Math.ceil(colMetadata.length / 8);
+  const state = parser.rowState();
 
-  while (parser.buffer.length - parser.position < bitmapByteLength) {
-    await parser.waitForChunk();
-  }
+  let bitmap = state.bitmap;
+  if (bitmap === undefined) {
+    const bitmapByteLength = Math.ceil(colMetadata.length / 8);
 
-  const bytes = parser.buffer.slice(parser.position, parser.position + bitmapByteLength);
-  parser.position += bitmapByteLength;
-
-  for (let i = 0, len = bytes.length; i < len; i++) {
-    const byte = bytes[i];
-
-    bitmap.push(byte & 0b1 ? true : false);
-    bitmap.push(byte & 0b10 ? true : false);
-    bitmap.push(byte & 0b100 ? true : false);
-    bitmap.push(byte & 0b1000 ? true : false);
-    bitmap.push(byte & 0b10000 ? true : false);
-    bitmap.push(byte & 0b100000 ? true : false);
-    bitmap.push(byte & 0b1000000 ? true : false);
-    bitmap.push(byte & 0b10000000 ? true : false);
-  }
-
-  for (let i = 0; i < colMetadata.length; i++) {
-    const metadata = colMetadata[i];
-    if (bitmap[i]) {
-      columns.push({ value: null, metadata });
-      continue;
+    if (parser.buffer.length - parser.position < bitmapByteLength) {
+      throw new NotEnoughDataError(parser.position + bitmapByteLength);
     }
 
-    while (true) {
-      if (isPLPStream(metadata)) {
-        const chunks = await readPLPStream(parser);
+    bitmap = state.bitmap = parser.buffer.slice(parser.position, parser.position + bitmapByteLength);
+    parser.position += bitmapByteLength;
+    parser.commit();
+  }
 
-        if (chunks === null) {
-          columns.push({ value: chunks, metadata });
-        } else if (metadata.type.name === 'NVarChar' || metadata.type.name === 'Xml') {
-          columns.push({ value: Buffer.concat(chunks).toString('ucs2'), metadata });
-        } else if (metadata.type.name === 'VarChar') {
-          columns.push({ value: iconv.decode(Buffer.concat(chunks), metadata.collation?.codepage ?? 'utf8'), metadata });
-        } else if (metadata.type.name === 'VarBinary' || metadata.type.name === 'UDT') {
-          columns.push({ value: Buffer.concat(chunks), metadata });
-        }
-      } else {
-        let result;
-        try {
-          result = readValue(parser.buffer, parser.position, metadata, parser.options);
-        } catch (err) {
-          if (err instanceof NotEnoughDataError) {
-            await parser.waitForChunk();
-            continue;
-          }
+  while (state.index < colMetadata.length) {
+    const index = state.index;
 
-          throw err;
-        }
-
-        parser.position = result.offset;
-        columns.push({ value: result.value, metadata });
-      }
-
-      break;
+    if (bitmap[index >> 3] & (1 << (index & 7))) {
+      state.skipColumn(colMetadata[index]);
+    } else {
+      state.readColumn(parser, colMetadata[index]);
     }
   }
 
-  if (parser.options.useColumnNames) {
-    const columnsMap: { [key: string]: Column } = Object.create(null);
-
-    columns.forEach((column) => {
-      const colName = column.metadata.colName;
-      if (columnsMap[colName] == null) {
-        columnsMap[colName] = column;
-      }
-    });
-
-    return new NBCRowToken(columnsMap);
-  } else {
-    return new NBCRowToken(columns);
-  }
+  parser.tokenState = undefined;
+  return new NBCRowToken(state.finish(parser.options));
 }
-
 
 export default nbcRowParser;
 module.exports = nbcRowParser;

--- a/src/token/returnvalue-token-parser.ts
+++ b/src/token/returnvalue-token-parser.ts
@@ -1,84 +1,73 @@
 // s2.2.7.16
 
 import Parser from './stream-parser';
-
 import { ReturnValueToken } from './token';
 
-import { readMetadata } from '../metadata-parser';
-import { isPLPStream, readPLPStream, readValue } from '../value-parser';
-import { NotEnoughDataError, readBVarChar, readUInt16LE, readUInt8 } from './helpers';
-import * as iconv from 'iconv-lite';
+import { readMetadata, type Metadata } from '../metadata-parser';
+import { isPLPStream, readPLPValue, readValue, type PLPState } from '../value-parser';
+import { readBVarChar, readUInt16LE, readUInt8 } from './helpers';
 
-async function returnParser(parser: Parser): Promise<ReturnValueToken> {
-  let paramName;
-  let paramOrdinal;
-  let metadata;
+/**
+ * The progress of a return value token being parsed: its header has been
+ * read, its value is being read.
+ */
+export class ReturnValueState {
+  declare paramOrdinal: number;
+  declare paramName: string;
+  declare metadata: Metadata;
+  /**
+   * The progress of the value, if it is a PLP value.
+   */
+  declare plp: PLPState | undefined;
 
-  while (true) {
+  constructor(paramOrdinal: number, paramName: string, metadata: Metadata) {
+    this.paramOrdinal = paramOrdinal;
+    this.paramName = paramName;
+    this.metadata = metadata;
+    this.plp = undefined;
+  }
+}
+
+/**
+ * Parses a return value token. Resumable: once the header has been read,
+ * it is kept on the parser while the value is read.
+ */
+function returnParser(parser: Parser): ReturnValueToken {
+  let state = parser.tokenState;
+
+  if (!(state instanceof ReturnValueState)) {
     const buf = parser.buffer;
-    let offset = parser.position;
 
-    try {
-      ({ offset, value: paramOrdinal } = readUInt16LE(buf, offset));
-      ({ offset, value: paramName } = readBVarChar(buf, offset));
-      // status
-      ({ offset } = readUInt8(buf, offset));
-      ({ offset, value: metadata } = readMetadata(buf, offset, parser.options));
+    const { offset: ordinalEnd, value: paramOrdinal } = readUInt16LE(buf, parser.position);
+    const { offset: nameEnd, value: name } = readBVarChar(buf, ordinalEnd);
+    // status
+    const { offset: statusEnd } = readUInt8(buf, nameEnd);
+    const { offset, value: metadata } = readMetadata(buf, statusEnd, parser.options);
 
-      if (paramName.charAt(0) === '@') {
-        paramName = paramName.slice(1);
-      }
-    } catch (err) {
-      if (err instanceof NotEnoughDataError) {
-        await parser.waitForChunk();
-        continue;
-      }
-
-      throw err;
-    }
+    const paramName = name.charAt(0) === '@' ? name.slice(1) : name;
 
     parser.position = offset;
-    break;
+    parser.commit();
+
+    state = parser.tokenState = new ReturnValueState(paramOrdinal, paramName, metadata);
   }
+
+  const metadata = state.metadata;
 
   let value;
-  while (true) {
-    const buf = parser.buffer;
-    let offset = parser.position;
-
-    if (isPLPStream(metadata)) {
-      const chunks = await readPLPStream(parser);
-
-      if (chunks === null) {
-        value = chunks;
-      } else if (metadata.type.name === 'NVarChar' || metadata.type.name === 'Xml') {
-        value = Buffer.concat(chunks).toString('ucs2');
-      } else if (metadata.type.name === 'VarChar') {
-        value = iconv.decode(Buffer.concat(chunks), metadata.collation?.codepage ?? 'utf8');
-      } else if (metadata.type.name === 'VarBinary' || metadata.type.name === 'UDT') {
-        value = Buffer.concat(chunks);
-      }
-    } else {
-      try {
-        ({ value, offset } = readValue(buf, offset, metadata, parser.options));
-      } catch (err) {
-        if (err instanceof NotEnoughDataError) {
-          await parser.waitForChunk();
-          continue;
-        }
-
-        throw err;
-      }
-
-      parser.position = offset;
-    }
-
-    break;
+  if (isPLPStream(metadata)) {
+    value = readPLPValue(parser, state, metadata);
+  } else {
+    const result = readValue(parser.buffer, parser.position, metadata, parser.options);
+    parser.position = result.offset;
+    value = result.value;
   }
 
+  parser.tokenState = undefined;
+
   return new ReturnValueToken({
-    paramOrdinal: paramOrdinal,
-    paramName: paramName,
+    paramOrdinal: state.paramOrdinal,
+    paramName: state.paramName,
     metadata: metadata,
     value: value
   });
@@ -86,3 +75,4 @@ async function returnParser(parser: Parser): Promise<ReturnValueToken> {
 
 export default returnParser;
 module.exports = returnParser;
+module.exports.ReturnValueState = ReturnValueState;

--- a/src/token/row-state.ts
+++ b/src/token/row-state.ts
@@ -1,0 +1,87 @@
+import Parser, { type ParserOptions } from './stream-parser';
+import { type ColumnMetadata } from './colmetadata-token-parser';
+import { isPLPStream, readPLPValue, readValue, type PLPState } from '../value-parser';
+
+export interface Column {
+  value: unknown;
+  metadata: ColumnMetadata;
+}
+
+/**
+ * The progress of a row or NBC row token being parsed.
+ *
+ * A row can span many packets, so instead of parsing it from the start
+ * again whenever more data arrives, the columns parsed so far are kept
+ * here, and the parser's position is committed after every column (and
+ * after every chunk of a PLP value).
+ */
+export class RowState {
+  declare columns: Column[];
+  /**
+   * The index of the next column to parse.
+   */
+  declare index: number;
+  /**
+   * The progress of the PLP value of column `index`, if any.
+   */
+  declare plp: PLPState | undefined;
+  /**
+   * The null bitmap of an NBC row.
+   */
+  declare bitmap: Buffer | undefined;
+
+  constructor(columnCount: number) {
+    this.columns = new Array(columnCount);
+    this.index = 0;
+    this.plp = undefined;
+    this.bitmap = undefined;
+  }
+
+  /**
+   * Reads the value of the next column from the parser and commits the
+   * parser's position past it.
+   */
+  readColumn(parser: Parser, metadata: ColumnMetadata) {
+    let value;
+    if (isPLPStream(metadata)) {
+      value = readPLPValue(parser, this, metadata);
+    } else {
+      const result = readValue(parser.buffer, parser.position, metadata, parser.options);
+      parser.position = result.offset;
+      value = result.value;
+    }
+
+    this.columns[this.index] = { value, metadata };
+    this.index += 1;
+    parser.commit();
+  }
+
+  /**
+   * Records the next column as `NULL` (for NBC rows).
+   */
+  skipColumn(metadata: ColumnMetadata) {
+    this.columns[this.index] = { value: null, metadata };
+    this.index += 1;
+  }
+
+  /**
+   * The parsed columns, as an array or, with `useColumnNames`, as a map by
+   * column name.
+   */
+  finish(options: ParserOptions): Column[] | { [key: string]: Column } {
+    if (!options.useColumnNames) {
+      return this.columns;
+    }
+
+    const columnsMap: { [key: string]: Column } = Object.create(null);
+
+    for (const column of this.columns) {
+      const colName = column.metadata.colName;
+      if (columnsMap[colName] == null) {
+        columnsMap[colName] = column;
+      }
+    }
+
+    return columnsMap;
+  }
+}

--- a/src/token/row-token-parser.ts
+++ b/src/token/row-token-parser.ts
@@ -1,71 +1,23 @@
 // s2.2.7.17
 
 import Parser from './stream-parser';
-import { type ColumnMetadata } from './colmetadata-token-parser';
-
 import { RowToken } from './token';
-import * as iconv from 'iconv-lite';
 
-import { isPLPStream, readPLPStream, readValue } from '../value-parser';
-import { NotEnoughDataError } from './helpers';
+/**
+ * Parses a row token. Resumable: if the buffered data runs out, the
+ * columns parsed so far are kept on the parser and parsing continues with
+ * the next column once more data is available.
+ */
+function rowParser(parser: Parser): RowToken {
+  const colMetadata = parser.colMetadata;
+  const state = parser.rowState();
 
-interface Column {
-  value: unknown;
-  metadata: ColumnMetadata;
-}
-
-async function rowParser(parser: Parser): Promise<RowToken> {
-  const columns: Column[] = [];
-
-  for (const metadata of parser.colMetadata) {
-    while (true) {
-      if (isPLPStream(metadata)) {
-        const chunks = await readPLPStream(parser);
-
-        if (chunks === null) {
-          columns.push({ value: chunks, metadata });
-        } else if (metadata.type.name === 'NVarChar' || metadata.type.name === 'Xml') {
-          columns.push({ value: Buffer.concat(chunks).toString('ucs2'), metadata });
-        } else if (metadata.type.name === 'VarChar') {
-          columns.push({ value: iconv.decode(Buffer.concat(chunks), metadata.collation?.codepage ?? 'utf8'), metadata });
-        } else if (metadata.type.name === 'VarBinary' || metadata.type.name === 'UDT') {
-          columns.push({ value: Buffer.concat(chunks), metadata });
-        }
-      } else {
-        let result;
-        try {
-          result = readValue(parser.buffer, parser.position, metadata, parser.options);
-        } catch (err) {
-          if (err instanceof NotEnoughDataError) {
-            await parser.waitForChunk();
-            continue;
-          }
-
-          throw err;
-        }
-
-        parser.position = result.offset;
-        columns.push({ value: result.value, metadata });
-      }
-
-      break;
-    }
+  while (state.index < colMetadata.length) {
+    state.readColumn(parser, colMetadata[state.index]);
   }
 
-  if (parser.options.useColumnNames) {
-    const columnsMap: { [key: string]: Column } = Object.create(null);
-
-    columns.forEach((column) => {
-      const colName = column.metadata.colName;
-      if (columnsMap[colName] == null) {
-        columnsMap[colName] = column;
-      }
-    });
-
-    return new RowToken(columnsMap);
-  } else {
-    return new RowToken(columns);
-  }
+  parser.tokenState = undefined;
+  return new RowToken(state.finish(parser.options));
 }
 
 export default rowParser;

--- a/src/token/stream-parser.ts
+++ b/src/token/stream-parser.ts
@@ -1,7 +1,7 @@
 import Debug from '../debug';
 import { type InternalConnectionOptions } from '../connection';
 
-import { TYPE, ColInfoToken, ColMetadataToken, DoneProcToken, DoneToken, DoneInProcToken, ErrorMessageToken, InfoMessageToken, RowToken, type EnvChangeToken, LoginAckToken, ReturnStatusToken, OrderToken, FedAuthInfoToken, SSPIToken, ReturnValueToken, NBCRowToken, FeatureExtAckToken, TabNameToken, Token } from './token';
+import { TYPE, ColMetadataToken, Token } from './token';
 
 import colInfoParser from './colinfo-token-parser';
 import colMetadataParser, { type ColumnMetadata } from './colmetadata-token-parser';
@@ -13,95 +13,249 @@ import featureExtAckParser from './feature-ext-ack-parser';
 import loginAckParser from './loginack-token-parser';
 import orderParser from './order-token-parser';
 import returnStatusParser from './returnstatus-token-parser';
-import returnValueParser from './returnvalue-token-parser';
+import returnValueParser, { ReturnValueState } from './returnvalue-token-parser';
 import rowParser from './row-token-parser';
+import { RowState } from './row-state';
 import nbcRowParser from './nbcrow-token-parser';
 import sspiParser from './sspi-token-parser';
 import tabNameParser from './tabname-token-parser';
-import { NotEnoughDataError } from './helpers';
+import { NotEnoughDataError, type Result } from './helpers';
 
 export type ParserOptions = Pick<InternalConnectionOptions, 'useUTC' | 'lowerCaseGuids' | 'tdsVersion' | 'useColumnNames' | 'columnNameReplacer' | 'camelCaseColumns'>;
 
+/**
+ * Returned by `parseNext` when the buffered data does not hold a complete
+ * token yet.
+ */
+export const NEED_MORE_DATA: unique symbol = Symbol('NEED_MORE_DATA');
+
+const EMPTY = Buffer.alloc(0);
+
+/**
+ * A push based parser for the tokens of a TDS message.
+ *
+ * Data is added via `push`, and `parseNext` is called repeatedly to parse
+ * one token at a time from the buffered data. A token that is not
+ * completely available yet is retried once more data has been pushed:
+ * the readers throw `NotEnoughDataError`, the parser rewinds to the last
+ * committed position and remembers how much data the reader asked for,
+ * so it will not try again before that much data has been buffered.
+ *
+ * Readers of tokens that can be large (rows) commit their progress via
+ * `commit` and keep their state on the parser (`tokenState`), so that a
+ * row spanning many packets is not parsed from the start again for each
+ * packet.
+ */
 class Parser {
   debug: Debug;
   colMetadata: ColumnMetadata[];
   options: ParserOptions;
 
-  iterator: AsyncIterator<Buffer, any, undefined> | Iterator<Buffer, any, undefined>;
+  /**
+   * The buffered, not yet consumed data.
+   */
   buffer: Buffer;
+  /**
+   * The current read position in `buffer`.
+   */
   position: number;
+  /**
+   * The position to rewind to when the current token cannot be completed
+   * with the buffered data.
+   */
+  committed: number;
+  /**
+   * The buffer length needed before the current token is worth another
+   * attempt, or `0`.
+   */
+  needed: number;
+  /**
+   * The type of the token being parsed when it could not be completed, so
+   * that parsing resumes with the same reader.
+   */
+  pendingType: number | undefined;
 
-  static async *parseTokens(iterable: AsyncIterable<Buffer> | Iterable<Buffer>, debug: Debug, options: ParserOptions, colMetadata: ColumnMetadata[] = []) {
-    const parser = new Parser(iterable, debug, options);
-    parser.colMetadata = colMetadata;
+  /**
+   * The progress of a partially parsed token whose reader resumes rather
+   * than restarts (rows, NBC rows and return values).
+   */
+  tokenState: RowState | ReturnValueState | undefined;
 
-    while (true) {
-      try {
-        await parser.waitForChunk();
-      } catch (err: unknown) {
-        if (parser.position === parser.buffer.length) {
-          return;
-        }
+  constructor(debug: Debug, options: ParserOptions) {
+    this.debug = debug;
+    this.colMetadata = [];
+    this.options = options;
 
-        throw err;
+    this.buffer = EMPTY;
+    this.position = 0;
+    this.committed = 0;
+    this.needed = 0;
+    this.pendingType = undefined;
+    this.tokenState = undefined;
+  }
+
+  /**
+   * Adds data to the parser.
+   */
+  push(chunk: Buffer) {
+    if (this.committed === this.buffer.length) {
+      this.buffer = chunk;
+    } else if (this.committed === 0) {
+      this.buffer = Buffer.concat([this.buffer, chunk]);
+    } else {
+      this.buffer = Buffer.concat([this.buffer.subarray(this.committed), chunk]);
+    }
+
+    if (this.needed > 0) {
+      this.needed -= this.committed;
+    }
+
+    this.position = 0;
+    this.committed = 0;
+  }
+
+  /**
+   * Whether all pushed data has been consumed.
+   */
+  isEmpty() {
+    return this.pendingType === undefined && this.committed === this.buffer.length;
+  }
+
+  /**
+   * Marks the current position as consumed: if the current token cannot be
+   * completed, parsing later resumes from here rather than from the start
+   * of the token.
+   */
+  commit() {
+    this.committed = this.position;
+  }
+
+  /**
+   * The state of the row (or NBC row) token being parsed, starting a new
+   * one if none is in progress.
+   */
+  rowState(): RowState {
+    const state = this.tokenState;
+    if (state instanceof RowState) {
+      return state;
+    }
+
+    return this.tokenState = new RowState(this.colMetadata.length);
+  }
+
+  /**
+   * Parses the next token from the buffered data.
+   *
+   * Returns the token, `undefined` for tokens that do not produce a value,
+   * or `NEED_MORE_DATA` if the buffered data does not hold a complete token.
+   */
+  parseNext(): Token | undefined | typeof NEED_MORE_DATA {
+    if (this.buffer.length < this.needed) {
+      return NEED_MORE_DATA;
+    }
+    this.needed = 0;
+
+    let type = this.pendingType;
+    if (type === undefined) {
+      if (this.position >= this.buffer.length) {
+        return NEED_MORE_DATA;
       }
 
-      while (parser.buffer.length >= parser.position + 1) {
-        const type = parser.buffer.readUInt8(parser.position);
-        parser.position += 1;
+      type = this.buffer[this.position];
+      this.position += 1;
+      this.committed = this.position;
+      this.pendingType = type;
+    }
 
-        const token = parser.readToken(type);
+    let token;
+    try {
+      token = this.readToken(type);
+    } catch (err) {
+      if (err instanceof NotEnoughDataError) {
+        this.needed = err.byteCount;
+        this.position = this.committed;
+        return NEED_MORE_DATA;
+      }
+
+      throw err;
+    }
+
+    this.pendingType = undefined;
+    this.committed = this.position;
+    return token;
+  }
+
+  /**
+   * Parses all tokens of a complete message, in one go. Meant for tests.
+   */
+  static async *parseTokens(iterable: AsyncIterable<Buffer> | Iterable<Buffer>, debug: Debug, options: ParserOptions, colMetadata: ColumnMetadata[] = []): AsyncGenerator<Token, void, unknown> {
+    const parser = new Parser(debug, options);
+    parser.colMetadata = colMetadata;
+
+    for await (const chunk of iterable) {
+      parser.push(chunk);
+
+      while (true) {
+        const token = parser.parseNext();
+        if (token === NEED_MORE_DATA) {
+          break;
+        }
+
         if (token !== undefined) {
           yield token;
         }
       }
     }
+
+    if (!parser.isEmpty()) {
+      throw new Error('unexpected end of data');
+    }
   }
 
-  readToken(type: number): Token | undefined | Promise<Token | undefined> {
+  readToken(type: number): Token | undefined {
     switch (type) {
       case TYPE.DONE: {
-        return this.readDoneToken();
+        return this.readSimpleToken(doneParser);
       }
 
       case TYPE.DONEPROC: {
-        return this.readDoneProcToken();
+        return this.readSimpleToken(doneProcParser);
       }
 
       case TYPE.DONEINPROC: {
-        return this.readDoneInProcToken();
+        return this.readSimpleToken(doneInProcParser);
       }
 
       case TYPE.ERROR: {
-        return this.readErrorToken();
+        return this.readSimpleToken(errorParser);
       }
 
       case TYPE.INFO: {
-        return this.readInfoToken();
+        return this.readSimpleToken(infoParser);
       }
 
       case TYPE.ENVCHANGE: {
-        return this.readEnvChangeToken();
+        return this.readSimpleToken(envChangeParser);
       }
 
       case TYPE.LOGINACK: {
-        return this.readLoginAckToken();
+        return this.readSimpleToken(loginAckParser);
       }
 
       case TYPE.RETURNSTATUS: {
-        return this.readReturnStatusToken();
+        return this.readSimpleToken(returnStatusParser);
       }
 
       case TYPE.ORDER: {
-        return this.readOrderToken();
+        return this.readSimpleToken(orderParser);
       }
 
       case TYPE.FEDAUTHINFO: {
-        return this.readFedAuthInfoToken();
+        return this.readSimpleToken(fedAuthInfoParser);
       }
 
       case TYPE.SSPI: {
-        return this.readSSPIToken();
+        return this.readSimpleToken(sspiParser);
       }
 
       case TYPE.COLMETADATA: {
@@ -109,27 +263,27 @@ class Parser {
       }
 
       case TYPE.RETURNVALUE: {
-        return this.readReturnValueToken();
+        return returnValueParser(this);
       }
 
       case TYPE.ROW: {
-        return this.readRowToken();
+        return rowParser(this);
       }
 
       case TYPE.NBCROW: {
-        return this.readNbcRowToken();
+        return nbcRowParser(this);
       }
 
       case TYPE.FEATUREEXTACK: {
-        return this.readFeatureExtAckToken();
+        return this.readSimpleToken(featureExtAckParser);
       }
 
       case TYPE.TABNAME: {
-        return this.readTabNameToken();
+        return this.readSimpleToken(tabNameParser);
       }
 
       case TYPE.COLINFO: {
-        return this.readColInfoToken();
+        return this.readSimpleToken(colInfoParser);
       }
 
       default: {
@@ -138,316 +292,23 @@ class Parser {
     }
   }
 
-  readFeatureExtAckToken(): FeatureExtAckToken | Promise<FeatureExtAckToken> {
-    let result;
-
-    try {
-      result = featureExtAckParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readFeatureExtAckToken();
-        });
-      }
-
-      throw err;
-    }
-
+  /**
+   * Reads a token whose parser works on a buffer and offset, and which is
+   * retried from the start of the token if it is not complete yet.
+   */
+  readSimpleToken<T>(parse: (buffer: Buffer, offset: number, options: ParserOptions) => Result<T>): T {
+    const result = parse(this.buffer, this.position, this.options);
     this.position = result.offset;
     return result.value;
   }
 
-  readTabNameToken(): TabNameToken | Promise<TabNameToken> {
-    let result;
-
-    try {
-      result = tabNameParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readTabNameToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readColInfoToken(): ColInfoToken | Promise<ColInfoToken> {
-    let result;
-
-    try {
-      result = colInfoParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readColInfoToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  async readNbcRowToken(): Promise<NBCRowToken> {
-    return await nbcRowParser(this);
-  }
-
-  async readReturnValueToken(): Promise<ReturnValueToken> {
-    return await returnValueParser(this);
-  }
-
-  async readColMetadataToken(): Promise<ColMetadataToken> {
-    const token = await colMetadataParser(this);
+  readColMetadataToken(): ColMetadataToken {
+    const token = colMetadataParser(this);
     this.colMetadata = token.columns;
     return token;
-  }
-
-  readSSPIToken(): SSPIToken | Promise<SSPIToken> {
-    let result;
-
-    try {
-      result = sspiParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readSSPIToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readFedAuthInfoToken(): FedAuthInfoToken | Promise<FedAuthInfoToken> {
-    let result;
-
-    try {
-      result = fedAuthInfoParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readFedAuthInfoToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readOrderToken(): OrderToken | Promise<OrderToken> {
-    let result;
-
-    try {
-      result = orderParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readOrderToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readReturnStatusToken(): ReturnStatusToken | Promise<ReturnStatusToken> {
-    let result;
-
-    try {
-      result = returnStatusParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readReturnStatusToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readLoginAckToken(): LoginAckToken | Promise<LoginAckToken> {
-    let result;
-
-    try {
-      result = loginAckParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readLoginAckToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readEnvChangeToken(): EnvChangeToken | undefined | Promise<EnvChangeToken | undefined> {
-    let result;
-
-    try {
-      result = envChangeParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readEnvChangeToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readRowToken(): RowToken | Promise<RowToken> {
-    return rowParser(this);
-  }
-
-  readInfoToken(): InfoMessageToken | Promise<InfoMessageToken> {
-    let result;
-
-    try {
-      result = infoParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readInfoToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readErrorToken(): ErrorMessageToken | Promise<ErrorMessageToken> {
-    let result;
-
-    try {
-      result = errorParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readErrorToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readDoneInProcToken(): DoneInProcToken | Promise<DoneInProcToken> {
-    let result;
-
-    try {
-      result = doneInProcParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readDoneInProcToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readDoneProcToken(): DoneProcToken | Promise<DoneProcToken> {
-    let result;
-
-    try {
-      result = doneProcParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readDoneProcToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  readDoneToken(): DoneToken | Promise<DoneToken> {
-    let result;
-
-    try {
-      result = doneParser(this.buffer, this.position, this.options);
-    } catch (err: any) {
-      if (err instanceof NotEnoughDataError) {
-        return this.waitForChunk().then(() => {
-          return this.readDoneToken();
-        });
-      }
-
-      throw err;
-    }
-
-    this.position = result.offset;
-    return result.value;
-  }
-
-  constructor(iterable: AsyncIterable<Buffer> | Iterable<Buffer>, debug: Debug, options: ParserOptions) {
-    this.debug = debug;
-    this.colMetadata = [];
-    this.options = options;
-
-    this.iterator = ((iterable as AsyncIterable<Buffer>)[Symbol.asyncIterator] || (iterable as Iterable<Buffer>)[Symbol.iterator]).call(iterable);
-
-    this.buffer = Buffer.alloc(0);
-    this.position = 0;
-  }
-
-  async waitForChunk() {
-    const result = await this.iterator.next();
-    if (result.done) {
-      throw new Error('unexpected end of data');
-    }
-
-    if (this.position === this.buffer.length) {
-      this.buffer = result.value;
-    } else {
-      this.buffer = Buffer.concat([this.buffer.slice(this.position), result.value]);
-    }
-
-    this.position = 0;
   }
 }
 
 export default Parser;
 module.exports = Parser;
+module.exports.NEED_MORE_DATA = NEED_MORE_DATA;

--- a/src/token/token-stream-parser.ts
+++ b/src/token/token-stream-parser.ts
@@ -1,39 +1,130 @@
 import { EventEmitter } from 'events';
-import StreamParser, { type ParserOptions } from './stream-parser';
+import StreamParser, { NEED_MORE_DATA, type ParserOptions } from './stream-parser';
 import Debug from '../debug';
-import { Token } from './token';
-import { Readable } from 'stream';
-import Message from '../message';
+import IncomingMessage, { type MessageSink } from '../incoming-message';
 import { TokenHandler } from './handler';
 
-export class Parser extends EventEmitter {
+/**
+  Parses the tokens of an incoming message and delivers them to a handler.
+
+  The parser attaches itself to the message as a sink, so that it receives
+  the message's data synchronously as it arrives, and parses and delivers
+  all complete tokens right away. Delivery can be paused, in which case the
+  remaining data is held back (and, via backpressure, no longer read from
+  the socket) until the parser is resumed.
+*/
+export class Parser extends EventEmitter implements MessageSink {
   declare debug: Debug;
   declare options: ParserOptions;
-  declare parser: Readable;
+  declare parser: StreamParser;
+  declare handler: TokenHandler;
 
-  constructor(message: Message, debug: Debug, handler: TokenHandler, options: ParserOptions) {
+  declare paused: boolean;
+  declare ended: boolean;
+  declare failed: boolean;
+  declare message: IncomingMessage | undefined;
+
+  constructor(message: IncomingMessage | Iterable<Buffer>, debug: Debug, handler: TokenHandler, options: ParserOptions) {
     super();
 
     this.debug = debug;
     this.options = options;
+    this.handler = handler;
+    this.parser = new StreamParser(debug, options);
 
-    this.parser = Readable.from(StreamParser.parseTokens(message, this.debug, this.options));
-    this.parser.on('data', (token: Token) => {
-      debug.token(token);
-      handler[token.handlerName as keyof TokenHandler](token as any);
-    });
+    this.paused = false;
+    this.ended = false;
+    this.failed = false;
+    this.message = undefined;
 
-    this.parser.on('drain', () => {
-      this.emit('drain');
-    });
+    // Attach in a microtask so that the caller can register its listeners
+    // before any token (or the end of the message) is delivered.
+    if (message instanceof IncomingMessage) {
+      this.message = message;
+      queueMicrotask(() => {
+        message.attach(this);
+      });
+    } else {
+      // A plain sequence of chunks (used by tests).
+      queueMicrotask(() => {
+        for (const chunk of message) {
+          if (!this.push(chunk)) {
+            throw new Error('Parsing a plain sequence of chunks cannot be paused');
+          }
+        }
+        this.end();
+      });
+    }
+  }
 
-    this.parser.on('end', () => {
-      this.emit('end');
-    });
+  push(data: Buffer): boolean {
+    if (this.failed) {
+      return true;
+    }
 
-    this.parser.on('error', (error: Error) => {
-      this.emit('error', error);
-    });
+    this.parser.push(data);
+    return this.drain();
+  }
+
+  end() {
+    if (this.failed) {
+      return;
+    }
+
+    this.ended = true;
+
+    if (this.paused) {
+      // The end of the message is delivered once the parser is resumed
+      // and all buffered data has been parsed.
+      return;
+    }
+
+    this.finish();
+  }
+
+  /**
+   * Parses and delivers all complete tokens from the buffered data.
+   * Returns `false` if delivery was paused before all data was consumed.
+   */
+  drain(): boolean {
+    const parser = this.parser;
+    const handler = this.handler;
+    const debug = this.debug;
+
+    while (!this.paused) {
+      let token;
+      try {
+        token = parser.parseNext();
+      } catch (err) {
+        this.fail(err as Error);
+        return true;
+      }
+
+      if (token === NEED_MORE_DATA) {
+        return true;
+      }
+
+      if (token !== undefined) {
+        debug.token(token);
+        handler[token.handlerName as keyof TokenHandler](token as any);
+      }
+    }
+
+    return false;
+  }
+
+  finish() {
+    if (!this.parser.isEmpty()) {
+      this.fail(new Error('unexpected end of message'));
+      return;
+    }
+
+    this.emit('end');
+  }
+
+  fail(err: Error) {
+    this.failed = true;
+    this.emit('error', err);
   }
 
   declare on: (
@@ -42,10 +133,28 @@ export class Parser extends EventEmitter {
   );
 
   pause() {
-    return this.parser.pause();
+    this.paused = true;
   }
 
   resume() {
-    return this.parser.resume();
+    if (!this.paused) {
+      return;
+    }
+
+    this.paused = false;
+
+    if (!this.drain()) {
+      // Paused again while delivering the buffered tokens.
+      return;
+    }
+
+    if (this.ended) {
+      this.finish();
+      return;
+    }
+
+    if (this.message !== undefined) {
+      this.message.continueSink();
+    }
   }
 }

--- a/src/value-parser.ts
+++ b/src/value-parser.ts
@@ -584,49 +584,81 @@ function readNChars(buf: Buffer, offset: number, dataLength: number): Result<str
   return new Result(buf.toString('ucs2', offset, offset + dataLength), offset + dataLength);
 }
 
-async function readPLPStream(parser: Parser): Promise<null | Buffer[]> {
-  while (parser.buffer.length < parser.position + 8) {
-    await parser.waitForChunk();
-  }
+/**
+ * The progress of reading a PLP value.
+ */
+export interface PLPState {
+  chunks: Buffer[];
+  expectedLength: bigint;
+  currentLength: number;
+}
 
-  const expectedLength = parser.buffer.readBigUInt64LE(parser.position);
-  parser.position += 8;
+/**
+ * Reads a partially length-prefixed value from the parser.
+ *
+ * The read is resumable: progress is kept in `holder.plp`, and the parser's
+ * position is committed after the header and after each chunk. When the
+ * buffered data runs out, a `NotEnoughDataError` is thrown, the parser
+ * rewinds to the last commit, and calling this function again once more
+ * data is available continues where it left off.
+ */
+function readPLPStream(parser: Parser, holder: { plp: PLPState | undefined }): null | Buffer[] {
+  const buffer = parser.buffer;
+  let position = parser.position;
 
-  if (expectedLength === PLP_NULL) {
-    return null;
-  }
-
-  const chunks: Buffer[] = [];
-  let currentLength = 0;
-
-  while (true) {
-    while (parser.buffer.length < parser.position + 4) {
-      await parser.waitForChunk();
+  let state = holder.plp;
+  if (state === undefined) {
+    if (buffer.length < position + 8) {
+      throw new NotEnoughDataError(position + 8);
     }
 
-    const chunkLength = parser.buffer.readUInt32LE(parser.position);
-    parser.position += 4;
+    const expectedLength = buffer.readBigUInt64LE(position);
+    position += 8;
+
+    if (expectedLength === PLP_NULL) {
+      parser.position = position;
+      return null;
+    }
+
+    state = holder.plp = { chunks: [], expectedLength, currentLength: 0 };
+    parser.position = position;
+    parser.commit();
+  }
+
+  while (true) {
+    if (buffer.length < position + 4) {
+      throw new NotEnoughDataError(position + 4);
+    }
+
+    const chunkLength = buffer.readUInt32LE(position);
 
     if (!chunkLength) {
+      position += 4;
       break;
     }
 
-    while (parser.buffer.length < parser.position + chunkLength) {
-      await parser.waitForChunk();
+    if (buffer.length < position + 4 + chunkLength) {
+      throw new NotEnoughDataError(position + 4 + chunkLength);
     }
 
-    chunks.push(parser.buffer.slice(parser.position, parser.position + chunkLength));
-    parser.position += chunkLength;
-    currentLength += chunkLength;
+    state.chunks.push(buffer.slice(position + 4, position + 4 + chunkLength));
+    position += 4 + chunkLength;
+    state.currentLength += chunkLength;
+
+    parser.position = position;
+    parser.commit();
   }
 
-  if (expectedLength !== UNKNOWN_PLP_LEN) {
-    if (currentLength !== Number(expectedLength)) {
-      throw new Error('Partially Length-prefixed Bytes unmatched lengths : expected ' + expectedLength + ', but got ' + currentLength + ' bytes');
+  parser.position = position;
+  holder.plp = undefined;
+
+  if (state.expectedLength !== UNKNOWN_PLP_LEN) {
+    if (state.currentLength !== Number(state.expectedLength)) {
+      throw new Error('Partially Length-prefixed Bytes unmatched lengths : expected ' + state.expectedLength + ', but got ' + state.currentLength + ' bytes');
     }
   }
 
-  return chunks;
+  return state.chunks;
 }
 
 // Epoch offsets for building UTC `Date` values via plain arithmetic, which
@@ -784,8 +816,38 @@ function readDateTimeOffset(buf: Buffer, offset: number, dataLength: number, sca
   return new Result(date, offset);
 }
 
+/**
+ * Reads a partially length-prefixed value (see `readPLPStream`) and
+ * converts it into the JavaScript value for `metadata`'s type.
+ */
+function readPLPValue(parser: Parser, holder: { plp: PLPState | undefined }, metadata: Metadata): unknown {
+  const chunks = readPLPStream(parser, holder);
+
+  if (chunks === null) {
+    return null;
+  }
+
+  switch (metadata.type.name) {
+    case 'NVarChar':
+    case 'Xml':
+      return Buffer.concat(chunks).toString('ucs2');
+
+    case 'VarChar':
+      return iconv.decode(Buffer.concat(chunks), metadata.collation?.codepage ?? 'utf8');
+
+    case 'VarBinary':
+    case 'UDT':
+      return Buffer.concat(chunks);
+
+    default:
+      throw new Error(sprintf('Unsupported PLP type %s', metadata.type.name));
+  }
+}
+
 module.exports.readValue = readValue;
+module.exports.readPLPValue = readPLPValue;
 module.exports.isPLPStream = isPLPStream;
 module.exports.readPLPStream = readPLPStream;
 
-export { readValue, isPLPStream, readPLPStream };
+
+export { readValue, isPLPStream, readPLPStream, readPLPValue };

--- a/test/unit/incoming-message-stream-test.ts
+++ b/test/unit/incoming-message-stream-test.ts
@@ -1,7 +1,7 @@
 import BufferList from 'bl';
 import { assert } from 'chai';
 import IncomingMessageStream from '../../src/incoming-message-stream';
-import Message from '../../src/message';
+import IncomingMessage from '../../src/incoming-message';
 import Debug from '../../src/debug';
 import { ConnectionError } from '../../src/errors';
 
@@ -23,7 +23,7 @@ describe('IncomingMessageStream', function() {
     const incoming = new IncomingMessageStream(new Debug());
 
     incoming.on('data', function(message) {
-      assert.instanceOf(message, Message);
+      assert.instanceOf(message, IncomingMessage);
       assert.strictEqual(message.type, 0x11);
       assert.strictEqual(message.resetConnection, false);
 
@@ -81,7 +81,7 @@ describe('IncomingMessageStream', function() {
 
     let messageEnded = false;
     incoming.on('data', function(message) {
-      assert.instanceOf(message, Message);
+      assert.instanceOf(message, IncomingMessage);
 
       message.on('end', function() {
         messageEnded = true;
@@ -145,7 +145,7 @@ describe('IncomingMessageStream', function() {
 
     let messageEnded = false;
     incoming.on('data', function(message) {
-      assert.instanceOf(message, Message);
+      assert.instanceOf(message, IncomingMessage);
 
       message.on('end', function() {
         messageEnded = true;

--- a/test/unit/incoming-message-test.ts
+++ b/test/unit/incoming-message-test.ts
@@ -1,0 +1,118 @@
+import { assert } from 'chai';
+
+import IncomingMessage, { type MessageSink } from '../../src/incoming-message';
+
+class RecordingSink implements MessageSink {
+  chunks: string[] = [];
+  ended = false;
+  accept = true;
+
+  push(data: Buffer) {
+    this.chunks.push(data.toString());
+    return this.accept;
+  }
+
+  end() {
+    this.ended = true;
+  }
+}
+
+describe('IncomingMessage', function() {
+  it('delivers data written before and after a sink is attached, in order', function() {
+    const message = new IncomingMessage({ type: 0x04 });
+    const sink = new RecordingSink();
+
+    assert.isTrue(message.write(Buffer.from('a')));
+    assert.isTrue(message.write(Buffer.from('b')));
+
+    message.attach(sink);
+    assert.deepEqual(sink.chunks, ['ab']);
+
+    assert.isTrue(message.write(Buffer.from('c')));
+    message.end();
+
+    assert.deepEqual(sink.chunks, ['ab', 'c']);
+    assert.isTrue(sink.ended);
+  });
+
+  it('holds the writer back while the sink is stalled', function() {
+    const message = new IncomingMessage({ type: 0x04 });
+    const sink = new RecordingSink();
+    message.attach(sink);
+
+    sink.accept = false;
+    assert.isFalse(message.write(Buffer.from('a')));
+    assert.isTrue(message.stalled);
+
+    let drained = false;
+    message.onDrain = () => { drained = true; };
+
+    sink.accept = true;
+    message.continueSink();
+
+    assert.isFalse(message.stalled);
+    assert.isTrue(drained);
+  });
+
+  it('queues data written while stalled behind data buffered before the sink attached', function() {
+    const message = new IncomingMessage({ type: 0x04 });
+    const sink = new RecordingSink();
+
+    // Two separately buffered chunks; the sink stalls after the first.
+    message.write(Buffer.from('a'));
+    message.write(Buffer.from('b'));
+    sink.accept = false;
+
+    // `attach` reads the buffered data in one go and stalls.
+    message.attach(sink);
+    assert.deepEqual(sink.chunks, ['ab']);
+    assert.isTrue(message.stalled);
+
+    // Data written while stalled must not overtake anything, and must
+    // hold the writer back.
+    assert.isFalse(message.write(Buffer.from('c')));
+    message.end();
+    assert.deepEqual(sink.chunks, ['ab']);
+    assert.isFalse(sink.ended);
+
+    let drained = false;
+    message.onDrain = () => { drained = true; };
+
+    sink.accept = true;
+    message.continueSink();
+
+    assert.deepEqual(sink.chunks, ['ab', 'c']);
+    assert.isTrue(sink.ended);
+    assert.isTrue(drained);
+  });
+
+  it('delivers the end of the message once the sink is no longer stalled', function() {
+    const message = new IncomingMessage({ type: 0x04 });
+    const sink = new RecordingSink();
+    message.attach(sink);
+
+    sink.accept = false;
+    assert.isFalse(message.write(Buffer.from('a')));
+    message.end();
+    assert.isFalse(sink.ended);
+
+    sink.accept = true;
+    message.continueSink();
+    assert.isTrue(sink.ended);
+  });
+
+  it('can be consumed as a readable stream', async function() {
+    const message = new IncomingMessage({ type: 0x04 });
+
+    message.write(Buffer.from('a'));
+    message.write(Buffer.from('b'));
+    message.end();
+
+    const chunks: string[] = [];
+    for await (const chunk of message) {
+      chunks.push(chunk.toString());
+    }
+
+    assert.deepEqual(chunks.join(''), 'ab');
+  });
+});

--- a/test/unit/message-io-test.ts
+++ b/test/unit/message-io-test.ts
@@ -9,7 +9,7 @@ import { Duplex } from 'stream';
 
 import Debug from '../../src/debug';
 import MessageIO from '../../src/message-io';
-import Message from '../../src/message';
+import IncomingMessage from '../../src/incoming-message';
 import { Packet, TYPE } from '../../src/packet';
 
 const packetType = 2;
@@ -159,7 +159,7 @@ describe('MessageIO', function() {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
           const message = await io.readMessage();
-          assert.instanceOf(message, Message);
+          assert.instanceOf(message, IncomingMessage);
 
           const chunks = [];
           for await (const chunk of message) {
@@ -190,7 +190,7 @@ describe('MessageIO', function() {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
           const message = await io.readMessage();
-          assert.instanceOf(message, Message);
+          assert.instanceOf(message, IncomingMessage);
 
           const chunks = [];
           for await (const chunk of message) {
@@ -229,7 +229,7 @@ describe('MessageIO', function() {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
           const message = await io.readMessage();
-          assert.instanceOf(message, Message);
+          assert.instanceOf(message, IncomingMessage);
 
           const receivedData: Buffer[] = [];
           for await (const chunk of message) {
@@ -275,7 +275,7 @@ describe('MessageIO', function() {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
           const message = await io.readMessage();
-          assert.instanceOf(message, Message);
+          assert.instanceOf(message, IncomingMessage);
 
           const receivedData: Buffer[] = [];
           for await (const chunk of message) {
@@ -322,7 +322,7 @@ describe('MessageIO', function() {
           const io = new MessageIO(clientConnection, packetSize, debug);
 
           const message = await io.readMessage();
-          assert.instanceOf(message, Message);
+          assert.instanceOf(message, IncomingMessage);
 
           const receivedData: Buffer[] = [];
           for await (const chunk of message) {

--- a/test/unit/token/token-stream-parser-test.ts
+++ b/test/unit/token/token-stream-parser-test.ts
@@ -3,7 +3,7 @@ import { Parser } from '../../../src/token/token-stream-parser';
 import { TYPE, DatabaseEnvChangeToken } from '../../../src/token/token';
 import { type ParserOptions } from '../../../src/token/stream-parser';
 import { TokenHandler } from '../../../src/token/handler';
-import type Message from '../../../src/message';
+import type IncomingMessage from '../../../src/incoming-message';
 import WritableTrackingBuffer from '../../../src/tracking-buffer/writable-tracking-buffer';
 import { assert } from 'chai';
 
@@ -40,8 +40,8 @@ describe('Token Stream Parser', () => {
     const debug = new Debug({ token: true });
     const buffer = createDbChangeBuffer();
 
-    // Cast to Message since tests use a simplified input instead of full Message
-    const parser = new Parser([buffer] as unknown as Message, debug, new TestDatabaseChangeHandler(), options);
+    // Cast to IncomingMessage since tests use a simplified input instead of full Message
+    const parser = new Parser([buffer] as unknown as IncomingMessage, debug, new TestDatabaseChangeHandler(), options);
 
     parser.on('end', done);
   });
@@ -50,8 +50,8 @@ describe('Token Stream Parser', () => {
     const debug = new Debug({ token: true });
     const buffer = createDbChangeBuffer();
 
-    // Cast to Message since tests use a simplified input instead of full Message
-    const parser = new Parser([buffer.slice(0, 6), buffer.slice(6)] as unknown as Message, debug, new TestDatabaseChangeHandler(), options);
+    // Cast to IncomingMessage since tests use a simplified input instead of full Message
+    const parser = new Parser([buffer.slice(0, 6), buffer.slice(6)] as unknown as IncomingMessage, debug, new TestDatabaseChangeHandler(), options);
 
     parser.on('end', done);
   });
@@ -62,8 +62,8 @@ describe('Token Stream Parser', () => {
 
     const chunks = Array.from(buffer, (byte) => Buffer.from([byte]));
 
-    // Cast to Message since tests use a simplified input instead of full Message
-    const parser = new Parser(chunks as unknown as Message, debug, new TestDatabaseChangeHandler(), options);
+    // Cast to IncomingMessage since tests use a simplified input instead of full Message
+    const parser = new Parser(chunks as unknown as IncomingMessage, debug, new TestDatabaseChangeHandler(), options);
 
     parser.on('end', done);
   });


### PR DESCRIPTION
## Summary

Incoming message data used to flow through a `Message` PassThrough into an async generator that awaited the message's async iterator for every chunk and, inside the token readers, whenever a token was incomplete. A single-row response cost ~80 promises and a 3-packet response ~60; delivery lagged the socket by several event loop turns. This replaces that with a synchronous, push based parser.

- `IncomingMessage` (new) replaces `Message` for incoming data. It is still a `Readable` for consumers that want raw bytes (TLS handshake, prelogin, tests), but a `MessageSink` can be attached that receives each chunk synchronously as `IncomingMessageStream` frames it.
- `TokenStreamParser` attaches itself as that sink and parses whatever complete tokens are buffered right away. Pausing a request makes `push` return `false`, which stops framing further packets until the request is resumed, so backpressure to the socket is preserved. Data that arrives while the sink is stalled is queued behind data buffered before it attached.
- `StreamParser` is push based: `push(chunk)` then `parseNext()` per token. Readers are synchronous and throw `NotEnoughDataError` for an incomplete token; the parser rewinds to the last committed position and waits for the byte count the reader asked for before retrying. Rows, NBC rows and return values keep their progress on the parser (`RowState`, `ReturnValueState`) and commit after every column and every PLP chunk, so a value spanning many packets is parsed linearly. All other tokens are retried from their start.
- The async column metadata, row, NBC row, return value and PLP readers are removed, as is the unused async `metadataParse`. `Parser.parseTokens` remains as an adapter for the token parser tests.

## Measurements

Local SQL Server 2025, loopback, Node 22, default 4 KB packets, warm connection (`n` iterations). Ops/s for `master` and for this branch, measured in the same session.

| benchmark | master | this branch |
| --- | --- | --- |
| select 100 rows (int, nvarchar(100), nvarchar(max)), n=1000 | 871 | 1077 |
| select 1000 rows, n=300 | 298 | 422 |
| select 10000 rows, n=100 | 43 | 77 |
| select 1 row, 10 KB varbinary, n=2000 | 1163 | 1384 |
| select 1 row, 10000 char nvarchar(max), n=2000 | 1149 | 1258 |
| select 1 MB varbinary, n=200 | 181 | 199 |
| 1 KB varbinary parameter, n=2000 | 1511 | 1643 |
| bulk load 1000 rows, n=200 | 20 | 20 |

Async resources per request (async_hooks): a 3-packet response goes from 61 promises to 9, and per-request cost now rises smoothly with response size instead of stepping up at the packet boundary.

## Testing

- `npm test`: 538 passing.
- `npm run test-integration` against a local SQL Server 2025: all passing except two pre-existing environment specific tests (a connect timeout test whose target address this sandbox rejects immediately, and the TDS 8 strict TLS test).
- `npm run lint` clean.
- Additionally exercised directly: pause/resume mid response (single and multi packet), pause and resume from within a row handler, cancel while paused, cancel immediately after `execSql`, error tokens, PLP and NULL (NBC) values, output parameters, prepared statements and multi result set responses.
- New unit tests for `IncomingMessage` cover sink attach ordering, stalling and end delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZCoWULmkdZ9hXnVoBAsj5